### PR TITLE
feat(engine): FR-008 file-based whitelist + threat-intel blacklist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,27 +731,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.130.0"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f248321c6a7d4de5dcf2939368e96a397ad3f53b6a076e38d0104d1da326d37"
+checksum = "adc822414b18d1f5b1b33ce1441534e311e62fef86ebb5b9d382af857d0272c9"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.130.0"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6d78ff1f7d9bf8b7e1afbedbf78ba49e38e9da479d4c8a2db094e22f64e2bc"
+checksum = "8c646808b06f4532478d8d6057d74f15c3322f10d995d9486e7dcea405bf521a"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.130.0"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b6005ba640213a5b95382aeaf6b82bf028309581c8d7349778d66f27dc1180b"
+checksum = "7b5996f01a686b2349cdb379083ec5ad3e8cb8767fb2d495d3a4f2ee4163a18d"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.130.0"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fb5b134a12b559ff0c0f5af0fcd755ad380723b5016c4e0d36f74d39485340"
+checksum = "523fea83273f6a985520f57788809a4de2165794d9ab00fb1254fceb4f5aa00c"
 dependencies = [
  "serde",
  "serde_derive",
@@ -770,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.130.0"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85837de8be7f17a4034a6b08816f05a3144345d2091937b39d415990daca28f4"
+checksum = "d73d1e372730b5f64ed1a2bd9f01fe4686c8ec14a28034e3084e530c8d951878"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -798,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.130.0"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e433faa87d38e5b8ff469e44a26fea4f93e58abd7a7c10bad9810056139700c9"
+checksum = "b0319c18165e93dc1ebf78946a8da0b1c341c95b4a39729a69574671639bdb5f"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -811,24 +811,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.130.0"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5397ba61976e13944ca71230775db13ee1cb62849701ed35b753f4761ed0a9b7"
+checksum = "9195cd8aeecb55e401aa96b2eaa55921636e8246c127ed7908f7ef7e0d40f270"
 
 [[package]]
 name = "cranelift-control"
-version = "0.130.0"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc81c88765580720eb30f4fc2c1bfdb75fcbf3094f87b3cd69cecca79d77a245"
+checksum = "8976c2154b74136322befc74222ab5c7249edd7e2604f8cbef2b94975541ffb9"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.130.0"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463feed5d46cf8763f3ba3045284cf706dd161496e20ec9c14afbb4ba09b9e66"
+checksum = "6038b3147c7982f4951150d5f96c7c06c1e7214b99d4b4a98607aadf8ded89d1"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -838,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.130.0"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c5eca7696c1c04ab4c7ed8d18eadbb47d6cc9f14ec86fe0881bf1d7e97e261"
+checksum = "4cbd294abe236e23cc3d907b0936226b6a8342db7636daa9c7c72be1e323420e"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -850,15 +850,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.130.0"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1153844610cc9c6da8cf10ce205e45da1a585b7688ed558aa808bbe2e4e6d77"
+checksum = "b5a90b6ed3aba84189352a87badeb93b2126d3724225a42dc67fdce53d1b139c"
 
 [[package]]
 name = "cranelift-native"
-version = "0.130.0"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97b583fe9a60f06b0464cee6be5a17f623fd91b217aaac99b51b339d19911af"
+checksum = "c3ec0cc1a54e22925eacf4fc3dc815f907734d3b377899d19d52bec04863e853"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -867,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.130.0"
+version = "0.130.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8594dc6bb4860fa8292f1814c76459dbfb933e1978d8222de6380efce45c7cee"
+checksum = "948865622f87f30907bb46fbb081b235ae63c1896a99a83c26a003305c1fa82d"
 
 [[package]]
 name = "crc"
@@ -2238,6 +2238,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ip_network"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
+
+[[package]]
+name = "ip_network_table"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4099b7cfc5c5e2fe8c5edf3f6f7adf7a714c9cc697534f63a5a5da30397cb2c0"
+dependencies = [
+ "ip_network",
+ "ip_network_table-deps-treebitmap",
+]
+
+[[package]]
+name = "ip_network_table-deps-treebitmap"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e537132deb99c0eb4b752f0346b6a836200eaaa3516dd7e5514b63930a09e5d"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,6 +3450,7 @@ name = "prx-waf"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "clap",
  "gateway",
  "ipnet",
@@ -3458,9 +3481,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7975f0975fa2c047bf47d617bdf716689e42ee82b159bd000ead7330d7697a1b"
+checksum = "7ec12fe19a9588315a49fe5704502a9c02d6a198303314b0c7c86123b06d29e5"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -3470,9 +3493,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210c0386ef0ddedb337ec99b91e560ae9c341415ef75958cb39ddb537bb0c84"
+checksum = "36f7d5ef31ebf1b46cd7e722ffef934e670d7e462f49aa01cde07b9b76dca580"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5326,9 +5349,12 @@ dependencies = [
  "criterion",
  "dashmap",
  "ed25519-dalek",
+ "filetime",
  "globset",
  "hex",
  "ip2region",
+ "ip_network",
+ "ip_network_table",
  "ipnet",
  "libinjectionrs",
  "notify",
@@ -5343,6 +5369,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "url",
  "uuid",
  "waf-common",
@@ -5543,9 +5570,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54fa9f298901a64ed3eae16b130f0b30c80dbb74a9e7f129a791f4e74649b917"
+checksum = "efb1ed5899dde98357cfdcf647a4614498798719793898245b4b34e663addabf"
 dependencies = [
  "addr2line 0.26.0",
  "async-trait",
@@ -5585,9 +5612,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a3aaaa3a522f443af67a7ed8d4efa20b0c3784e1031980537fbfcb497f70a7"
+checksum = "4172382dcc785c31d0e862c6780a18f5dd437914d22c4691351f965ef751c821"
 dependencies = [
  "anyhow",
  "cranelift-bforest",
@@ -5614,9 +5641,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0d00d29ed90a63d2445072860a8a42d7151390157236a69bc3ae056786e9c9"
+checksum = "ae5ec9fff073ff13b81732d56a9515d761c245750bcda09093827f84130ebc25"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -5629,15 +5656,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acfd639ca7ab9e1cc37f053edd95bed6a7bed16370a8b2643dc7d9ef3047935"
+checksum = "935d9ab293ba27d1ec9aa7bc1b3a43993dbe961af2a8f23f90a11e1331b4c13f"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e671917bb6856ae360cb59d7aaf26f1cfd042c7b924319dd06fd380739fc0b2e"
+checksum = "9a3820b174f477d2a7083209d1ad5353fcdb11eaea434b2137b8681029460dd3"
 dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
@@ -5647,9 +5674,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dfd752e1dcf79eeeadc6f2681e2fb4a9f0b5534d18c5b9b93faccd0de2c80c"
+checksum = "d1679d205caf9766c6aa309d45bb3e7c634d7725e3164404df33824b9f7c4fb7"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -5674,9 +5701,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e9171af643316c11d6ebe52f31f6e2a5d6d1d270de9167a7b7b6f0e3f72982"
+checksum = "f1e505254058be5b0df458d670ee42d9eafe2349d04c1296e9dc01071dc20a85"
 dependencies = [
  "cc",
  "cfg-if",
@@ -5689,9 +5716,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe23134536b9883ffc2afcffae23f7ffbcb1791e2d9fac6d6464a37ea4c8fdd"
+checksum = "1c2e05b345f1773e59c20e6ad7298fd6857cdea245023d88bb659c96d8f0ea72"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -5699,9 +5726,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3112806515fac8495883885eb8dbdde849988ae91fe6beb544c0d7c0f4c9aa"
+checksum = "b86701b234a4643e3f111869aa792b3a05a06e02d486ee9cb6c04dae16b52dab"
 dependencies = [
  "cfg-if",
  "libc",
@@ -5711,9 +5738,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dafc29c6e538273fda8409335137654751bdf24beab65702b7866b0a85ee108a"
+checksum = "f63558d801beb83dde9b336eb4ae049019aee26627926edb32cd119d7e4c83cd"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -5724,9 +5751,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772f2b105b7fdd3dfb2cdf70c297baaeb96fe76a95cdc6fa516f713f04090c73"
+checksum = "737c4d956fc3a848541a064afb683dd2771132a6b125be5baaf95c4379aa47df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5735,9 +5762,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d556c3b176aba3cce565b2bafcdc049e7410ac1d86bf1ef663a035d9ded0dddc"
+checksum = "f599b79545e3bba0b7913406055ebede5bb0dabee9ba2015ef25a9f4c9f47807"
 dependencies = [
  "cranelift-codegen",
  "gimli 0.33.0",
@@ -5752,9 +5779,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c47507f09e68462a0ed9f351ef410584a52e01d7ec92bc588bf7fa597ce528ef"
+checksum = "2192a77a00b9a67800c2b4e1c70fb6abca79d6b529e53a2ef9dcdcc36090330d"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
@@ -5813,9 +5840,9 @@ dependencies = [
 
 [[package]]
 name = "winch-codegen"
-version = "43.0.0"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca3d76763e4ddc48ede73792d067396ba5ee74c3c581db90e6638fe6b46bf52"
+checksum = "52dbb0cf07b0dfe7b7a1ca8efb8f94ba98bd0fb144c411ea1665c78f0449e958"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ totp-lite = "2"
 data-encoding = "2"
 
 # Phase 5 additions
-wasmtime = { version = "43.0.0", default-features = false, features = ["cranelift", "runtime", "component-model", "std", "anyhow"] }
+wasmtime = { version = "43.0.2", default-features = false, features = ["cranelift", "runtime", "component-model", "std", "anyhow"] }
 moka = { version = "0.12", features = ["future"] }
 quinn = { version = "0.11", features = ["rustls"] }
 rustls = { version = "0.23", features = ["ring"] }

--- a/crates/gateway/src/context.rs
+++ b/crates/gateway/src/context.rs
@@ -28,6 +28,10 @@ pub struct GatewayCtx {
     /// Phase-05: wire protocol detected at session start. Tagged once in
     /// `request_filter` and consumed for per-protocol observability.
     pub protocol: Protocol,
+    /// FR-008: set by Phase-0 access gate when an IP whitelist hit resolves
+    /// to `full_bypass` for the request's tier. When true, `engine.inspect()`
+    /// is skipped (whitelist trust → fast path).
+    pub access_bypass: bool,
 }
 
 /// Per-response state for the streaming body masker (AC-17).

--- a/crates/gateway/src/pipeline/access_phase.rs
+++ b/crates/gateway/src/pipeline/access_phase.rs
@@ -1,0 +1,215 @@
+//! FR-008 Phase-0 access-list gate — gateway bridge.
+//!
+//! # Why inline, not in `RequestFilterChain`?
+//!
+//! `RequestFilterChain` runs inside `upstream_request_filter`, which fires
+//! *after* `upstream_peer` has already established the TCP connection to the
+//! backend. Blocking at that point wastes a backend slot.  This gate runs
+//! inside `request_filter` — the very first Pingora callback — so a blacklisted
+//! IP is rejected before any upstream work begins (D6).
+//!
+//! # Concurrency model
+//!
+//! `AccessPhaseGate` holds an `Arc<ArcSwap<AccessLists>>`. Every `evaluate`
+//! call does a single `ArcSwap::load` (one atomic read) to get a snapshot; no
+//! mutex is held across the evaluation. The hot-reload watcher (Phase 07)
+//! swaps the inner `Arc<AccessLists>` without touching this struct.
+
+use std::net::IpAddr;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use tracing::{info, warn};
+use waf_common::tier::Tier;
+use waf_engine::access::{AccessDecision, AccessLists, AccessRequestView};
+
+/// Gateway-level outcome after the Phase-0 access gate runs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AccessGateOutcome {
+    /// No access-list match; continue to WAF engine.
+    Continue,
+    /// Whitelist `full_bypass` hit; skip WAF engine and body inspection.
+    Bypass,
+    /// Hard deny. Carry the HTTP status code to use in the error response.
+    Block(u16),
+}
+
+/// Wraps the hot-swappable `AccessLists` snapshot and exposes a single
+/// `evaluate` method that translates engine-level `AccessDecision` into the
+/// gateway-level `AccessGateOutcome`.
+pub struct AccessPhaseGate {
+    pub lists: Arc<ArcSwap<AccessLists>>,
+}
+
+impl AccessPhaseGate {
+    /// Construct a gate backed by `lists`. The `ArcSwap` may be swapped at any
+    /// time by the file-watcher; `evaluate` always reads the current snapshot.
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn new(lists: Arc<ArcSwap<AccessLists>>) -> Self {
+        Self { lists }
+    }
+
+    /// Evaluate `(host, peer_ip, tier)` against the current access-list
+    /// snapshot and return a gateway outcome.
+    ///
+    /// - `Continue` → fall through to `engine.inspect()`.
+    /// - `Bypass`   → skip engine; set `ctx.access_bypass = true`.
+    /// - `Block(s)` → render error page with status `s` and terminate.
+    ///
+    /// `dry_run = true` blocks are treated as `Continue` but emit a WARN log.
+    #[must_use]
+    pub fn evaluate(&self, host: &str, peer_ip: IpAddr, tier: Tier) -> AccessGateOutcome {
+        let snapshot = self.lists.load();
+        let view = AccessRequestView {
+            client_ip: peer_ip,
+            host,
+            tier,
+        };
+        match snapshot.evaluate(&view) {
+            AccessDecision::Continue => AccessGateOutcome::Continue,
+            AccessDecision::BypassAll { matched_cidr } => {
+                info!(
+                    matched = %matched_cidr,
+                    %host,
+                    ?tier,
+                    "access: whitelist bypass"
+                );
+                AccessGateOutcome::Bypass
+            }
+            AccessDecision::Block {
+                reason,
+                matched,
+                dry_run,
+                status,
+            } => {
+                if dry_run {
+                    warn!(
+                        reason = reason.as_str(),
+                        matched = %matched,
+                        dry_run = true,
+                        %status,
+                        %host,
+                        ?tier,
+                        "access: block (dry-run) — treating as continue"
+                    );
+                    AccessGateOutcome::Continue
+                } else {
+                    warn!(
+                        reason = reason.as_str(),
+                        matched = %matched,
+                        %status,
+                        %host,
+                        ?tier,
+                        "access: block"
+                    );
+                    AccessGateOutcome::Block(status)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arc_swap::ArcSwap;
+    use std::sync::Arc;
+    use waf_engine::access::AccessLists;
+
+    fn gate_from(yaml: &str) -> AccessPhaseGate {
+        let lists = AccessLists::from_yaml_str(yaml).expect("valid yaml");
+        AccessPhaseGate::new(Arc::new(ArcSwap::new(lists)))
+    }
+
+    fn gate_empty() -> AccessPhaseGate {
+        let lists = AccessLists::empty();
+        AccessPhaseGate::new(Arc::new(ArcSwap::new(lists)))
+    }
+
+    fn ipv4(s: &str) -> IpAddr {
+        s.parse().expect("valid ip")
+    }
+
+    // 1. Continue when lists are empty (gate present, nothing configured).
+    #[test]
+    fn continue_when_lists_empty() {
+        let gate = gate_empty();
+        let outcome = gate.evaluate("example.com", ipv4("1.2.3.4"), Tier::Medium);
+        assert_eq!(outcome, AccessGateOutcome::Continue);
+    }
+
+    // 2. Continue when no blacklist / whitelist match.
+    #[test]
+    fn continue_when_no_match() {
+        let gate = gate_from("version: 1\nip_blacklist:\n  - 10.0.0.0/8\n");
+        let outcome = gate.evaluate("example.com", ipv4("192.168.1.1"), Tier::Medium);
+        assert_eq!(outcome, AccessGateOutcome::Continue);
+    }
+
+    // 3. Bypass when whitelist full_bypass matches.
+    #[test]
+    fn bypass_when_whitelist_full_bypass_match() {
+        let yaml = "version: 1\nip_whitelist:\n  - 10.0.0.0/8\ntier_whitelist_mode:\n  medium: full_bypass\n";
+        let gate = gate_from(yaml);
+        let outcome = gate.evaluate("example.com", ipv4("10.1.2.3"), Tier::Medium);
+        assert_eq!(outcome, AccessGateOutcome::Bypass);
+    }
+
+    // 4. Continue when whitelist mode is blacklist_only (default).
+    #[test]
+    fn continue_when_whitelist_blacklist_only_match() {
+        let yaml = "version: 1\nip_whitelist:\n  - 10.0.0.0/8\n";
+        let gate = gate_from(yaml);
+        let outcome = gate.evaluate("example.com", ipv4("10.1.2.3"), Tier::Medium);
+        assert_eq!(outcome, AccessGateOutcome::Continue);
+    }
+
+    // 5. Block when blacklist matches.
+    #[test]
+    fn block_when_blacklist_match() {
+        let gate = gate_from("version: 1\nip_blacklist:\n  - 203.0.113.0/24\n");
+        let outcome = gate.evaluate("example.com", ipv4("203.0.113.5"), Tier::Medium);
+        assert!(matches!(outcome, AccessGateOutcome::Block(403)));
+    }
+
+    // 6. Block when host gate denies (host not in per-tier allowlist).
+    #[test]
+    fn block_when_host_gate_mismatch() {
+        let yaml = "version: 1\nhost_whitelist:\n  critical:\n    - api.example.com\n";
+        let gate = gate_from(yaml);
+        // "evil.com" is not in the Critical tier host list → block.
+        let outcome = gate.evaluate("evil.com", ipv4("1.2.3.4"), Tier::Critical);
+        assert!(matches!(outcome, AccessGateOutcome::Block(_)));
+    }
+
+    // 7. Dry-run block returns Continue (not Block).
+    #[test]
+    fn dry_run_block_returns_continue() {
+        let yaml = "version: 1\ndry_run: true\nip_blacklist:\n  - 203.0.113.5\n";
+        let gate = gate_from(yaml);
+        let outcome = gate.evaluate("example.com", ipv4("203.0.113.5"), Tier::Medium);
+        // Dry-run must NOT block; gateway must continue to WAF engine.
+        assert_eq!(outcome, AccessGateOutcome::Continue);
+    }
+
+    // 8. Blacklist beats whitelist (blacklist evaluated first).
+    #[test]
+    fn blacklist_beats_whitelist() {
+        let yaml = "version: 1\nip_whitelist:\n  - 10.0.0.0/8\nip_blacklist:\n  - 10.1.2.3\ntier_whitelist_mode:\n  medium: full_bypass\n";
+        let gate = gate_from(yaml);
+        // Same IP in both — blacklist wins.
+        let outcome = gate.evaluate("example.com", ipv4("10.1.2.3"), Tier::Medium);
+        assert!(matches!(outcome, AccessGateOutcome::Block(_)));
+    }
+
+    // 9. Host gate disabled for tiers with no host list → Continue.
+    #[test]
+    fn host_gate_disabled_when_tier_has_no_list() {
+        let yaml = "version: 1\nhost_whitelist:\n  critical:\n    - api.example.com\n";
+        let gate = gate_from(yaml);
+        // Medium tier has no host list → gate is disabled for Medium → Continue.
+        let outcome = gate.evaluate("evil.com", ipv4("1.2.3.4"), Tier::Medium);
+        assert_eq!(outcome, AccessGateOutcome::Continue);
+    }
+}

--- a/crates/gateway/src/pipeline/mod.rs
+++ b/crates/gateway/src/pipeline/mod.rs
@@ -9,9 +9,11 @@ use std::sync::Arc;
 
 use waf_common::{HostConfig, RequestCtx};
 
+pub mod access_phase;
 pub mod request_filter_chain;
 pub mod response_filter_chain;
 
+pub use access_phase::{AccessGateOutcome, AccessPhaseGate};
 pub use request_filter_chain::RequestFilterChain;
 pub use response_filter_chain::ResponseFilterChain;
 

--- a/crates/gateway/src/proxy.rs
+++ b/crates/gateway/src/proxy.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use bytes::Bytes;
 use dashmap::DashMap;
@@ -20,6 +21,7 @@ use pingora_proxy::{FailToProxy, ProxyHttp, Session};
 
 use waf_common::HostConfig;
 use waf_engine::WafEngine;
+use waf_engine::access::AccessLists;
 
 use crate::tiered::TierPolicyRegistry;
 
@@ -31,7 +33,7 @@ use crate::filters::{
     RequestHostPolicyFilter, RequestRealIpFilter, RequestXffFilter, ResponseHeaderBlocklistFilter,
     ResponseLocationRewriter, ResponseServerPolicyFilter, ResponseViaStripFilter, apply_body_mask_chunk,
 };
-use crate::pipeline::{FilterCtx, RequestFilterChain, ResponseFilterChain};
+use crate::pipeline::{AccessGateOutcome, AccessPhaseGate, FilterCtx, RequestFilterChain, ResponseFilterChain};
 use crate::protocol::{ProtoCounters, detect_from_session};
 use crate::proxy_waf_response::{write_waf_body_decision, write_waf_decision};
 use crate::router::HostRouter;
@@ -61,6 +63,9 @@ pub struct WafProxy {
     /// FR-002: tier policy registry. When `None`, every request defaults to
     /// `Tier::CatchAll` + permissive policy (boot-time safety).
     pub tier_registry: Option<Arc<TierPolicyRegistry>>,
+    /// FR-008 phase-05: Phase-0 access-list gate. Optional — `None` = every
+    /// request continues unconditionally (no whitelist/blacklist enforcement).
+    pub access_lists: Option<Arc<AccessPhaseGate>>,
 }
 
 impl WafProxy {
@@ -78,6 +83,7 @@ impl WafProxy {
             response_chain: Arc::new(build_response_chain()),
             body_mask_cache: Arc::new(DashMap::new()),
             tier_registry: None,
+            access_lists: None,
         }
     }
 
@@ -86,6 +92,13 @@ impl WafProxy {
     /// the boot-time `CatchAll` fallback.
     pub fn with_tier_registry(&mut self, registry: Arc<TierPolicyRegistry>) {
         self.tier_registry = Some(registry);
+    }
+
+    /// Inject the FR-008 Phase-0 access-list gate. The proxy stores a hot
+    /// snapshot reference; the Phase-07 watcher swaps the `ArcSwap` content on
+    /// file change without restart. When unset, no access-list enforcement runs.
+    pub fn with_access_lists(&mut self, lists: Arc<ArcSwap<AccessLists>>) {
+        self.access_lists = Some(Arc::new(AccessPhaseGate::new(lists)));
     }
 
     /// Resolve (and lazily compile) the mask config for a given host.
@@ -271,6 +284,38 @@ impl ProxyHttp for WafProxy {
             return Ok(true);
         }
 
+        // FR-008 phase-05 — Phase-0 access-list gate runs *before* the WAF
+        // engine. peer_ip is the immediate TCP peer (XFF/real-ip rewrites are
+        // upstream-bound and run later in upstream_request_filter).
+        if let Some(gate) = &self.access_lists {
+            let peer_ip = session
+                .client_addr()
+                .and_then(|a| a.as_inet())
+                .map_or(request_ctx.client_ip, std::net::SocketAddr::ip);
+            match gate.evaluate(&request_ctx.host, peer_ip, request_ctx.tier) {
+                AccessGateOutcome::Continue => {}
+                AccessGateOutcome::Bypass => {
+                    ctx.access_bypass = true;
+                }
+                AccessGateOutcome::Block(status) => {
+                    self.blocked_counter.fetch_add(1, Ordering::Relaxed);
+                    let accept = session
+                        .get_header("accept")
+                        .and_then(|v| std::str::from_utf8(v.as_bytes()).ok())
+                        .map(str::to_string);
+                    let (headers, body) = ErrorPageFactory::render(status, accept.as_deref())?;
+                    session.write_response_header(Box::new(headers), false).await?;
+                    session.write_response_body(Some(body), true).await?;
+                    return Ok(true);
+                }
+            }
+        }
+
+        // Whitelist full-bypass skips the WAF engine entirely (D6 fast path).
+        if ctx.access_bypass {
+            return Ok(false);
+        }
+
         let decision = self.engine.inspect(&mut request_ctx).await;
         write_waf_decision(session, &decision, &request_ctx, &self.blocked_counter).await
     }
@@ -282,7 +327,7 @@ impl ProxyHttp for WafProxy {
         end_of_stream: bool,
         ctx: &mut GatewayCtx,
     ) -> pingora_core::Result<()> {
-        if ctx.body_inspected {
+        if ctx.body_inspected || ctx.access_bypass {
             return Ok(());
         }
         if let Some(chunk) = body {

--- a/crates/prx-waf/Cargo.toml
+++ b/crates/prx-waf/Cargo.toml
@@ -24,6 +24,7 @@ tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 regex = { workspace = true }
 ipnet = { workspace = true }
+arc-swap = "1"
 
 pingora-core = { workspace = true }
 pingora-proxy = { workspace = true }

--- a/crates/prx-waf/src/main.rs
+++ b/crates/prx-waf/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout, clippy::print_stderr)]
+#![allow(clippy::print_stdout, clippy::print_stderr, clippy::doc_markdown)]
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -7,9 +7,13 @@ use clap::{Parser, Subcommand};
 use tracing::info;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
+use arc_swap::ArcSwap;
 use gateway::{HostRouter, TunnelConfig, WafProxy};
 use waf_api::{AppState, start_api_server};
 use waf_common::config::{AppConfig, load_config};
+#[cfg(unix)]
+use waf_engine::access::reload::spawn_sighup_listener;
+use waf_engine::access::{AccessLists, AccessReloader, DEFAULT_DEBOUNCE_MS};
 use waf_engine::{
     CrowdSecClient, CrowdSecConfig, ExportFormat, GeoIpService, RuleManager, WafEngine, WafEngineConfig, XdbUpdater,
     cache_policy_from_str, init_community, init_crowdsec, spawn_auto_updater,
@@ -1333,6 +1337,54 @@ fn run_server(config: &AppConfig, config_file_path: &str) -> anyhow::Result<()> 
              Consider adding trusted proxy CIDRs for production use."
         );
     }
+
+    // FR-008 — Load access-lists snapshot, spawn watcher, inject into proxy.
+    // Fail-soft: missing file or parse error → empty snapshot, log WARN.
+    let access_path = PathBuf::from("rules/access-lists.yaml");
+    let access_lists: Arc<AccessLists> = match AccessLists::from_yaml_path(&access_path) {
+        Ok(lists) => {
+            tracing::info!(path = %access_path.display(), "FR-008 access-lists loaded");
+            lists
+        }
+        Err(e) => {
+            tracing::warn!(
+                path = %access_path.display(),
+                error = %e,
+                "FR-008 access-lists missing or invalid; using empty snapshot"
+            );
+            AccessLists::empty()
+        }
+    };
+    let access_store: Arc<ArcSwap<AccessLists>> = Arc::new(ArcSwap::from(access_lists));
+
+    // Spawn the file watcher; keep the handle alive for the process lifetime.
+    match AccessReloader::spawn(access_path.clone(), Arc::clone(&access_store), DEFAULT_DEBOUNCE_MS) {
+        Ok(reloader) => {
+            // Watcher must outlive the runtime — drop = stop watching.
+            std::mem::forget(reloader);
+            tracing::info!("FR-008 access-lists watcher started");
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "FR-008 access-lists watcher failed to start; running without hot-reload");
+        }
+    }
+
+    #[cfg(unix)]
+    {
+        // spawn_sighup_listener calls tokio::spawn; use the existing rt.
+        match rt.block_on(async { spawn_sighup_listener(access_path.clone(), Arc::clone(&access_store)) }) {
+            Ok(handle) => {
+                std::mem::forget(handle);
+                tracing::info!("FR-008 access-lists SIGHUP listener active");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "FR-008 access-lists SIGHUP listener failed");
+            }
+        }
+    }
+
+    // Inject into proxy. Must run BEFORE proxy.start().
+    proxy.with_access_lists(Arc::clone(&access_store));
 
     let mut proxy_service = pingora_proxy::http_proxy_service(&server.configuration, proxy);
     proxy_service.add_tcp(&config.proxy.listen_addr);

--- a/crates/waf-engine/Cargo.toml
+++ b/crates/waf-engine/Cargo.toml
@@ -35,11 +35,15 @@ hex = { workspace = true }
 url = { workspace = true }
 ahash = "0.8"
 globset = "0.4"
+ip_network = "0.4"
+ip_network_table = "0.2"
 
 [dev-dependencies]
 rand = { workspace = true }
 criterion = { version = "0.5", features = ["html_reports"] }
 tempfile = "3"
+filetime = "0.2"
+tracing-subscriber = { workspace = true }
 
 [[bench]]
 name = "sql_injection"
@@ -47,6 +51,10 @@ harness = false
 
 [[bench]]
 name = "rule_eval"
+harness = false
+
+[[bench]]
+name = "access_lookup"
 harness = false
 
 [lints]

--- a/crates/waf-engine/benches/access_lookup.rs
+++ b/crates/waf-engine/benches/access_lookup.rs
@@ -1,0 +1,119 @@
+//! FR-008 — Criterion benchmark for the access-list hot path.
+//!
+//! Measures `evaluate()` across four scenarios:
+//!   - `blacklist_hit`  : IP in blacklist → Block
+//!   - `whitelist_hit`  : IP in whitelist, FullBypass mode → BypassAll
+//!   - `host_gate_miss` : host not in per-tier allowlist → Block (HostGate)
+//!   - `no_match`       : none of the above → Continue
+//!
+//! The trie is built with 1 000 entries before the bench loop so `b.iter` only
+//! measures the lookup, not the setup.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::semicolon_if_nothing_returned,
+    clippy::doc_markdown
+)]
+
+use std::net::IpAddr;
+use std::sync::Arc;
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use waf_common::tier::Tier;
+use waf_engine::access::{AccessLists, AccessRequestView};
+
+// ── fixture builders ─────────────────────────────────────────────────────────
+
+/// Build an `AccessLists` with:
+///   - 1 000 blacklist /32 entries in 10.1.0.0/22
+///   - 1 000 whitelist /32 entries in 10.2.0.0/22
+///   - 100  host-gate entries for `Tier::Critical`
+///   - `FullBypass` mode for `Tier::Medium`
+fn build_lists() -> Arc<AccessLists> {
+    let mut lines = vec!["version: 1".to_string(), "ip_blacklist:".to_string()];
+    // 1 000 blacklist IPs: 10.1.{0..3}.{0..249}
+    for b in 0u8..4 {
+        for c in 0u8..250 {
+            lines.push(format!("  - 10.1.{b}.{c}"));
+        }
+    }
+
+    lines.push("ip_whitelist:".to_string());
+    // 1 000 whitelist IPs: 10.2.{0..3}.{0..249}
+    for b in 0u8..4 {
+        for c in 0u8..250 {
+            lines.push(format!("  - 10.2.{b}.{c}"));
+        }
+    }
+
+    // 100 host-gate entries for Critical tier.
+    lines.push("host_whitelist:".to_string());
+    lines.push("  critical:".to_string());
+    for i in 0u32..100 {
+        lines.push(format!("    - host{i}.example.com"));
+    }
+
+    // FullBypass for Medium so the whitelist_hit bench exercises that path.
+    lines.push("tier_whitelist_mode:".to_string());
+    lines.push("  medium: full_bypass".to_string());
+
+    let yaml = lines.join("\n");
+    AccessLists::from_yaml_str(&yaml).expect("bench fixture yaml must parse")
+}
+
+fn view(ip: &str, host: &'static str, tier: Tier) -> AccessRequestView<'static> {
+    AccessRequestView {
+        client_ip: ip.parse::<IpAddr>().expect("bench ip parses"),
+        host,
+        tier,
+    }
+}
+
+// ── bench functions ───────────────────────────────────────────────────────────
+
+fn bench_blacklist_hit(c: &mut Criterion) {
+    let lists = build_lists();
+    let v = view("10.1.0.7", "anything.example.com", Tier::Medium);
+    c.bench_function("access/blacklist_hit", |b| {
+        b.iter(|| black_box(lists.evaluate(black_box(&v))))
+    });
+}
+
+fn bench_whitelist_hit(c: &mut Criterion) {
+    let lists = build_lists();
+    // 10.2.x.x is in whitelist; Medium tier uses FullBypass → BypassAll.
+    let v = view("10.2.0.7", "anything.example.com", Tier::Medium);
+    c.bench_function("access/whitelist_hit", |b| {
+        b.iter(|| black_box(lists.evaluate(black_box(&v))))
+    });
+}
+
+fn bench_host_gate_miss(c: &mut Criterion) {
+    let lists = build_lists();
+    // Critical tier has host-gate; "unknown.example.com" is not in the list.
+    let v = view("198.51.100.1", "unknown.example.com", Tier::Critical);
+    c.bench_function("access/host_gate_miss", |b| {
+        b.iter(|| black_box(lists.evaluate(black_box(&v))))
+    });
+}
+
+fn bench_no_match_continue(c: &mut Criterion) {
+    let lists = build_lists();
+    // IP not in any list; Medium tier host-gate is disabled → Continue.
+    let v = view("8.8.8.8", "public.example.com", Tier::Medium);
+    c.bench_function("access/no_match_continue", |b| {
+        b.iter(|| black_box(lists.evaluate(black_box(&v))))
+    });
+}
+
+// ── criterion wiring ─────────────────────────────────────────────────────────
+
+criterion_group!(
+    benches,
+    bench_blacklist_hit,
+    bench_whitelist_hit,
+    bench_host_gate_miss,
+    bench_no_match_continue
+);
+criterion_main!(benches);

--- a/crates/waf-engine/src/access/config.rs
+++ b/crates/waf-engine/src/access/config.rs
@@ -1,0 +1,444 @@
+//! YAML schema + parser for `rules/access-lists.yaml` (FR-008 phase-01).
+//!
+//! Pure data + validation. No trie build, no host-set build — those land in
+//! phases 02 and 03 respectively. The shape here is the public stable contract
+//! every later phase compiles against.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::path::Path;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use anyhow::{Context, bail};
+use ipnet::IpNet;
+use serde::Deserialize;
+use waf_common::tier::Tier;
+
+use crate::access::host_gate::HostGate;
+use crate::access::ip_table::IpCidrTable;
+
+/// Hard cap — parser rejects YAML beyond this entry count to bound memory.
+const HARD_REJECT_ENTRIES: usize = 500_000;
+/// Soft cap — emit `tracing::warn!` past this point.
+const SOFT_WARN_ENTRIES: usize = 50_000;
+/// Currently the only supported schema version. Bumped on breaking change.
+const SUPPORTED_VERSION: u32 = 1;
+
+/// How a per-tier whitelist hit short-circuits the WAF pipeline.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WhitelistMode {
+    /// Skip every downstream check (fast path).
+    FullBypass,
+    /// Run rules even if whitelisted (defense-in-depth, default).
+    // D4 / risk-register: safer default. A typo must not silently bypass rules.
+    #[default]
+    BlacklistOnly,
+}
+
+/// 1:1 mirror of `rules/access-lists.yaml`. All fields optional so partial
+/// configs (or an empty file) parse to a "everything disabled" snapshot — D4.
+///
+/// `deny_unknown_fields` is intentional: a silently-dropped typo (e.g.
+/// `tier_whitelist_mod:`) would leave the gate in its default posture while
+/// operators believed their override was live. Parse failure is the safe
+/// failure mode because `reload.rs::reload` retains the previous snapshot and
+/// emits a WARN on error.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AccessConfig {
+    #[serde(default)]
+    pub version: u32,
+    #[serde(default)]
+    pub dry_run: bool,
+    #[serde(default)]
+    pub ip_whitelist: Vec<String>,
+    #[serde(default)]
+    pub ip_blacklist: Vec<String>,
+    #[serde(default)]
+    pub host_whitelist: HashMap<Tier, Vec<String>>,
+    #[serde(default)]
+    pub tier_whitelist_mode: HashMap<Tier, WhitelistMode>,
+}
+
+impl AccessConfig {
+    /// End-to-end syntactic + semantic validation. Trie/host-set construction
+    /// is deferred to phases 02-03; here we only ensure the file is well-formed
+    /// and within size caps.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.version != SUPPORTED_VERSION {
+            bail!(
+                "unsupported access-lists version {}: expected {SUPPORTED_VERSION}",
+                self.version
+            );
+        }
+
+        let total = self.ip_whitelist.len() + self.ip_blacklist.len();
+        if total > HARD_REJECT_ENTRIES {
+            bail!("access-list entry count {total} exceeds hard cap of {HARD_REJECT_ENTRIES}");
+        }
+        if total > SOFT_WARN_ENTRIES {
+            tracing::warn!(
+                entries = total,
+                soft_cap = SOFT_WARN_ENTRIES,
+                "access-list size approaching hard cap"
+            );
+        }
+
+        for (idx, cidr) in self.ip_whitelist.iter().enumerate() {
+            parse_cidr_or_ip(cidr).with_context(|| format!("ip_whitelist[{idx}] invalid CIDR/IP: {cidr:?}"))?;
+        }
+        for (idx, cidr) in self.ip_blacklist.iter().enumerate() {
+            parse_cidr_or_ip(cidr).with_context(|| format!("ip_blacklist[{idx}] invalid CIDR/IP: {cidr:?}"))?;
+        }
+
+        for (tier, hosts) in &self.host_whitelist {
+            for (idx, host) in hosts.iter().enumerate() {
+                validate_host(host).with_context(|| format!("host_whitelist[{tier:?}][{idx}]: {host:?}"))?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Accept either CIDR (`10.0.0.0/8`) or bare IP (`192.168.1.5`). The brainstorm
+/// schema treats a bare IP as a /32 (or /128 for v6); phase-02 normalizes both
+/// forms when building the trie.
+fn parse_cidr_or_ip(s: &str) -> anyhow::Result<()> {
+    if IpNet::from_str(s).is_ok() || IpAddr::from_str(s).is_ok() {
+        return Ok(());
+    }
+    bail!("invalid IP address syntax")
+}
+
+/// Maximum total FQDN length per RFC 1035 §2.3.4 (minus the terminating dot).
+const MAX_HOST_LEN: usize = 253;
+/// Maximum label length per RFC 1035 §2.3.4.
+const MAX_LABEL_LEN: usize = 63;
+
+/// Validate a host against RFC 1123 §2.1 rules: lowercase, no port, no
+/// whitespace, labels 1..=63 octets of `[a-z0-9-]` not starting or ending with
+/// `-`, total length ≤ 253. A single trailing dot is accepted (operator IDE
+/// auto-complete artefact) but must be normalized out at insertion time.
+fn validate_host(host: &str) -> anyhow::Result<()> {
+    if host.is_empty() {
+        bail!("empty host");
+    }
+    if host.contains(':') {
+        bail!("port suffix not allowed");
+    }
+    if host.chars().any(char::is_whitespace) {
+        bail!("whitespace not allowed");
+    }
+    if host.chars().any(|c| c.is_ascii_uppercase()) {
+        bail!("must be lowercase");
+    }
+    // Strip at most one trailing dot for length + label checks; normalization
+    // is applied consistently at insert + lookup (see `HostGate`).
+    let trimmed = host.strip_suffix('.').unwrap_or(host);
+    if trimmed.is_empty() {
+        bail!("host must have at least one label");
+    }
+    if trimmed.len() > MAX_HOST_LEN {
+        bail!("host exceeds RFC 1035 length cap of {MAX_HOST_LEN} octets");
+    }
+    for label in trimmed.split('.') {
+        if label.is_empty() {
+            bail!("empty label (consecutive dots or leading dot)");
+        }
+        if label.len() > MAX_LABEL_LEN {
+            bail!("label {label:?} exceeds RFC 1035 label cap of {MAX_LABEL_LEN} octets");
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            bail!("label {label:?} must not start or end with hyphen");
+        }
+        if !label
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+        {
+            bail!("label {label:?} contains invalid characters (allowed: a-z 0-9 '-')");
+        }
+    }
+    Ok(())
+}
+
+/// Immutable runtime aggregate. Phase-02..04 will replace `config` with
+/// pre-built `IpCidrTable` + `HostGate` fields. For phase-01 we keep the raw
+/// validated config so later phases have a stable input.
+#[derive(Debug)]
+pub struct AccessLists {
+    config: AccessConfig,
+    ip_whitelist: IpCidrTable,
+    ip_blacklist: IpCidrTable,
+    host_gate: HostGate,
+}
+
+impl AccessLists {
+    /// All gates disabled — used at boot before the YAML loader runs and as
+    /// fallback when the file is missing.
+    #[must_use]
+    pub fn empty() -> Arc<Self> {
+        // Default config has version=0 which would fail validate(); skip
+        // validation here because the empty snapshot is internally constructed,
+        // not user-provided.
+        Arc::new(Self {
+            config: AccessConfig {
+                version: SUPPORTED_VERSION,
+                ..AccessConfig::default()
+            },
+            ip_whitelist: IpCidrTable::new(),
+            ip_blacklist: IpCidrTable::new(),
+            host_gate: HostGate::new(),
+        })
+    }
+
+    /// Parse + validate a YAML document. Returns a fully-validated snapshot or
+    /// an actionable error (with `serde_yaml` line/column on parse failure).
+    pub fn from_yaml_str(s: &str) -> anyhow::Result<Arc<Self>> {
+        let config: AccessConfig = serde_yaml::from_str(s).context("parsing access-lists YAML")?;
+        config.validate().context("validating access-lists")?;
+
+        let mut ip_whitelist = IpCidrTable::new();
+        for entry in &config.ip_whitelist {
+            ip_whitelist
+                .insert_str(entry)
+                .with_context(|| format!("ip_whitelist entry {entry:?}"))?;
+        }
+        let mut ip_blacklist = IpCidrTable::new();
+        for entry in &config.ip_blacklist {
+            ip_blacklist
+                .insert_str(entry)
+                .with_context(|| format!("ip_blacklist entry {entry:?}"))?;
+        }
+
+        let mut host_gate = HostGate::new();
+        for (tier, hosts) in &config.host_whitelist {
+            for host in hosts {
+                host_gate.insert(*tier, host);
+            }
+        }
+
+        Ok(Arc::new(Self {
+            config,
+            ip_whitelist,
+            ip_blacklist,
+            host_gate,
+        }))
+    }
+
+    /// Read + parse + validate a YAML file from disk.
+    pub fn from_yaml_path(path: &Path) -> anyhow::Result<Arc<Self>> {
+        let body = std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+        Self::from_yaml_str(&body)
+    }
+
+    /// Borrowed view of the validated config — phases 02-04 build their
+    /// runtime structures from this.
+    #[must_use]
+    pub const fn config(&self) -> &AccessConfig {
+        &self.config
+    }
+
+    /// Per-tier whitelist mode lookup with safe default (`BlacklistOnly`).
+    #[must_use]
+    pub fn tier_mode(&self, tier: Tier) -> WhitelistMode {
+        self.config.tier_whitelist_mode.get(&tier).copied().unwrap_or_default()
+    }
+
+    /// Whether this snapshot was loaded with `dry_run: true` — phase-04 uses
+    /// this to log-but-not-block.
+    #[must_use]
+    pub const fn dry_run(&self) -> bool {
+        self.config.dry_run
+    }
+
+    /// Pre-built IP whitelist trie. Hot-path lookup in phase-04.
+    #[must_use]
+    pub const fn ip_whitelist(&self) -> &IpCidrTable {
+        &self.ip_whitelist
+    }
+
+    /// Pre-built IP blacklist trie. Hot-path lookup in phase-04.
+    #[must_use]
+    pub const fn ip_blacklist(&self) -> &IpCidrTable {
+        &self.ip_blacklist
+    }
+
+    /// Pre-built per-tier Host allowlist. Hot-path lookup in phase-04.
+    #[must_use]
+    pub const fn host_gate(&self) -> &HostGate {
+        &self.host_gate
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_YAML: &str = r"
+version: 1
+ip_whitelist:
+  - 10.0.0.0/8
+  - 192.168.1.5
+  - 2001:db8::/32
+ip_blacklist:
+  - 203.0.113.0/24
+  - 198.51.100.42
+host_whitelist:
+  critical:
+    - api.example.com
+    - secure.example.com
+  high:
+    - api.example.com
+  medium: []
+  catch_all: []
+tier_whitelist_mode:
+  critical: blacklist_only
+  high: blacklist_only
+  medium: full_bypass
+  catch_all: full_bypass
+";
+
+    #[test]
+    fn parses_brainstorm_sample() {
+        let lists = AccessLists::from_yaml_str(SAMPLE_YAML).expect("sample must parse");
+        let cfg = lists.config();
+        assert_eq!(cfg.ip_whitelist.len(), 3);
+        assert_eq!(cfg.ip_blacklist.len(), 2);
+        assert_eq!(cfg.host_whitelist.get(&Tier::Critical).map(Vec::len), Some(2));
+        assert_eq!(lists.tier_mode(Tier::Medium), WhitelistMode::FullBypass);
+    }
+
+    #[test]
+    fn missing_tier_mode_defaults_to_blacklist_only() {
+        let yaml = "version: 1\n";
+        let lists = AccessLists::from_yaml_str(yaml).expect("minimal yaml parses");
+        assert_eq!(lists.tier_mode(Tier::Medium), WhitelistMode::BlacklistOnly);
+    }
+
+    #[test]
+    fn rejects_unsupported_version() {
+        let err = AccessLists::from_yaml_str("version: 2\n").expect_err("v2 must fail");
+        assert!(format!("{err:#}").contains("version"));
+    }
+
+    #[test]
+    fn rejects_invalid_cidr() {
+        let yaml = "version: 1\nip_blacklist:\n  - not-a-cidr\n";
+        let err = AccessLists::from_yaml_str(yaml).expect_err("bad CIDR must fail");
+        assert!(format!("{err:#}").contains("ip_blacklist"));
+    }
+
+    #[test]
+    fn rejects_host_with_port() {
+        let yaml = "version: 1\nhost_whitelist:\n  critical:\n    - api.example.com:8080\n";
+        let err = AccessLists::from_yaml_str(yaml).expect_err("port must fail");
+        assert!(format!("{err:#}").contains("host_whitelist"));
+    }
+
+    #[test]
+    fn rejects_uppercase_host() {
+        let yaml = "version: 1\nhost_whitelist:\n  critical:\n    - API.example.com\n";
+        let err = AccessLists::from_yaml_str(yaml).expect_err("uppercase must fail");
+        assert!(format!("{err:#}").contains("lowercase"));
+    }
+
+    #[test]
+    fn hard_cap_rejects_oversized_list() {
+        // Build the AccessConfig directly: rendering 500_001 CIDRs through
+        // serde_yaml is wasteful and we only need validate() to fire.
+        let mut cfg = AccessConfig {
+            version: SUPPORTED_VERSION,
+            ..AccessConfig::default()
+        };
+        cfg.ip_blacklist = vec!["10.0.0.0/32".to_string(); HARD_REJECT_ENTRIES + 1];
+        let err = cfg.validate().expect_err("must reject");
+        assert!(format!("{err:#}").contains("hard cap"));
+    }
+
+    #[test]
+    fn empty_returns_disabled_snapshot() {
+        let lists = AccessLists::empty();
+        assert!(lists.config().ip_whitelist.is_empty());
+        assert!(!lists.dry_run());
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_field() {
+        // Operator typo — `tier_whitelist_mod` instead of `tier_whitelist_mode`.
+        // Must fail parse rather than silently dropping the override; otherwise
+        // the gate falls back to `BlacklistOnly` without any operator warning.
+        let yaml = "version: 1\ntier_whitelist_mod:\n  critical: full_bypass\n";
+        let err = AccessLists::from_yaml_str(yaml).expect_err("typo must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("unknown field") || msg.contains("tier_whitelist_mod"),
+            "error should name the unknown field, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn accepts_fqdn_with_trailing_dot() {
+        // RFC 1034 FQDN root dot. Validator must accept, gate must normalize.
+        let yaml = "version: 1\nhost_whitelist:\n  critical:\n    - api.example.com.\n";
+        let lists = AccessLists::from_yaml_str(yaml).expect("trailing dot is valid FQDN");
+        assert!(lists.host_gate().is_allowed(Tier::Critical, "api.example.com"));
+        assert!(lists.host_gate().is_allowed(Tier::Critical, "api.example.com."));
+    }
+
+    #[test]
+    fn rejects_empty_label() {
+        let yaml = "version: 1\nhost_whitelist:\n  critical:\n    - api..example.com\n";
+        let err = AccessLists::from_yaml_str(yaml).expect_err("empty label must fail");
+        assert!(format!("{err:#}").contains("empty label"));
+    }
+
+    #[test]
+    fn rejects_leading_hyphen_label() {
+        let yaml = "version: 1\nhost_whitelist:\n  critical:\n    - -bad.example.com\n";
+        let err = AccessLists::from_yaml_str(yaml).expect_err("leading hyphen must fail");
+        assert!(format!("{err:#}").contains("hyphen"));
+    }
+
+    #[test]
+    fn rejects_trailing_hyphen_label() {
+        let yaml = "version: 1\nhost_whitelist:\n  critical:\n    - bad-.example.com\n";
+        let err = AccessLists::from_yaml_str(yaml).expect_err("trailing hyphen must fail");
+        assert!(format!("{err:#}").contains("hyphen"));
+    }
+
+    #[test]
+    fn rejects_underscore_in_label() {
+        let yaml = "version: 1\nhost_whitelist:\n  critical:\n    - api_dev.example.com\n";
+        let err = AccessLists::from_yaml_str(yaml).expect_err("underscore must fail");
+        assert!(format!("{err:#}").contains("invalid characters"));
+    }
+
+    #[test]
+    fn rejects_oversize_label() {
+        let long = "a".repeat(64);
+        let yaml = format!("version: 1\nhost_whitelist:\n  critical:\n    - {long}.example.com\n");
+        let err = AccessLists::from_yaml_str(&yaml).expect_err("oversize label must fail");
+        assert!(format!("{err:#}").contains("label cap"));
+    }
+
+    #[test]
+    fn rejects_oversize_total_length() {
+        // 254 octets excluding the root dot → must fail.
+        let labels: Vec<String> = (0..127).map(|_| "ab".to_string()).collect();
+        let host = labels.join("."); // 127 * 3 - 1 = 380 octets, well over cap
+        let yaml = format!("version: 1\nhost_whitelist:\n  critical:\n    - {host}\n");
+        let err = AccessLists::from_yaml_str(&yaml).expect_err("oversize host must fail");
+        assert!(format!("{err:#}").contains("length cap"));
+    }
+
+    #[test]
+    fn rejects_bare_trailing_dot() {
+        let yaml = "version: 1\nhost_whitelist:\n  critical:\n    - .\n";
+        let err = AccessLists::from_yaml_str(yaml).expect_err("bare dot must fail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("at least one label") || msg.contains("empty label"));
+    }
+}

--- a/crates/waf-engine/src/access/evaluator.rs
+++ b/crates/waf-engine/src/access/evaluator.rs
@@ -1,0 +1,296 @@
+//! FR-008 phase-04 — access-list evaluator (Chain of Responsibility).
+//!
+//! Three stages run in fixed order: Host gate → Blacklist → Whitelist. Each may
+//! short-circuit; otherwise control falls through to `Continue`. The chain is a
+//! hard-coded sequence rather than a `Vec<Box<dyn Stage>>` — at three stages
+//! the trait indirection is pure overhead (KISS). If a fourth stage lands
+//! (FR-042 Tor egress), revisit.
+
+use std::net::IpAddr;
+
+use waf_common::tier::Tier;
+
+use crate::access::config::{AccessLists, WhitelistMode};
+
+/// Default block status code. FR-002 may later thread a per-tier status
+/// through `tier_policy.block_status`; for now `403` is hard-coded.
+const BLOCK_STATUS: u16 = 403;
+
+/// Outcome of evaluating an inbound request against the access lists.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AccessDecision {
+    /// No access-list match; continue to subsequent WAF phases.
+    Continue,
+    /// Whitelist hit with `full_bypass` mode for this tier — skip later phases.
+    BypassAll {
+        /// Stringified client IP that matched the whitelist (for audit logging).
+        matched_cidr: String,
+    },
+    /// Hard deny (host gate miss or blacklist hit).
+    Block {
+        reason: BlockReason,
+        /// Stringified value that triggered the block (host or IP).
+        matched: String,
+        /// `true` when the snapshot was loaded with `dry_run: true`. The gateway
+        /// treats dry-run blocks as `Continue` but still emits a WARN log.
+        dry_run: bool,
+        status: u16,
+    },
+}
+
+/// Why a request was blocked at Phase 0. `'static` so audit logging is alloc-free.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BlockReason {
+    HostGate,
+    IpBlacklist,
+}
+
+impl BlockReason {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::HostGate => "host_gate",
+            Self::IpBlacklist => "ip_blacklist",
+        }
+    }
+}
+
+impl AccessDecision {
+    /// Audit-log fields: `(reason, matched)`. `Continue` returns empty strings.
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn audit_fields(&self) -> (&'static str, &str) {
+        match self {
+            Self::Continue => ("continue", ""),
+            Self::BypassAll { matched_cidr } => ("bypass_all", matched_cidr.as_str()),
+            Self::Block { reason, matched, .. } => (reason.as_str(), matched.as_str()),
+        }
+    }
+}
+
+/// Borrowed snapshot fed to `evaluate`. Decouples the evaluator from
+/// `pingora_http::RequestHeader` so it can be unit-tested without a full
+/// request mock.
+#[derive(Clone, Copy, Debug)]
+pub struct AccessRequestView<'a> {
+    pub client_ip: IpAddr,
+    pub host: &'a str,
+    pub tier: Tier,
+}
+
+/// Run the three-stage chain in order: Host gate → Blacklist → Whitelist.
+///
+/// Order matters: a leaked whitelist IP must not bypass an explicit blacklist
+/// entry, so blacklist is evaluated before whitelist.
+#[must_use]
+pub fn evaluate(lists: &AccessLists, view: &AccessRequestView<'_>) -> AccessDecision {
+    let dry_run = lists.dry_run();
+
+    // 1. Host gate (deny-by-default IF the per-tier list is non-empty).
+    if !lists.host_gate().is_allowed(view.tier, view.host) {
+        return AccessDecision::Block {
+            reason: BlockReason::HostGate,
+            matched: view.host.to_string(),
+            dry_run,
+            status: BLOCK_STATUS,
+        };
+    }
+
+    // 2. Blacklist — evaluated before whitelist so explicit denies always win.
+    if lists.ip_blacklist().contains(view.client_ip) {
+        return AccessDecision::Block {
+            reason: BlockReason::IpBlacklist,
+            matched: view.client_ip.to_string(),
+            dry_run,
+            status: BLOCK_STATUS,
+        };
+    }
+
+    // 3. Whitelist (per-tier mode dispatch).
+    if lists.ip_whitelist().contains(view.client_ip) {
+        return match lists.tier_mode(view.tier) {
+            WhitelistMode::FullBypass => AccessDecision::BypassAll {
+                matched_cidr: view.client_ip.to_string(),
+            },
+            WhitelistMode::BlacklistOnly => AccessDecision::Continue,
+        };
+    }
+
+    AccessDecision::Continue
+}
+
+impl AccessLists {
+    /// Convenience delegate so callers can write `lists.evaluate(&view)`.
+    #[inline]
+    #[must_use]
+    pub fn evaluate(&self, view: &AccessRequestView<'_>) -> AccessDecision {
+        evaluate(self, view)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().expect("test ip parses")
+    }
+
+    fn view<'a>(client: &str, host: &'a str, tier: Tier) -> AccessRequestView<'a> {
+        AccessRequestView {
+            client_ip: ip(client),
+            host,
+            tier,
+        }
+    }
+
+    fn lists_from(yaml: &str) -> std::sync::Arc<AccessLists> {
+        AccessLists::from_yaml_str(yaml).expect("yaml parses")
+    }
+
+    #[test]
+    fn t_continue_no_lists() {
+        let lists = AccessLists::empty();
+        let v = view("198.51.100.1", "anything", Tier::Medium);
+        assert_eq!(lists.evaluate(&v), AccessDecision::Continue);
+    }
+
+    #[test]
+    fn t_blacklist_v4_blocks() {
+        let lists = lists_from("version: 1\nip_blacklist:\n  - 203.0.113.0/24\n");
+        let v = view("203.0.113.5", "x", Tier::Medium);
+        let d = lists.evaluate(&v);
+        assert!(matches!(
+            d,
+            AccessDecision::Block {
+                reason: BlockReason::IpBlacklist,
+                ref matched,
+                dry_run: false,
+                status: 403,
+            } if matched == "203.0.113.5"
+        ));
+    }
+
+    #[test]
+    fn t_blacklist_v6_blocks() {
+        let lists = lists_from("version: 1\nip_blacklist:\n  - 2001:db8::/32\n");
+        let v = view("2001:db8::1", "x", Tier::Medium);
+        assert!(matches!(
+            lists.evaluate(&v),
+            AccessDecision::Block {
+                reason: BlockReason::IpBlacklist,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn t_whitelist_full_bypass() {
+        let yaml = "version: 1\nip_whitelist:\n  - 10.0.0.0/8\ntier_whitelist_mode:\n  medium: full_bypass\n";
+        let lists = lists_from(yaml);
+        let v = view("10.1.2.3", "x", Tier::Medium);
+        let d = lists.evaluate(&v);
+        assert!(matches!(d, AccessDecision::BypassAll { ref matched_cidr } if matched_cidr == "10.1.2.3"));
+    }
+
+    #[test]
+    fn t_whitelist_blacklist_only() {
+        // Default mode is BlacklistOnly — whitelist hit becomes Continue, not BypassAll.
+        let yaml = "version: 1\nip_whitelist:\n  - 10.0.0.0/8\n";
+        let lists = lists_from(yaml);
+        let v = view("10.1.2.3", "x", Tier::Medium);
+        assert_eq!(lists.evaluate(&v), AccessDecision::Continue);
+    }
+
+    #[test]
+    fn t_blacklist_beats_whitelist() {
+        // Same IP in both lists. Blacklist runs first → Block wins.
+        let yaml = "version: 1\nip_whitelist:\n  - 10.0.0.0/8\nip_blacklist:\n  - 10.1.2.3\ntier_whitelist_mode:\n  medium: full_bypass\n";
+        let lists = lists_from(yaml);
+        let v = view("10.1.2.3", "x", Tier::Medium);
+        assert!(matches!(
+            lists.evaluate(&v),
+            AccessDecision::Block {
+                reason: BlockReason::IpBlacklist,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn t_host_gate_pass() {
+        let yaml = "version: 1\nhost_whitelist:\n  critical:\n    - api.example.com\n";
+        let lists = lists_from(yaml);
+        let v = view("198.51.100.1", "api.example.com", Tier::Critical);
+        assert_eq!(lists.evaluate(&v), AccessDecision::Continue);
+    }
+
+    #[test]
+    fn t_host_gate_block() {
+        let yaml = "version: 1\nhost_whitelist:\n  critical:\n    - api.example.com\n";
+        let lists = lists_from(yaml);
+        let v = view("198.51.100.1", "evil.com", Tier::Critical);
+        assert!(matches!(
+            lists.evaluate(&v),
+            AccessDecision::Block { reason: BlockReason::HostGate, ref matched, .. } if matched == "evil.com"
+        ));
+    }
+
+    #[test]
+    fn t_host_gate_disabled() {
+        // Medium tier has no hosts → D4 disabled-by-default → any host allowed.
+        let yaml = "version: 1\nhost_whitelist:\n  critical:\n    - api.example.com\n";
+        let lists = lists_from(yaml);
+        let v = view("198.51.100.1", "evil.com", Tier::Medium);
+        assert_eq!(lists.evaluate(&v), AccessDecision::Continue);
+    }
+
+    #[test]
+    fn t_dry_run_stamp() {
+        let yaml = "version: 1\ndry_run: true\nip_blacklist:\n  - 203.0.113.5\n";
+        let lists = lists_from(yaml);
+        let v = view("203.0.113.5", "x", Tier::Medium);
+        assert!(matches!(
+            lists.evaluate(&v),
+            AccessDecision::Block { dry_run: true, .. }
+        ));
+    }
+
+    #[test]
+    fn t_host_block_short_circuits_blacklist() {
+        // Host gate must run before blacklist: even if IP is also blacklisted,
+        // the reason recorded is HostGate.
+        let yaml = "version: 1\nhost_whitelist:\n  critical:\n    - api.example.com\nip_blacklist:\n  - 203.0.113.5\n";
+        let lists = lists_from(yaml);
+        let v = view("203.0.113.5", "evil.com", Tier::Critical);
+        assert!(matches!(
+            lists.evaluate(&v),
+            AccessDecision::Block {
+                reason: BlockReason::HostGate,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn t_audit_fields_block() {
+        let d = AccessDecision::Block {
+            reason: BlockReason::IpBlacklist,
+            matched: "1.2.3.4".to_string(),
+            dry_run: false,
+            status: 403,
+        };
+        assert_eq!(d.audit_fields(), ("ip_blacklist", "1.2.3.4"));
+    }
+
+    #[test]
+    fn t_view_constructs_with_v4() {
+        let v = AccessRequestView {
+            client_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            host: "localhost",
+            tier: Tier::CatchAll,
+        };
+        assert_eq!(v.host, "localhost");
+    }
+}

--- a/crates/waf-engine/src/access/host_gate.rs
+++ b/crates/waf-engine/src/access/host_gate.rs
@@ -1,0 +1,162 @@
+//! Per-tier `Host` header allowlist (FR-008 phase-03).
+//!
+//! Strict exact-match gate. Empty list for a tier = disabled (D4 safety rail):
+//! `is_allowed` returns true unconditionally so a missing config never locks a
+//! tenant out. Lookups are case-insensitive (RFC 6125 §6.4.1) and a defensive
+//! port strip handles `Host: example.com:8443` even though the parser rejects
+//! port suffixes at insert time.
+
+use std::collections::HashSet;
+
+use waf_common::tier::Tier;
+
+/// O(1) per-tier exact-match Host allowlist. Wildcards are intentionally out of
+/// scope for phase-1 (D2/D3); add a separate suffix matcher if needed later.
+///
+/// Per-tier sets are named fields rather than `[HashSet; 4]` to satisfy
+/// `clippy::indexing-slicing` without `unsafe` — the compiler proves
+/// exhaustiveness on `Tier`.
+#[derive(Debug, Default)]
+pub struct HostGate {
+    critical: HashSet<String>,
+    high: HashSet<String>,
+    medium: HashSet<String>,
+    catch_all: HashSet<String>,
+}
+
+impl HostGate {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a host into a tier's allowlist. Normalization: trim whitespace,
+    /// lowercase ASCII, strip at most one trailing `.` (FQDN root dot is
+    /// operator-input noise — stripping here keeps insert and lookup symmetric).
+    pub fn insert(&mut self, tier: Tier, host: &str) {
+        self.set_mut(tier).insert(normalize(host));
+    }
+
+    /// `true` when the request's `Host` header is allowed for this tier, OR the
+    /// tier list is empty (D4 disabled-by-default).
+    #[inline]
+    #[must_use]
+    pub fn is_allowed(&self, tier: Tier, host_header: &str) -> bool {
+        let set = self.set(tier);
+        if set.is_empty() {
+            return true;
+        }
+        // Strip first `:` defensively — `Host: example.com:8443` is valid HTTP.
+        let h = host_header.split(':').next().unwrap_or(host_header);
+        set.contains(&normalize(h))
+    }
+
+    /// `true` when no hosts are configured for this tier — phase-04 audit log
+    /// records `gate=disabled` so operators can see the D4 path was taken.
+    #[inline]
+    #[must_use]
+    pub fn is_disabled_for(&self, tier: Tier) -> bool {
+        self.set(tier).is_empty()
+    }
+
+    #[inline]
+    #[allow(clippy::missing_const_for_fn)]
+    fn set(&self, tier: Tier) -> &HashSet<String> {
+        match tier {
+            Tier::Critical => &self.critical,
+            Tier::High => &self.high,
+            Tier::Medium => &self.medium,
+            Tier::CatchAll => &self.catch_all,
+        }
+    }
+
+    #[inline]
+    #[allow(clippy::missing_const_for_fn)]
+    fn set_mut(&mut self, tier: Tier) -> &mut HashSet<String> {
+        match tier {
+            Tier::Critical => &mut self.critical,
+            Tier::High => &mut self.high,
+            Tier::Medium => &mut self.medium,
+            Tier::CatchAll => &mut self.catch_all,
+        }
+    }
+}
+
+/// Canonicalize a host string for insert/lookup equality. Lower-cases ASCII,
+/// trims surrounding whitespace, and strips at most one trailing `.` so that
+/// `api.example.com.` (FQDN root form) matches `api.example.com`.
+#[inline]
+fn normalize(host: &str) -> String {
+    let trimmed = host.trim();
+    let without_root = trimmed.strip_suffix('.').unwrap_or(trimmed);
+    without_root.to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn t_empty_disabled() {
+        let g = HostGate::new();
+        assert!(g.is_disabled_for(Tier::Critical));
+        assert!(g.is_allowed(Tier::Critical, "anything.example.com"));
+    }
+
+    #[test]
+    fn t_strict_hit() {
+        let mut g = HostGate::new();
+        g.insert(Tier::Critical, "api.example.com");
+        assert!(g.is_allowed(Tier::Critical, "api.example.com"));
+    }
+
+    #[test]
+    fn t_strict_miss() {
+        let mut g = HostGate::new();
+        g.insert(Tier::Critical, "api.example.com");
+        assert!(!g.is_allowed(Tier::Critical, "evil.com"));
+    }
+
+    #[test]
+    fn t_case_insensitive() {
+        let mut g = HostGate::new();
+        g.insert(Tier::Critical, "Api.Example.com");
+        assert!(g.is_allowed(Tier::Critical, "API.example.COM"));
+    }
+
+    #[test]
+    fn t_port_stripped() {
+        let mut g = HostGate::new();
+        g.insert(Tier::Critical, "api.example.com");
+        assert!(g.is_allowed(Tier::Critical, "api.example.com:8443"));
+    }
+
+    #[test]
+    fn t_per_tier_isolation() {
+        let mut g = HostGate::new();
+        g.insert(Tier::Critical, "api.example.com");
+        // Medium tier left empty → D4: any host allowed.
+        assert!(g.is_allowed(Tier::Medium, "evil.com"));
+        // But Critical still strict.
+        assert!(!g.is_allowed(Tier::Critical, "evil.com"));
+    }
+
+    #[test]
+    fn t_trailing_dot_symmetric_insert() {
+        // Insert with FQDN root dot — query without dot must match.
+        let mut g = HostGate::new();
+        g.insert(Tier::Critical, "api.example.com.");
+        assert!(g.is_allowed(Tier::Critical, "api.example.com"));
+        assert!(g.is_allowed(Tier::Critical, "api.example.com."));
+    }
+
+    #[test]
+    fn t_trailing_dot_symmetric_query() {
+        // Insert without dot — query with FQDN root dot must match.
+        let mut g = HostGate::new();
+        g.insert(Tier::Critical, "api.example.com");
+        assert!(g.is_allowed(Tier::Critical, "api.example.com."));
+        // And the port-stripping path must also handle the trailing dot.
+        assert!(g.is_allowed(Tier::Critical, "api.example.com.:8443"));
+    }
+}

--- a/crates/waf-engine/src/access/ip_table.rs
+++ b/crates/waf-engine/src/access/ip_table.rs
@@ -1,0 +1,180 @@
+//! Patricia-trie adapter over `ip_network_table` for dual-stack longest-prefix
+//! IP/CIDR matching (FR-008 phase-02).
+//!
+//! The crate's table already implements longest-prefix matching; we expose
+//! only `insert_str` + `contains` so the evaluator stays decoupled from the
+//! backing implementation (D9, D11). A future swap to `treebitmap` won't ripple.
+
+use std::net::IpAddr;
+use std::str::FromStr;
+
+use anyhow::{Context, anyhow};
+use ip_network::IpNetwork;
+use ip_network_table::IpNetworkTable;
+
+/// Dual-stack IP/CIDR set with O(prefix-length) lookup and no allocations on
+/// the hot path.
+pub struct IpCidrTable {
+    table: IpNetworkTable<()>,
+    len: usize,
+}
+
+impl IpCidrTable {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            table: IpNetworkTable::new(),
+            len: 0,
+        }
+    }
+
+    /// Insert a CIDR (`10.0.0.0/8`, `2001:db8::/32`) or bare IP (treated as
+    /// `/32` v4 or `/128` v6). Duplicate inserts are silently coalesced.
+    pub fn insert_str(&mut self, raw: &str) -> anyhow::Result<()> {
+        let net = parse_cidr_or_ip(raw).with_context(|| format!("invalid CIDR/IP: {raw:?}"))?;
+        // `insert` returns the previous value for the exact prefix; ignore it.
+        let _ = self.table.insert(net, ());
+        self.len += 1;
+        Ok(())
+    }
+
+    /// Longest-prefix membership test. Hot path — no allocations.
+    #[inline]
+    #[must_use]
+    pub fn contains(&self, ip: IpAddr) -> bool {
+        self.table.longest_match(ip).is_some()
+    }
+
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+impl Default for IpCidrTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for IpCidrTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IpCidrTable")
+            .field("len", &self.len)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Accept either a CIDR string or a bare IP (lifted to a host route).
+/// `ip_network` and `ipnet` are different crates — convert at this boundary so
+/// only `IpNetwork` leaks into the trie, never the public API.
+fn parse_cidr_or_ip(raw: &str) -> anyhow::Result<IpNetwork> {
+    if let Ok(net) = IpNetwork::from_str(raw) {
+        return Ok(net);
+    }
+    let ip = IpAddr::from_str(raw).map_err(|_| anyhow!("not a valid CIDR or IP address"))?;
+    let host_bits = match ip {
+        IpAddr::V4(_) => 32,
+        IpAddr::V6(_) => 128,
+    };
+    IpNetwork::new(ip, host_bits).map_err(|e| anyhow!("host route construction failed: {e:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn t_v4_hit() {
+        let mut t = IpCidrTable::new();
+        t.insert_str("10.0.0.0/8").unwrap();
+        assert!(t.contains("10.1.2.3".parse().unwrap()));
+        assert!(!t.contains("11.0.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn t_v6_hit() {
+        let mut t = IpCidrTable::new();
+        t.insert_str("2001:db8::/32").unwrap();
+        assert!(t.contains("2001:db8::1".parse().unwrap()));
+        assert!(!t.contains("2001:db9::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn t_longest_prefix_wins() {
+        // Both /8 and /24 are inserted into the same table; both report a match
+        // for an IP inside /24. Allow-vs-deny semantics live in the evaluator
+        // (phase-04), not here — this test just verifies trie membership.
+        let mut t = IpCidrTable::new();
+        t.insert_str("10.0.0.0/8").unwrap();
+        t.insert_str("10.0.0.0/24").unwrap();
+        assert!(t.contains("10.0.0.5".parse().unwrap()));
+        assert!(t.contains("10.1.0.5".parse().unwrap()));
+    }
+
+    #[test]
+    fn t_miss() {
+        let t = IpCidrTable::new();
+        assert!(!t.contains("8.8.8.8".parse().unwrap()));
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn t_single_ip() {
+        let mut t = IpCidrTable::new();
+        t.insert_str("192.168.1.5").unwrap();
+        assert!(t.contains("192.168.1.5".parse().unwrap()));
+        assert!(!t.contains("192.168.1.6".parse().unwrap()));
+    }
+
+    #[test]
+    fn t_single_ipv6() {
+        let mut t = IpCidrTable::new();
+        t.insert_str("2001:db8::1").unwrap();
+        assert!(t.contains("2001:db8::1".parse().unwrap()));
+        assert!(!t.contains("2001:db8::2".parse().unwrap()));
+    }
+
+    #[test]
+    fn t_malformed() {
+        let mut t = IpCidrTable::new();
+        let err = t.insert_str("not-an-ip").unwrap_err();
+        assert!(format!("{err:#}").contains("not-an-ip"));
+    }
+
+    #[test]
+    fn t_len_tracks_inserts() {
+        let mut t = IpCidrTable::new();
+        assert_eq!(t.len(), 0);
+        assert!(t.is_empty());
+        t.insert_str("10.0.0.0/8").unwrap();
+        assert_eq!(t.len(), 1);
+        assert!(!t.is_empty());
+        t.insert_str("192.168.1.5").unwrap();
+        assert_eq!(t.len(), 2);
+    }
+
+    #[test]
+    fn t_default_constructs_empty_table() {
+        let t = IpCidrTable::default();
+        assert_eq!(t.len(), 0);
+        assert!(t.is_empty());
+        assert!(!t.contains("10.0.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn t_debug_includes_len_field() {
+        let mut t = IpCidrTable::new();
+        t.insert_str("10.0.0.0/8").unwrap();
+        t.insert_str("192.168.0.0/16").unwrap();
+        let s = format!("{t:?}");
+        assert!(s.contains("IpCidrTable"));
+        assert!(s.contains("len"));
+        assert!(s.contains('2'));
+    }
+}

--- a/crates/waf-engine/src/access/mod.rs
+++ b/crates/waf-engine/src/access/mod.rs
@@ -1,0 +1,17 @@
+//! FR-008 — IP/Host whitelist + blacklist subsystem.
+//!
+//! Phase-01 wires only the public data model and YAML parser. The IP trie
+//! (`ip_table`), host gate (`host_gate`), and runtime evaluator (`evaluator`)
+//! are filled by phases 02-04.
+
+pub mod config;
+pub mod evaluator;
+pub mod host_gate;
+pub mod ip_table;
+pub mod reload;
+
+pub use config::{AccessConfig, AccessLists, WhitelistMode};
+pub use evaluator::{AccessDecision, AccessRequestView, BlockReason, evaluate};
+pub use host_gate::HostGate;
+pub use ip_table::IpCidrTable;
+pub use reload::{AccessReloader, DEFAULT_DEBOUNCE_MS, WatcherError};

--- a/crates/waf-engine/src/access/reload.rs
+++ b/crates/waf-engine/src/access/reload.rs
@@ -1,0 +1,303 @@
+//! FR-008 phase-06 — Access-list hot-reload watcher.
+//!
+//! Watches `rules/access-lists.yaml` and atomically `swap()`s the live
+//! [`AccessLists`] snapshot on change. Mirrors `gateway::tiered::tier_config_watcher`
+//! conventions (sync `std::thread` + `std::sync::mpsc`, parent-dir watch,
+//! debounced reload, structured logging) so review surface stays small.
+//!
+//! Drop the returned [`AccessReloader`] to stop watching.
+//!
+//! Failure semantics (D8 / AC-07): any error in read → parse → validate →
+//! build is logged at `warn` and the previous snapshot is retained. The
+//! gateway never crashes from a bad config.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use arc_swap::ArcSwap;
+use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
+use tracing::{info, warn};
+
+use crate::access::AccessLists;
+
+/// Default debounce window. 250 ms covers typical editor save bursts
+/// (truncate + write + chmod) per FR-002 precedent.
+pub const DEFAULT_DEBOUNCE_MS: u64 = 250;
+
+/// Errors returned synchronously from [`AccessReloader::spawn`]. Reload errors
+/// happen on the background thread and are logged, not propagated.
+#[derive(Debug)]
+pub enum WatcherError {
+    NoParent(PathBuf),
+    NoFileName(PathBuf),
+    Notify(notify::Error),
+}
+
+impl std::fmt::Display for WatcherError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoParent(p) => write!(f, "config file has no parent directory: {}", p.display()),
+            Self::NoFileName(p) => write!(f, "config file has no file name: {}", p.display()),
+            Self::Notify(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for WatcherError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Notify(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<notify::Error> for WatcherError {
+    fn from(e: notify::Error) -> Self {
+        Self::Notify(e)
+    }
+}
+
+/// Running file watcher. Drop to stop.
+pub struct AccessReloader {
+    // Notify watcher must outlive the reload thread — drop = stop watching.
+    _watcher: RecommendedWatcher,
+}
+
+impl AccessReloader {
+    /// Watch `path`'s parent directory and reload `store` on changes to that file.
+    ///
+    /// Watches the parent (not the file) so editors that rename-then-write —
+    /// which replace the inode — are still observed.
+    pub fn spawn(path: PathBuf, store: Arc<ArcSwap<AccessLists>>, debounce_ms: u64) -> Result<Self, WatcherError> {
+        let parent = path
+            .parent()
+            .ok_or_else(|| WatcherError::NoParent(path.clone()))?
+            .to_path_buf();
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| WatcherError::NoFileName(path.clone()))?
+            .to_os_string();
+
+        let (tx, rx) = std::sync::mpsc::channel::<notify::Result<Event>>();
+        let mut watcher = RecommendedWatcher::new(tx, Config::default())?;
+        watcher.watch(&parent, RecursiveMode::NonRecursive)?;
+        info!(file = %path.display(), "access-lists hot-reload watching");
+
+        let reload_path = path;
+        std::thread::spawn(move || {
+            let debounce = Duration::from_millis(debounce_ms);
+            let mut last_event = Instant::now();
+            let mut pending = false;
+
+            loop {
+                match rx.recv_timeout(debounce) {
+                    Ok(Ok(event)) => {
+                        let touches_us = event.paths.iter().any(|p| p.file_name() == Some(file_name.as_os_str()));
+                        let relevant = matches!(
+                            event.kind,
+                            notify::EventKind::Create(_) | notify::EventKind::Modify(_) | notify::EventKind::Remove(_)
+                        );
+                        if touches_us && relevant {
+                            last_event = Instant::now();
+                            pending = true;
+                        }
+                    }
+                    Ok(Err(e)) => warn!(error = %e, "access-lists watch error"),
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                        if pending && last_event.elapsed() >= debounce {
+                            pending = false;
+                            reload(&reload_path, &store);
+                        }
+                    }
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                        info!("access-lists watcher channel closed; stopping");
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(Self { _watcher: watcher })
+    }
+}
+
+/// Read → parse → validate → build → swap. Logs at `warn` on failure;
+/// previous snapshot is kept. Exposed so integration tests can drive the same
+/// code path without racing the watcher's debounce window.
+pub fn reload(path: &Path, store: &ArcSwap<AccessLists>) {
+    match AccessLists::from_yaml_path(path) {
+        Ok(new) => {
+            store.store(new);
+            info!(path = %path.display(), "access-lists reloaded");
+        }
+        Err(err) => {
+            warn!(
+                error = %err,
+                path = %path.display(),
+                "access-lists reload failed; keeping previous"
+            );
+        }
+    }
+}
+
+/// SIGHUP listener (Unix only).
+///
+/// Spawns a tokio task that calls [`reload`] on every SIGHUP — same fail-soft
+/// semantics. Caller must already be inside a tokio runtime; returns the task
+/// handle so it can be aborted on shutdown.
+#[cfg(unix)]
+pub fn spawn_sighup_listener(
+    path: PathBuf,
+    store: Arc<ArcSwap<AccessLists>>,
+) -> std::io::Result<tokio::task::JoinHandle<()>> {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let mut sig = signal(SignalKind::hangup())?;
+    Ok(tokio::spawn(async move {
+        while sig.recv().await.is_some() {
+            info!("SIGHUP received; reloading access-lists");
+            reload(&path, &store);
+        }
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error as _;
+
+    #[test]
+    fn t_watcher_error_display_no_parent() {
+        let e = WatcherError::NoParent(PathBuf::from("/no-parent"));
+        assert!(e.to_string().contains("no parent directory"));
+        assert!(e.source().is_none());
+    }
+
+    #[test]
+    fn t_watcher_error_display_no_file_name() {
+        let e = WatcherError::NoFileName(PathBuf::from("/"));
+        assert!(e.to_string().contains("no file name"));
+        assert!(e.source().is_none());
+    }
+
+    #[test]
+    fn t_watcher_error_from_notify_carries_source() {
+        let notify_err = notify::Error::generic("synthetic");
+        let e: WatcherError = notify_err.into();
+        assert!(matches!(e, WatcherError::Notify(_)));
+        assert!(e.source().is_some());
+        // Display must not panic.
+        let _ = e.to_string();
+    }
+
+    #[test]
+    fn t_spawn_rejects_root_path() {
+        // `/` has no parent → NoParent (Path::parent returns None for the root).
+        let store = Arc::new(ArcSwap::from(AccessLists::empty()));
+        match AccessReloader::spawn(PathBuf::from("/"), store, DEFAULT_DEBOUNCE_MS) {
+            Err(WatcherError::NoParent(_)) => {}
+            Ok(_) => panic!("root path should not succeed"),
+            Err(other) => panic!("expected NoParent, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn t_reload_swaps_on_success() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let path = tmp.path().join("a.yaml");
+        std::fs::write(&path, "version: 1\nip_blacklist:\n  - 203.0.113.0/24\n").expect("write");
+        let store = Arc::new(ArcSwap::from(AccessLists::empty()));
+        assert_eq!(store.load().config().ip_blacklist.len(), 0);
+        reload(&path, &store);
+        assert_eq!(store.load().config().ip_blacklist.len(), 1);
+    }
+
+    #[test]
+    fn t_reload_keeps_prior_on_bad_yaml() {
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let path = tmp.path().join("a.yaml");
+        std::fs::write(&path, "version: 1\nip_blacklist:\n  - 203.0.113.0/24\n").expect("write");
+        let initial = AccessLists::from_yaml_path(&path).expect("v1");
+        let store = Arc::new(ArcSwap::from(initial));
+        let prior_ptr = Arc::as_ptr(&store.load_full());
+
+        std::fs::write(&path, "version: 1\nip_blacklist:\n  - garbage\n").expect("write bad");
+        reload(&path, &store);
+
+        let now_ptr = Arc::as_ptr(&store.load_full());
+        assert_eq!(prior_ptr, now_ptr, "snapshot must be retained on bad reload");
+    }
+
+    #[test]
+    fn t_reload_keeps_prior_on_missing_file() {
+        // Missing file → IO error → reload() must log warn and retain prior.
+        let tmp = tempfile::tempdir().expect("tmpdir");
+        let path = tmp.path().join("does-not-exist.yaml");
+        let initial = AccessLists::empty();
+        let store = Arc::new(ArcSwap::from(initial));
+        let prior_ptr = Arc::as_ptr(&store.load_full());
+        reload(&path, &store);
+        let now_ptr = Arc::as_ptr(&store.load_full());
+        assert_eq!(prior_ptr, now_ptr, "snapshot must be retained when file is missing");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn t_sighup_listener_reloads_snapshot() {
+        // Drive the SIGHUP listener end-to-end inside a tokio runtime: prepare
+        // a YAML file, spawn the listener, send SIGHUP to ourselves, observe
+        // the ArcSwap snapshot pick up the new state.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("rt");
+
+        rt.block_on(async {
+            let tmp = tempfile::tempdir().expect("tmpdir");
+            let path = tmp.path().join("a.yaml");
+            std::fs::write(&path, "version: 1\nip_blacklist:\n  - 203.0.113.0/24\n").expect("write v1");
+
+            let initial = AccessLists::from_yaml_path(&path).expect("v1");
+            let store: Arc<ArcSwap<AccessLists>> = Arc::new(ArcSwap::from(initial));
+            assert_eq!(store.load().config().ip_blacklist.len(), 1);
+
+            let handle = spawn_sighup_listener(path.clone(), Arc::clone(&store)).expect("listener");
+
+            // Yield once so the spawned listener task installs its handler
+            // before we deliver the signal.
+            tokio::task::yield_now().await;
+
+            // Update on disk, then deliver SIGHUP to ourselves via /bin/kill
+            // (no unsafe FFI; workspace lints deny `unsafe_code`).
+            std::fs::write(
+                &path,
+                "version: 1\nip_blacklist:\n  - 203.0.113.0/24\n  - 198.51.100.42\n",
+            )
+            .expect("write v2");
+            let pid = std::process::id().to_string();
+            let status = std::process::Command::new("kill")
+                .arg("-HUP")
+                .arg(&pid)
+                .status()
+                .expect("kill spawn");
+            assert!(status.success(), "kill -HUP {pid} failed: {status:?}");
+
+            // Poll for the swap with a generous deadline (signals are async).
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+            loop {
+                if store.load().config().ip_blacklist.len() == 2 {
+                    break;
+                }
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "SIGHUP did not trigger reload within 2s"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+
+            handle.abort();
+        });
+    }
+}

--- a/crates/waf-engine/src/lib.rs
+++ b/crates/waf-engine/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod access;
 pub mod block_page;
 pub mod checker;
 pub mod checks;
@@ -8,7 +9,6 @@ pub mod geoip;
 pub mod geoip_updater;
 pub mod plugins;
 pub mod rules;
-
 pub use checker::RuleStore;
 pub use checks::{AntiHotlinkCheck, GeoCheck, GeoRule, GeoRuleMode, OWASPCheck, SensitiveCheck};
 pub use community::{

--- a/crates/waf-engine/tests/access_hot_reload.rs
+++ b/crates/waf-engine/tests/access_hot_reload.rs
@@ -1,0 +1,119 @@
+//! FR-008 — Hot-reload integration tests for the access-lists watcher.
+//!
+//! Two cases:
+//!   1. Valid YAML v2 written mid-flight → snapshot swapped within debounce window.
+//!   2. Bad YAML written mid-flight → prior snapshot retained.
+//!
+//! These tests use `tokio::time::sleep` to wait out the debounce + settle window
+//! (debounce=100ms, sleep=800ms gives >3× headroom on slow CI).
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use arc_swap::ArcSwap;
+use tempfile::TempDir;
+use waf_engine::access::{AccessLists, AccessReloader};
+
+/// Debounce fed to the watcher in these tests. Use a shorter window than the
+/// default (250ms) so tests are fast, but still generous relative to CI.
+const DEBOUNCE_MS: u64 = 100;
+
+/// How long to wait after writing a file before asserting the swap occurred.
+/// 800ms >> debounce (100ms) + watcher settle (~50ms) — safe even on slow CI.
+const SETTLE: Duration = Duration::from_millis(800);
+
+// ── YAML fixtures ────────────────────────────────────────────────────────────
+
+/// Initial state: empty blacklist.
+const V1_YAML: &str = r"
+version: 1
+dry_run: false
+ip_whitelist: []
+ip_blacklist: []
+";
+
+/// Updated state: one blacklist entry. Used to assert the swap happened.
+const V2_YAML: &str = r"
+version: 1
+dry_run: false
+ip_whitelist: []
+ip_blacklist:
+  - 203.0.113.42
+";
+
+/// Invalid YAML — parser rejects this, keeping prior snapshot.
+const BAD_YAML: &str = "version: 1\nip_blacklist:\n  - not-an-ip\n";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn write_and_spawn(dir: &TempDir, initial_yaml: &str) -> (std::path::PathBuf, Arc<ArcSwap<AccessLists>>) {
+    let path = dir.path().join("access-lists.yaml");
+    // Canonicalize so FSEvents on macOS matches the watch path.
+    let path = {
+        std::fs::write(&path, initial_yaml).expect("write initial yaml");
+        path.canonicalize().expect("canonicalize path")
+    };
+    let lists = AccessLists::from_yaml_path(&path).expect("initial parse");
+    let store = Arc::new(ArcSwap::new(lists));
+    (path, store)
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+/// Happy path: write V1 → spawn watcher → write V2 → wait → assert swap visible.
+#[tokio::test]
+async fn reload_replaces_snapshot_on_valid_yaml() {
+    let dir = TempDir::new().expect("tempdir");
+    let (path, store) = write_and_spawn(&dir, V1_YAML);
+
+    // Spawn watcher — drop handle at end of test to stop it.
+    let _reloader = AccessReloader::spawn(path.clone(), Arc::clone(&store), DEBOUNCE_MS).expect("spawn reloader");
+
+    // Let the OS watcher fully attach before mutating.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Precondition: snapshot has empty blacklist.
+    assert_eq!(
+        store.load().config().ip_blacklist.len(),
+        0,
+        "precondition: v1 empty blacklist"
+    );
+
+    // Write v2 — has one blacklist entry.
+    std::fs::write(&path, V2_YAML).expect("write v2");
+
+    // Wait for debounce + settle.
+    tokio::time::sleep(SETTLE).await;
+
+    let snap = store.load();
+    assert_eq!(
+        snap.config().ip_blacklist.len(),
+        1,
+        "expected v2 blacklist (1 entry) after hot-reload"
+    );
+}
+
+/// Error path: write V1 → spawn watcher → write bad YAML → wait → prior snapshot retained.
+#[tokio::test]
+async fn reload_keeps_prior_on_bad_yaml() {
+    let dir = TempDir::new().expect("tempdir");
+    let (path, store) = write_and_spawn(&dir, V1_YAML);
+
+    let _reloader = AccessReloader::spawn(path.clone(), Arc::clone(&store), DEBOUNCE_MS).expect("spawn reloader");
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Record the pointer of the current snapshot for identity comparison.
+    let prior_ptr = Arc::as_ptr(&store.load_full());
+
+    // Write bad YAML.
+    std::fs::write(&path, BAD_YAML).expect("write bad yaml");
+    tokio::time::sleep(SETTLE).await;
+
+    let now_ptr = Arc::as_ptr(&store.load_full());
+    assert_eq!(
+        prior_ptr, now_ptr,
+        "snapshot pointer must be unchanged after bad-YAML reload"
+    );
+}

--- a/crates/waf-engine/tests/access_reload_under_load.rs
+++ b/crates/waf-engine/tests/access_reload_under_load.rs
@@ -1,0 +1,157 @@
+//! FR-008 AC-08 — Reload-under-load stress test.
+//!
+//! 16 reader threads each run a tight `evaluate()` loop for 2 seconds while a
+//! writer thread rewrites the YAML mid-flight. After all threads join we assert:
+//!   - No panic occurred (join handles are unwrapped).
+//!   - The ArcSwap snapshot reflects the new state within a 2-second poll window.
+//!
+//! This exercises the lock-free `ArcSwap` swap path under genuine read pressure
+//! and validates AC-08 ("no panic under concurrent reload").
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::doc_markdown,
+    clippy::missing_const_for_fn,
+    clippy::redundant_clone,
+    clippy::manual_assert,
+    clippy::uninlined_format_args
+)]
+
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use arc_swap::ArcSwap;
+use tempfile::TempDir;
+use waf_common::tier::Tier;
+use waf_engine::access::{AccessLists, AccessReloader, AccessRequestView, DEFAULT_DEBOUNCE_MS};
+
+// ── YAML fixtures ─────────────────────────────────────────────────────────────
+
+/// Initial YAML: empty blacklist.
+const V1_YAML: &str = r"
+version: 1
+dry_run: false
+ip_whitelist: []
+ip_blacklist: []
+";
+
+/// Rewritten YAML: 8 blacklist entries. Readers should see this after the swap.
+const V2_YAML: &str = r"
+version: 1
+dry_run: false
+ip_whitelist: []
+ip_blacklist:
+  - 203.0.113.1
+  - 203.0.113.2
+  - 203.0.113.3
+  - 203.0.113.4
+  - 203.0.113.5
+  - 203.0.113.6
+  - 203.0.113.7
+  - 203.0.113.8
+";
+
+/// Number of expected blacklist entries in V2. Used in poll assertion.
+const V2_BLACKLIST_LEN: usize = 8;
+
+/// Number of concurrent reader threads.
+const READER_THREADS: usize = 16;
+
+/// How long each reader thread runs its evaluate() loop.
+const READER_DURATION: Duration = Duration::from_secs(2);
+
+/// Poll interval when waiting for the swap to become visible.
+const POLL_TICK: Duration = Duration::from_millis(50);
+
+/// Maximum time to wait for V2 to appear in the snapshot after the writer finishes.
+const SWAP_TIMEOUT: Duration = Duration::from_secs(2);
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn make_view(ip: IpAddr, host: &str, tier: Tier) -> AccessRequestView<'_> {
+    AccessRequestView {
+        client_ip: ip,
+        host,
+        tier,
+    }
+}
+
+fn write_and_spawn(dir: &TempDir, initial_yaml: &str) -> (std::path::PathBuf, Arc<ArcSwap<AccessLists>>) {
+    let path = dir.path().join("access-lists.yaml");
+    std::fs::write(&path, initial_yaml).expect("write initial yaml");
+    let path = path.canonicalize().expect("canonicalize path");
+    let lists = AccessLists::from_yaml_path(&path).expect("initial parse");
+    let store = Arc::new(ArcSwap::new(lists));
+    (path, store)
+}
+
+// ── test ──────────────────────────────────────────────────────────────────────
+
+/// AC-08: 16 reader threads × 2 s, mid-flight YAML rewrite, no panic,
+/// post-swap snapshot reflects V2 within 2 s.
+#[test]
+fn reload_under_concurrent_reads_no_panic() {
+    let dir = TempDir::new().expect("tempdir");
+    let (path, store) = write_and_spawn(&dir, V1_YAML);
+
+    let _reloader =
+        AccessReloader::spawn(path.clone(), Arc::clone(&store), DEFAULT_DEBOUNCE_MS).expect("spawn reloader");
+
+    // Give watcher a moment to fully attach.
+    std::thread::sleep(Duration::from_millis(300));
+
+    // Precondition.
+    assert_eq!(store.load().config().ip_blacklist.len(), 0, "precondition: v1 empty");
+
+    // ── spawn 16 reader threads ───────────────────────────────────────────────
+    let mut handles = Vec::with_capacity(READER_THREADS);
+    for i in 0..READER_THREADS {
+        let store_clone = Arc::clone(&store);
+        // Each thread uses a distinct IP so there is no shared L1-cache line bias.
+        let client_ip: IpAddr = format!("10.0.{}.{}", i / 256, i % 256).parse().expect("valid ip");
+        let handle = std::thread::spawn(move || {
+            let end = Instant::now() + READER_DURATION;
+            let view = make_view(client_ip, "bench.example.com", Tier::Medium);
+            while Instant::now() < end {
+                let snap = store_clone.load();
+                // evaluate() must never panic regardless of mid-flight swap.
+                let _ = snap.evaluate(&view);
+            }
+        });
+        handles.push(handle);
+    }
+
+    // ── writer: sleep 300ms then rewrite mid-flight ───────────────────────────
+    let writer_path = path.clone();
+    let writer = std::thread::spawn(move || {
+        // Readers have been running for ~300ms at this point.
+        std::thread::sleep(Duration::from_millis(300));
+        std::fs::write(&writer_path, V2_YAML).expect("write v2");
+    });
+
+    // Join writer — must not panic.
+    writer.join().expect("writer panicked");
+
+    // Join all readers — any panic propagates here.
+    for (i, h) in handles.into_iter().enumerate() {
+        h.join().unwrap_or_else(|e| panic!("reader thread {i} panicked: {e:?}"));
+    }
+
+    // ── poll until the swap is visible (max 2 s) ─────────────────────────────
+    let deadline = Instant::now() + SWAP_TIMEOUT;
+    loop {
+        let len = store.load().config().ip_blacklist.len();
+        if len == V2_BLACKLIST_LEN {
+            break;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "snapshot did not reflect V2 within {:?}; blacklist.len()={len} (expected {V2_BLACKLIST_LEN})",
+                SWAP_TIMEOUT
+            );
+        }
+        std::thread::sleep(POLL_TICK);
+    }
+}

--- a/docs/access-lists.md
+++ b/docs/access-lists.md
@@ -1,0 +1,295 @@
+# Access Lists — Operator Guide (FR-008)
+
+> **Source of truth:** `rules/access-lists.yaml`
+> **Schema version:** 1
+> **Hot-reload:** yes — file save triggers atomic swap (~250 ms debounce)
+
+---
+
+## Overview
+
+The access-list subsystem is the **Phase-0 gate** — it runs before every other WAF check. A request that hits a deny rule at this stage never reaches rule evaluation, risk scoring, or rate limiting. A request with a `full_bypass` whitelist hit skips all downstream phases entirely.
+
+Three checks run in fixed order:
+
+```
+Host gate → IP blacklist → IP whitelist → Continue (no match)
+```
+
+All gates are **off by default**. An empty `rules/access-lists.yaml` (the shipped default) passes every request through to the rest of the WAF unchanged. Gates activate only when you populate the relevant list.
+
+---
+
+## File Location
+
+```
+rules/access-lists.yaml
+```
+
+The path is resolved relative to the WAF working directory and is currently hardcoded — for a containerized deploy, bind-mount the host file onto `<workdir>/rules/access-lists.yaml`. A configurable override key is tracked as a follow-up.
+
+The file is watched with `notify` (inotify on Linux, FSEvents on macOS, ReadDirectoryChanges on Windows). Editor "rename then write" workflows (vim, most IDEs) are supported because the watcher observes the parent directory, not the inode.
+
+Reload can also be triggered manually with **SIGHUP**:
+
+```bash
+kill -HUP $(pgrep prx-waf)
+```
+
+---
+
+## Schema Reference
+
+```yaml
+version: 1              # Required. Only version 1 is supported; bump = breaking change.
+dry_run: false          # Optional. true = log decisions but never actually block.
+
+ip_whitelist: []        # List of IPv4/IPv6 CIDRs or bare IPs.
+ip_blacklist: []        # List of IPv4/IPv6 CIDRs or bare IPs.
+
+host_whitelist:         # Per-tier FQDN allowlist. Empty list = gate disabled for that tier.
+  critical:  []
+  high:      []
+  medium:    []
+  catch_all: []
+
+tier_whitelist_mode:    # Per-tier whitelist short-circuit behaviour.
+  critical:  blacklist_only   # default
+  high:      blacklist_only
+  medium:    full_bypass
+  catch_all: full_bypass
+```
+
+### Field Details
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `version` | integer | `0` (invalid) | Must be `1`. Missing field causes rejection. |
+| `dry_run` | bool | `false` | Audit-only mode; see below. |
+| `ip_whitelist` | list\<string\> | `[]` | CIDRs/IPs to trust. |
+| `ip_blacklist` | list\<string\> | `[]` | CIDRs/IPs to block. |
+| `host_whitelist` | map\<tier, list\<string\>\> | `{}` | Per-tier FQDN allowlist. |
+| `tier_whitelist_mode` | map\<tier, mode\> | `{}` | `full_bypass` or `blacklist_only`. Missing tier defaults to `blacklist_only`. |
+
+---
+
+## Whitelist Modes
+
+### `blacklist_only` (default)
+
+A whitelist hit does **not** skip downstream checks. The request continues through rule evaluation and risk scoring as normal. Only the IP blacklist check is effectively bypassed (because blacklist runs before whitelist and already passed).
+
+Use this for internal networks you trust enough not to block, but still want to audit.
+
+### `full_bypass`
+
+A whitelist hit **skips all downstream WAF phases**. The request is forwarded to the upstream with no further inspection. This is the fast path for known-clean traffic (internal load balancers, health checkers).
+
+Use with caution: a misconfigured CIDR silently bypasses the entire WAF.
+
+**Default assignment in shipped config:**
+
+| Tier | Default mode |
+|---|---|
+| `critical` | `blacklist_only` |
+| `high` | `blacklist_only` |
+| `medium` | `full_bypass` |
+| `catch_all` | `full_bypass` |
+
+---
+
+## CIDR and IP Format
+
+Both IPv4 and IPv6 are accepted, and you can mix them freely in the same list.
+
+```yaml
+ip_blacklist:
+  - 203.0.113.0/24       # IPv4 CIDR
+  - 198.51.100.42        # bare IPv4 (treated as /32)
+  - 2001:db8::/32        # IPv6 CIDR
+  - 2001:db8::1          # bare IPv6 (treated as /128)
+```
+
+Longest-prefix match is used: a `/32` entry overrides a `/8` entry for the same IP. There is no "weight" — the first matching rule wins in blacklist order; the blacklist always wins over the whitelist regardless of entry order (blacklist is evaluated first in the chain).
+
+**Hard cap:** 500 000 combined entries across `ip_whitelist` + `ip_blacklist`. The parser rejects files that exceed this. **Soft cap:** 50 000 entries triggers a `WARN` log on load.
+
+---
+
+## Host (FQDN) Format
+
+```yaml
+host_whitelist:
+  critical:
+    - api.example.com
+    - secure.example.com
+```
+
+Rules:
+- Lowercase only (no `API.example.com`).
+- No port suffix (no `api.example.com:443`).
+- No leading/trailing whitespace.
+- Exact match only — wildcards (`*.example.com`) are **not** supported in v1.
+- Empty list for a tier = host gate disabled for that tier (any host allowed).
+
+The `Host` request header is lowercased before comparison so case differences in the upstream request are handled transparently.
+
+---
+
+## Hot-Reload Mechanics
+
+1. File save detected by OS watcher (parent-dir watch, non-recursive).
+2. 250 ms debounce window drains editor burst events (truncate + write + chmod).
+3. File is read, parsed, and validated.
+4. On success: `ArcSwap::store()` atomically replaces the live snapshot. In-flight requests using the old snapshot complete normally; new requests see the new snapshot.
+5. On failure: **prior snapshot is retained**. A `WARN` log line is emitted with the parse error. The WAF continues operating with the last known-good config.
+
+```
+[WARN] access-lists reload failed; keeping previous  path=rules/access-lists.yaml  error=...
+[INFO] access-lists reloaded                          path=rules/access-lists.yaml
+```
+
+---
+
+## Audit Logging
+
+Block and bypass decisions emit structured log fields. `Continue` is silent on the hot path.
+
+| Field | Values | Emitted on | Notes |
+|---|---|---|---|
+| message | `access: whitelist bypass` / `access: block` / `access: block (dry-run) — treating as continue` | bypass / block / dry-run | `tracing` event message |
+| `reason` | `host_gate`, `ip_blacklist` | block, dry-run block | Which gate fired |
+| `matched` | client IP string or `Host` header | bypass, block, dry-run block | What triggered the decision |
+| `host` | request `Host` header | bypass, block, dry-run block | Host as observed by the gate |
+| `tier` | `Critical`, `High`, `Medium`, `CatchAll` | bypass, block, dry-run block | Tier the request resolved to |
+| `dry_run` | `true` | dry-run block only | Marker that the block was suppressed |
+| `status` | `403` | block, dry-run block | HTTP status that would be returned (even in dry-run mode) |
+
+In `dry_run: true` mode the gateway logs a `WARN` (`access: block (dry-run) — treating as continue`) and forwards the request — no traffic is actually blocked.
+
+---
+
+## Decision Flow
+
+```
+Request arrives
+      │
+      ▼
+┌─────────────────────────────────────┐
+│  Host gate (per-tier FQDN check)    │
+│  Enabled only if host_whitelist     │
+│  for this tier is non-empty.        │
+│  Host NOT in list → Block(HostGate) │
+└────────────────┬────────────────────┘
+                 │ pass
+                 ▼
+┌─────────────────────────────────────┐
+│  IP blacklist (CIDR trie lookup)    │
+│  IP matches → Block(IpBlacklist)    │
+└────────────────┬────────────────────┘
+                 │ pass
+                 ▼
+┌─────────────────────────────────────┐
+│  IP whitelist (CIDR trie lookup)    │
+│  IP matches + FullBypass → BypassAll│
+│  IP matches + BlacklistOnly → Cont. │
+└────────────────┬────────────────────┘
+                 │ no match
+                 ▼
+             Continue
+        (downstream WAF phases)
+```
+
+**Blacklist beats whitelist.** If the same IP appears in both lists, the blacklist check fires first and the request is blocked regardless of the whitelist entry.
+
+---
+
+## Operator Playbook
+
+### Block a known-bad IP
+
+```yaml
+ip_blacklist:
+  - 198.51.100.99        # specific attacker
+  - 192.0.2.0/24        # entire hostile /24
+```
+
+Save the file. Reload happens within ~250 ms. Verify:
+
+```bash
+tail -f logs/waf.log | grep '"reason":"ip_blacklist"'
+```
+
+### Trust an internal admin IP (full bypass)
+
+```yaml
+ip_whitelist:
+  - 10.10.0.0/16        # internal admin network
+
+tier_whitelist_mode:
+  critical: full_bypass  # admins skip WAF on critical tier too
+```
+
+### Lock a Critical-tier service to known frontends only
+
+```yaml
+host_whitelist:
+  critical:
+    - api.internal.example.com
+    - admin.internal.example.com
+```
+
+Any request to a `Critical`-tier upstream with a different `Host` header receives a 403 at Phase 0.
+
+### Test a new blocklist non-destructively
+
+```yaml
+dry_run: true
+ip_blacklist:
+  - 203.0.113.0/24
+```
+
+The WAF logs `reason=ip_blacklist dry_run=true` but forwards every request normally. Review logs, then set `dry_run: false` to activate.
+
+---
+
+## Troubleshooting
+
+**Reload not taking effect:**
+```bash
+tail -f logs/waf.log | grep 'access-list'
+```
+Look for `WARN access-lists reload failed` — the error message contains the YAML line/column of the parse failure.
+
+**Unexpected blocks:**
+Check the `reason` and `matched` fields in the request log to identify which gate fired and which entry matched.
+
+**Tier not found:**
+If the `Tier` field in a request log is unexpected, verify the tier-routing config in `configs/gateway.toml`. The access-list evaluator uses whatever tier the gateway assigned.
+
+**File parse rejected:**
+- Confirm `version: 1` is present.
+- Hosts must be lowercase with no port (`:443` suffix breaks validation).
+- CIDRs must be valid (`10.0.0.0/33` is rejected; max prefix is `/32` for v4, `/128` for v6).
+- Total IP entries must not exceed 500 000.
+
+---
+
+## Production Caveats
+
+- **Soft cap 50 000 entries** — a `WARN` is logged on load. Performance degrades gracefully (trie lookup is O(prefix-length), not O(n)).
+- **Hard cap 500 000 entries** — the parser rejects the file. The previous snapshot is retained.
+- **Empty file** — parsed as all-gates-disabled (same as the shipped default). The WAF continues normally.
+- **Missing file at boot** — WAF starts with an empty (all-gates-disabled) snapshot and logs an `INFO`. A subsequent file creation triggers a reload automatically.
+
+---
+
+## Migration from FR-008 v1 (threat_intel module)
+
+The `threat_intel` module (Tor exit-node fetcher, ASN auto-classifier, Ed25519 signed blocklists) was **deferred to FR-042** and is not present in this release. Operators who need Tor exit-node blocking can:
+
+1. Download the Tor exit-node list periodically (e.g. from `https://check.torproject.org/torbulkexitlist`).
+2. Concatenate the IPs into `ip_blacklist:` in `rules/access-lists.yaml`.
+3. Automate the refresh with a cron job that writes the file — the hot-reload watcher picks up the change within 250 ms.
+
+ASN-based blocking and cryptographically signed blocklist distribution are tracked in FR-042.

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -75,6 +75,8 @@ prx-waf/
 │   │   │   ├── geoip.rs       # GeoIP lookup (ip2region)
 │   │   │   └── url_validator.rs # SSRF protection, DNS rebinding guard
 │   │   │
+│   │   ├── access/            # FR-008 — file-based YAML allowlist/blocklist (IP, CIDR, host)
+│   │   │
 │   │   └── lib.rs
 │   │
 │   ├── waf-storage/src/
@@ -435,6 +437,16 @@ See [Tiered Protection Consumer Guide](./tiered-protection.md) for request class
 - Criterion benchmarks: p99 <500µs clean traffic, <1ms malicious payloads
 
 **Testing**: 63+ acceptance tests covering all pattern types, encoding bypasses, false positives
+
+---
+
+## Threat-Intel Module (FR-008 v1.5)
+
+File-based IP/FQDN allow+block lists, Tor exit blocking, and ASN-based blocking inserted as Phase 1.5 in the detection pipeline (between DB IP-allow and DB IP-block). Hot-reloaded via inotify, 4h periodic re-scan, and SIGHUP.
+
+**v1.5 hardening** — Phase 01: feed-freshness tracking (`list_max_age_hours`, `freshness_minutes` audit field, `bypass_attempt` warn throttled 1/60s). Phase 02: optional Ed25519 sidecar signing (`public_key_pins`, per-list `signing_required`, `signed_by` audit field).
+
+See [`docs/threat-intel-operator-runbook.md`](./threat-intel-operator-runbook.md) for full setup, key rotation procedure, and signed-mirror cron examples.
 
 ---
 

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -100,6 +100,12 @@ Implements a four-tier request classification and per-tier policy bus that all d
 
 ---
 
+### FR-008 — File-Based Access Lists (allow/block) — complete
+
+YAML-driven IP/CIDR/host allow+block layer (access module). Hot-reload via inotify + SIGHUP. Replaces earlier threat_intel module.
+
+---
+
 ## v0.3.0 (Proposed — Q3 2026)
 
 **Theme**: Observability & Developer Experience

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -108,6 +108,18 @@ Phase 1: IP Allowlist (CIDR)
 ├─ If match → allow this phase, continue to Phase 2
 └─ If no match → continue (allowlist is permissive)
 
+Phase 1.5: Threat-Intel (FR-008 v1.5) — file-based, inserted between Phase 1 and Phase 2
+├─ IP allowlist files (CIDR) → short-circuit allow if matched
+├─ IP blocklist files (CIDR) + ASN blocklist + Tor exits → BLOCK if matched
+├─ FQDN allowlist (IDNA-normalized) → short-circuit allow
+├─ CDN ASN short-circuit (Cloudflare/AWS/Akamai/Fastly/Google)
+├─ Feed freshness: mtime checked at load; stale file → tracing::warn! (never fail-closed)
+│   freshness_minutes added to WafDecision.detail for SIEM alerting (Phase 01)
+├─ Ed25519 sidecar signing: public_key_pins in TOML; per-list signing_required;
+│   signed_by audit field on verified hits (Phase 02)
+├─ bypass_attempt warn (throttled 1/60s) when IP matches both allowlist + blocklist
+└─ If no match → continue to Phase 2
+
 Phase 2: IP Blocklist (CIDR)
 ├─ Check if client IP in block_ips table
 ├─ If match → BLOCK (decision made)

--- a/rules/access-lists.yaml
+++ b/rules/access-lists.yaml
@@ -1,0 +1,31 @@
+# FR-008 — Access lists (IP allow/deny + per-tier Host allowlist).
+#
+# All-empty default → every gate is OFF until populated. Safe to deploy as-is.
+# Schema mirrored verbatim in docs/access-lists.md — keep both in sync.
+#
+# Hot-reloaded on file save (notify watcher, ~250 ms debounce). Parse errors
+# keep the previous snapshot live; check WAF logs for `access-list reload`.
+
+version: 1
+dry_run: false
+
+# IP/CIDR lists. Bare IPs accepted (treated as /32 or /128). v4 + v6 mix freely.
+ip_whitelist: []
+ip_blacklist: []
+
+# Per-tier Host (FQDN) whitelist. Lowercase, no port suffix.
+# Empty list per tier = gate disabled for that tier (deny-by-default OFF).
+host_whitelist:
+  critical:  []
+  high:      []
+  medium:    []
+  catch_all: []
+
+# How a whitelist hit short-circuits the pipeline, per tier.
+#   full_bypass    → skip ALL downstream WAF phases (fast path).
+#   blacklist_only → run rules even if whitelisted (defense-in-depth, default).
+tier_whitelist_mode:
+  critical:  blacklist_only
+  high:      blacklist_only
+  medium:    full_bypass
+  catch_all: full_bypass


### PR DESCRIPTION
## Summary

Refactor of FR-008 (whitelist + blacklist) using a focused `access-lists` module in place of the previous file-based threat-intel subsystem. A single hot-reloadable YAML config (`rules/access-lists.yaml`) drives:

- **IP whitelist** — CIDR or bare IP, dual-stack, longest-prefix match (Patricia trie).
- **IP blacklist** — same shape; explicit denies always win over whitelist.
- **Per-tier Host (FQDN) whitelist** — exact-match, lowercase, port-stripped. Empty per-tier list = gate disabled (does not lock tenants out on missing config).
- **`WhitelistMode` per tier** — `full_bypass` (skip the WAF engine for this request) or `blacklist_only` (run rules even when whitelisted, default).
- **`dry_run: true`** — log every decision but never block; safe staging path for new lists.

Hot-reload runs via `notify` parent-directory watch + 250 ms debounce + `ArcSwap` atomic snapshot swap. Bad YAML keeps the previous snapshot live with a structured WARN — the gateway never crashes from a bad config. SIGHUP triggers the same reload path on Unix.

The Phase-0 access gate runs inline in `gateway::WafProxy::request_filter` *before* the WAF engine, so a blacklisted IP pays no rule-engine cost.

## What changed

| Area | Diff |
|---|---|
| `crates/waf-engine/src/access/` (config, ip_table, host_gate, evaluator, reload) | +1,151 LOC, 39 unit tests |
| `crates/gateway/src/pipeline/access_phase.rs` + proxy/context wiring | +260 LOC, 9 unit tests |
| `crates/prx-waf/src/main.rs` boot wiring (load YAML, spawn watcher, SIGHUP) | +55 LOC |
| `crates/waf-engine/tests/access_hot_reload.rs` | +108 LOC, 2 cases |
| `crates/waf-engine/tests/access_reload_under_load.rs` (AC-08, 16 readers × 2 s) | +144 LOC, 1 case |
| `crates/waf-engine/benches/access_lookup.rs` (Criterion, 4 benches) | +121 LOC |
| `rules/access-lists.yaml` (empty defaults, schema-versioned `version: 1`) | +31 LOC |
| `docs/access-lists.md` (operator guide: schema, decision flow, audit fields, troubleshooting) | +293 LOC |
| Deletes: previous threat-intel module + `ThreatIntelConfig` + 815-line acceptance suite + 519-line runbook | −4,200 LOC |

**Net: ~−2,700 LOC.**

## Out of scope (deferred to FR-042 IP Reputation Feed)

- **Tor exit list auto-fetcher** — operators that need Tor egress filtering can periodically refresh `https://check.torproject.org/exit-addresses` and concat into `ip_blacklist:` (single text file, hot-reload picks it up).
- **Bad-ASN classification** — needs a maintained ASN→reputation source.
- **Ed25519 feed signing / verification** — requires an operator-side signing pipeline; out of scope for v1.
- **Per-source freshness checks** — relevant when feeds are auto-fetched.

These were carried by the old threat-intel module but are not part of FR-008's P0 surface; they belong with the IP-reputation work in FR-042.

## Reviewer notes — previous review on commit `31b201a`

The three blocking findings raised on the previous commit are moot under this design — the underlying code paths no longer exist:

- **C1 (`extra_internal_cidrs` dead config)** — `ThreatIntelConfig` removed entirely; the new schema has no equivalent unread field.
- **C2 (`u64 * 3600` overflow risk on freshness)** — freshness module deleted; the new YAML parser hard-caps entry counts (50 K soft warn, 500 K reject) at boot, no time-window arithmetic.
- **I7 (`signing_required = true` + empty `signing_pins` fail-open)** — signing logic deleted; not re-introduced for v1.

The earlier protonmns comments R1 (Medium/CatchAll soft-label asymmetry) and R2 (`ThreatIntelWatcher` `JoinHandle` leak) are likewise moot — both files no longer exist. The new evaluator stamps `access_decision` / `access_reason` / `matched` audit fields uniformly across all tiers, and `AccessReloader` is owned by the bootstrap call-site (drop = stop watching).

## Test plan

- [x] `cargo fmt --all -- --check` — Docker `rust:1.95-slim-bookworm`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — Docker
- [x] `cargo test -p waf-engine -p waf-common -p gateway -p prx-waf` — Docker, 477 tests green
- [x] `cargo bench -p waf-engine --no-run` — Docker, all benches compile
- [x] `access_hot_reload` integration test — 2 cases pass (good YAML → swap, bad YAML → keep prior)
- [x] `access_reload_under_load` (AC-08) — 16 readers × 2 s, mid-flight rewrite, no panics
- [ ] Manual: edit `rules/access-lists.yaml`, expect live propagation in ≤ 1 s without restart

## Operator notes

`rules/access-lists.yaml` ships empty (every gate disabled). Drop in entries and save — the watcher picks up the change. See `docs/access-lists.md` for the full schema and a playbook for common scenarios (block a known-bad IP, lock down `Critical` to known frontends, stage a new list with `dry_run`).
