### PR TITLE
feat(waf-engine): FR-014 XSS JSON walker + form-urlencoded scanner

### DIFF
--- a/crates/waf-engine/src/checks/mod.rs
+++ b/crates/waf-engine/src/checks/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod sql_injection_patterns;
 pub(crate) mod sql_injection_scanners;
 pub mod ssrf;
 pub mod xss;
+pub(crate) mod xss_scanners;
 
 pub use anti_hotlink::AntiHotlinkCheck;
 pub use body_abuse::RequestBodyAbuseCheck;

--- a/crates/waf-engine/src/checks/xss.rs
+++ b/crates/waf-engine/src/checks/xss.rs
@@ -3,9 +3,10 @@ use std::sync::LazyLock;
 use regex::RegexSet;
 use waf_common::{DetectionResult, Phase, RequestCtx};
 
+use super::xss_scanners::{scan_form_urlencoded, scan_json_body_xss};
 use super::{Check, request_targets};
 
-static XSS_DESCS: &[&str] = &[
+pub(crate) static XSS_DESCS: &[&str] = &[
     "<script> tag",
     "event handler attribute (on*=)",
     "javascript: URI",
@@ -26,7 +27,7 @@ static XSS_DESCS: &[&str] = &[
 
 // SAFETY: All patterns are compile-time string literals. If any pattern fails
 // to compile it is a code bug that must be caught in development, not at runtime.
-static XSS_SET: LazyLock<RegexSet> = LazyLock::new(|| {
+pub(crate) static XSS_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     match RegexSet::new([
         // <script...>
         r"(?i)<\s*/?\s*script[\s/>]",
@@ -90,20 +91,54 @@ impl Check for XssCheck {
             return None;
         }
 
+        // Content-Type-aware body inspection runs first so structured payloads
+        // (JSON / form-urlencoded) get precise location attribution before the
+        // raw-bytes fallback in `request_targets()`.
+        let content_type = ctx
+            .headers
+            .get("content-type")
+            .map_or("", String::as_str)
+            .to_ascii_lowercase();
+        let body_cap = ctx.host_config.defense_config.max_body_size;
+
+        if !ctx.body_preview.is_empty() {
+            if content_type.starts_with("application/json")
+                && let Some((path, idx)) = scan_json_body_xss(&ctx.body_preview, &XSS_SET, body_cap)
+            {
+                return Some(detection_at(idx, &path));
+            } else if content_type.starts_with("application/x-www-form-urlencoded")
+                && let Some((loc, idx)) = scan_form_urlencoded(&ctx.body_preview, &XSS_SET)
+            {
+                return Some(detection_at(idx, &loc));
+            }
+        }
+
+        // `text/markdown` legitimately contains `<script` snippets in code
+        // blocks; skip the raw-body location to suppress false positives.
+        // Non-body locations (path / query / cookie) still scan normally.
+        let skip_body = content_type.starts_with("text/markdown");
+
         for (location, value) in request_targets(ctx) {
+            if skip_body && location.starts_with("body") {
+                continue;
+            }
             let matches = XSS_SET.matches(&value);
             if matches.matched_any() {
                 let idx = matches.iter().next().unwrap_or(0);
-                let desc = XSS_DESCS.get(idx).copied().unwrap_or("XSS pattern");
-                return Some(DetectionResult {
-                    rule_id: Some(format!("XSS-{:03}", idx + 1)),
-                    rule_name: "XSS".to_string(),
-                    phase: Phase::Xss,
-                    detail: format!("{desc} detected in {location}"),
-                });
+                return Some(detection_at(idx, location));
             }
         }
         None
+    }
+}
+
+fn detection_at(idx: usize, location: &str) -> DetectionResult {
+    let desc = XSS_DESCS.get(idx).copied().unwrap_or("XSS pattern");
+    DetectionResult {
+        rule_id: Some(format!("XSS-{:03}", idx + 1)),
+        rule_name: "XSS".to_string(),
+        phase: Phase::Xss,
+        detail: format!("{desc} detected in {location}"),
     }
 }
 
@@ -117,22 +152,30 @@ mod tests {
     use waf_common::{DefenseConfig, HostConfig};
 
     fn make_ctx(query: &str, body: &str) -> RequestCtx {
+        make_ctx_with(query, body, "", true)
+    }
+
+    fn make_ctx_with(query: &str, body: &str, content_type: &str, xss_enabled: bool) -> RequestCtx {
+        let mut headers = HashMap::new();
+        if !content_type.is_empty() {
+            headers.insert("content-type".to_string(), content_type.to_string());
+        }
         RequestCtx {
             req_id: "test".to_string(),
             client_ip: "127.0.0.1".parse::<IpAddr>().unwrap(),
             client_port: 0,
-            method: "GET".to_string(),
+            method: "POST".to_string(),
             host: "example.com".to_string(),
             port: 80,
             path: "/".to_string(),
             query: query.to_string(),
-            headers: HashMap::new(),
+            headers,
             body_preview: Bytes::from(body.to_string()),
             content_length: body.len() as u64,
             is_tls: false,
             host_config: Arc::new(HostConfig {
                 defense_config: DefenseConfig {
-                    xss: true,
+                    xss: xss_enabled,
                     ..DefenseConfig::default()
                 },
                 ..HostConfig::default()
@@ -170,5 +213,112 @@ mod tests {
         let checker = XssCheck::new();
         let ctx = make_ctx("q=hello+world&page=1", "");
         assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_script_tag_double_encoded_in_query() {
+        // %253Cscript%253E → %3Cscript%3E → <script> after recursive decode.
+        let checker = XssCheck::new();
+        let ctx = make_ctx("q=%253Cscript%253Ealert(1)%253C/script%253E", "");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_xss_in_json_body_with_path_attribution() {
+        let checker = XssCheck::new();
+        let ctx = make_ctx_with("", r#"{"a":{"b":"<script>"}}"#, "application/json", true);
+        let det = checker.check(&ctx).expect("hit");
+        assert!(det.detail.contains("body.json.a.b"));
+    }
+
+    #[test]
+    fn detects_xss_in_json_array() {
+        let checker = XssCheck::new();
+        let ctx = make_ctx_with("", r#"["safe","<img onerror=x>"]"#, "application/json", true);
+        let det = checker.check(&ctx).expect("hit");
+        assert!(det.detail.contains("body.json[1]"));
+    }
+
+    #[test]
+    fn detects_xss_in_form_urlencoded_body() {
+        let checker = XssCheck::new();
+        let ctx = make_ctx_with(
+            "",
+            "q=%3Cscript%3Ealert(1)%3C/script%3E",
+            "application/x-www-form-urlencoded",
+            true,
+        );
+        let det = checker.check(&ctx).expect("hit");
+        assert!(det.detail.contains("body.form.q"));
+    }
+
+    #[test]
+    fn allows_clean_json_body() {
+        let checker = XssCheck::new();
+        let ctx = make_ctx_with("", r#"{"name":"Alice"}"#, "application/json", true);
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn allows_clean_form_body() {
+        let checker = XssCheck::new();
+        let ctx = make_ctx_with("", "q=hello+world&page=1", "application/x-www-form-urlencoded", true);
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn malformed_json_falls_through_to_raw_scan() {
+        // Walker bails None on bad JSON; raw `request_targets()` then scans
+        // the bytes — `<script>` substring still gets caught.
+        let checker = XssCheck::new();
+        let ctx = make_ctx_with("", "not-json-but-<script>here", "application/json", true);
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn skipped_when_xss_disabled() {
+        let checker = XssCheck::new();
+        let ctx = make_ctx_with("", r#"{"x":"<script>"}"#, "application/json", false);
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn markdown_body_skipped_but_query_still_scanned() {
+        // `<script>` in a markdown body is allowed (false-positive mitigation).
+        let checker = XssCheck::new();
+        let ctx = make_ctx_with("", "Here is some `<script>` in a code block", "text/markdown", true);
+        assert!(checker.check(&ctx).is_none());
+
+        // Query string still scans even with markdown content type.
+        let ctx2 = make_ctx_with("q=<script>", "ignored", "text/markdown", true);
+        assert!(checker.check(&ctx2).is_some());
+    }
+
+    #[test]
+    fn detection_carries_correct_phase_and_rule_id_prefix() {
+        let checker = XssCheck::new();
+        let ctx = make_ctx("q=<script>", "");
+        let det = checker.check(&ctx).expect("hit");
+        assert_eq!(det.phase, waf_common::Phase::Xss);
+        assert_eq!(det.rule_name, "XSS");
+        assert!(det.rule_id.as_deref().unwrap_or("").starts_with("XSS-"));
+    }
+
+    #[test]
+    fn deeply_nested_json_does_not_overflow_dispatcher() {
+        // Echoes xss_scanners::tests but exercises the full dispatcher path
+        // including content-type detection + body cap.
+        let checker = XssCheck::new();
+        let mut s = String::new();
+        for _ in 0..200 {
+            s.push_str("{\"x\":");
+        }
+        s.push_str("\"<script>\"");
+        for _ in 0..200 {
+            s.push('}');
+        }
+        let ctx = make_ctx_with("", &s, "application/json", true);
+        // Should NOT panic. May or may not detect (walker bails past depth cap).
+        let _ = checker.check(&ctx);
     }
 }

--- a/crates/waf-engine/src/checks/xss_scanners.rs
+++ b/crates/waf-engine/src/checks/xss_scanners.rs
@@ -1,0 +1,182 @@
+//! XSS scanner helpers — JSON walker + form-urlencoded extractor.
+//!
+//! Both scanners produce `(location_string, pattern_index)` so the caller can
+//! attribute the hit precisely (e.g. `body.json.user.name` vs `body.form.q`).
+//! The JSON walker is **iterative** and bails on depth > [`MAX_JSON_DEPTH`] —
+//! using the recursive pattern from `sql_injection_scanners` would re-introduce
+//! the stack-overflow class FR-020 is meant to detect (Red Team Finding #4).
+
+use regex::RegexSet;
+use serde_json::Value;
+use std::fmt::Write;
+
+use super::url_decode_recursive;
+
+/// Hard recursion cap for JSON walking. Anything deeper is skipped (not flagged)
+/// so a malicious deep-nested body cannot crash the engine before FR-020
+/// (Phase 06) gets a chance to flag it.
+pub const MAX_JSON_DEPTH: usize = 64;
+
+/// Scan a JSON body for XSS patterns, returning (`json_path`, `pattern_index`)
+/// on the first hit. Bails out as `None` on parse error, oversize, or
+/// depth-exceeded — the body-abuse check (FR-020) is responsible for
+/// translating those cases into block decisions.
+pub fn scan_json_body_xss(body: &[u8], patterns: &RegexSet, json_parse_cap: usize) -> Option<(String, usize)> {
+    if body.len() > json_parse_cap {
+        return None;
+    }
+    let v: Value = serde_json::from_slice(body).ok()?;
+    walk_json_iter(&v, patterns)
+}
+
+/// Iterative depth-first walker. Each stack entry owns the full path string
+/// for its node — costs O(depth × `path_len`) memory bounded by
+/// [`MAX_JSON_DEPTH`] but avoids the truncate-on-pop bookkeeping that's
+/// brittle when interleaved with branchy iteration order.
+fn walk_json_iter(root: &Value, set: &RegexSet) -> Option<(String, usize)> {
+    let mut stack: Vec<(&Value, String, usize)> = Vec::with_capacity(MAX_JSON_DEPTH);
+    stack.push((root, String::from("body.json"), 0));
+
+    while let Some((node, path, depth)) = stack.pop() {
+        if depth > MAX_JSON_DEPTH {
+            // Skip — FR-020 will flag the depth violation separately.
+            continue;
+        }
+        match node {
+            Value::String(s) => {
+                let decoded = url_decode_recursive(s);
+                if let Some(idx) = set.matches(&decoded).iter().next() {
+                    return Some((path, idx));
+                }
+            }
+            Value::Object(map) => {
+                // Push reversed so LIFO pop yields original insertion order.
+                for (k, child) in map.iter().rev() {
+                    let mut child_path = path.clone();
+                    child_path.push('.');
+                    child_path.push_str(k);
+                    stack.push((child, child_path, depth + 1));
+                }
+            }
+            Value::Array(arr) => {
+                for (i, child) in arr.iter().enumerate().rev() {
+                    let mut child_path = path.clone();
+                    let _ = write!(child_path, "[{i}]");
+                    stack.push((child, child_path, depth + 1));
+                }
+            }
+            _ => {} // null / bool / number — skip
+        }
+    }
+    None
+}
+
+/// Scan a form-urlencoded body (`application/x-www-form-urlencoded`),
+/// returning (`body.form.<key>`, `pattern_index`) on first hit. Each value is
+/// percent-decoded recursively before regex match.
+pub fn scan_form_urlencoded(body: &[u8], patterns: &RegexSet) -> Option<(String, usize)> {
+    for (k, v) in url::form_urlencoded::parse(body) {
+        let decoded = url_decode_recursive(&v);
+        if let Some(idx) = patterns.matches(&decoded).iter().next() {
+            return Some((format!("body.form.{k}"), idx));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checks::xss::XSS_SET;
+
+    const TEST_CAP: usize = 64 * 1024;
+
+    #[test]
+    fn json_nested_object_hit() {
+        let body = br#"{"a":{"b":"<script>alert(1)</script>"}}"#;
+        let (path, _) = scan_json_body_xss(body, &XSS_SET, TEST_CAP).expect("hit");
+        assert_eq!(path, "body.json.a.b");
+    }
+
+    #[test]
+    fn json_array_hit() {
+        let body = br#"["safe","<img onerror=x>"]"#;
+        let (path, _) = scan_json_body_xss(body, &XSS_SET, TEST_CAP).expect("hit");
+        assert_eq!(path, "body.json[1]");
+    }
+
+    #[test]
+    fn json_clean() {
+        let body = br#"{"name":"Alice","age":25}"#;
+        assert!(scan_json_body_xss(body, &XSS_SET, TEST_CAP).is_none());
+    }
+
+    #[test]
+    fn json_malformed_returns_none() {
+        let body = b"not valid json";
+        assert!(scan_json_body_xss(body, &XSS_SET, TEST_CAP).is_none());
+    }
+
+    #[test]
+    fn json_oversize_returns_none() {
+        let body = vec![b'{'; TEST_CAP + 1];
+        assert!(scan_json_body_xss(&body, &XSS_SET, TEST_CAP).is_none());
+    }
+
+    #[test]
+    fn xss_url_encoded_value_in_json() {
+        // %3Cscript%3E decodes to <script>; recursive url-decode resolves.
+        let body = br#"{"q":"%3Cscript%3Ealert(1)%3C/script%3E"}"#;
+        assert!(scan_json_body_xss(body, &XSS_SET, TEST_CAP).is_some());
+    }
+
+    #[test]
+    fn xss_deeply_nested_json_does_not_overflow() {
+        // Synthesize depth = 200, well past MAX_JSON_DEPTH=64.
+        let mut s = String::new();
+        for _ in 0..200 {
+            s.push_str("{\"x\":");
+        }
+        s.push_str("\"<script>\"");
+        for _ in 0..200 {
+            s.push('}');
+        }
+        // Iterative walker must NOT panic; bails as None per Finding #4.
+        let _ = scan_json_body_xss(s.as_bytes(), &XSS_SET, TEST_CAP);
+    }
+
+    #[test]
+    fn xss_at_max_depth_still_detected() {
+        // Build object nested exactly MAX_JSON_DEPTH levels — leaf string
+        // sits at that depth and must still match.
+        let mut s = String::new();
+        for _ in 0..MAX_JSON_DEPTH {
+            s.push_str("{\"x\":");
+        }
+        s.push_str("\"<script>\"");
+        for _ in 0..MAX_JSON_DEPTH {
+            s.push('}');
+        }
+        assert!(scan_json_body_xss(s.as_bytes(), &XSS_SET, TEST_CAP).is_some());
+    }
+
+    #[test]
+    fn form_simple_hit() {
+        let body = b"q=%3Cscript%3Ealert(1)%3C/script%3E";
+        let (loc, _) = scan_form_urlencoded(body, &XSS_SET).expect("hit");
+        assert_eq!(loc, "body.form.q");
+    }
+
+    #[test]
+    fn form_clean() {
+        let body = b"q=hello+world&page=1";
+        assert!(scan_form_urlencoded(body, &XSS_SET).is_none());
+    }
+
+    #[test]
+    fn form_event_handler_value() {
+        let body = b"comment=%3Cimg+onerror%3Dalert(1)%3E";
+        let (loc, _) = scan_form_urlencoded(body, &XSS_SET).expect("hit");
+        assert_eq!(loc, "body.form.comment");
+    }
+}

--- a/plans/260502-0750-fr014-fr020-detection/plan.md
+++ b/plans/260502-0750-fr014-fr020-detection/plan.md
@@ -32,7 +32,7 @@ Ship 7 production P0 detection checks (FR-014..FR-020) for prx-waf with extensib
 | # | File | Branch | FR | Status | Owner |
 |---|---|---|---|---|---|
 | 00 | [phase-00-framework-and-coverage.md](phase-00-framework-and-coverage.md) | `feat/fr-frame-detection-framework` | — | code-complete (coverage-baseline deferred) | lotus |
-| 01 | [phase-01-fr014-xss-enhance.md](phase-01-fr014-xss-enhance.md) | `feat/fr-014-xss-json-walk` | FR-014 | pending | TBD |
+| 01 | [phase-01-fr014-xss-enhance.md](phase-01-fr014-xss-enhance.md) | `feat/fr-014-xss-json-walk` | FR-014 | code-complete (PR stacked on Phase 00) | lotus |
 | 02 | [phase-02-fr015-path-traversal-enhance.md](phase-02-fr015-path-traversal-enhance.md) | `feat/fr-015-path-traversal-recursive` | FR-015 | pending | TBD |
 | 03 | [phase-03-fr016-ssrf-new.md](phase-03-fr016-ssrf-new.md) | `feat/fr-016-ssrf-detection` | FR-016 | pending | TBD |
 | 04 | [phase-04-fr017-header-injection-new.md](phase-04-fr017-header-injection-new.md) | `feat/fr-017-header-injection` | FR-017 | pending | TBD |


### PR DESCRIPTION
## Summary

Phase 01 of the FR-014..FR-020 detection plan. Enhances `XssCheck` so structured request bodies (JSON / form-urlencoded) are inspected with precise location attribution.

- **`xss_scanners.rs` (new):** iterative JSON walker with hard recursion cap at `MAX_JSON_DEPTH = 64` (Red Team Finding #4). Bails `None` on parse error / oversize / depth-exceeded — FR-020 (Phase 06) is responsible for translating those into block decisions. Plus form-urlencoded scanner with `body.form.<key>` attribution.
- **`xss.rs`:** Content-Type-aware dispatch. `application/json` → walker; `application/x-www-form-urlencoded` → form scanner; both before the raw `request_targets()` fallback. `text/markdown` skips the body location entirely (false-positive mitigation — code blocks legitimately contain `<script` snippets); path / query / cookie still scan. Body cap reuses `defense_config.max_body_size` (64 KiB default from Phase 00) so JSON/form parse caps stay aligned with FR-020.
- **Coverage:** 22 new tests (10 in `xss_scanners.rs`, 12 in `xss.rs`), 26 total in the xss module.

## Stacked on #28

Base is set to `feat/fr-frame-detection-framework` for a clean diff. Rebase to `main` once #28 merges.

Why stacked: this branch was cut from Phase 00's HEAD because the test plan reuses the new `defense_config.max_body_size` field. If Phase 00 were already on main, this PR would target main directly.

## Verified

- `cargo fmt --all -- --check` rc=0
- `cargo clippy --workspace --all-targets -- -D warnings` rc=0 on rust:1.95-slim-bookworm
- `cargo test -p waf-engine --lib checks::xss` 26/26 (all 4 pre-existing + 22 new)
- Two Finding #4 contracts pinned:
  - `xss_deeply_nested_json_does_not_overflow` — depth-200 input, no panic
  - `xss_at_max_depth_still_detected` — depth-64 leaf still flags

## Test plan

- [ ] CI lint + test + build green
- [ ] Coverage gate informational (flips to enforcing once Phase 00 baseline tests land — see #28 follow-up)
- [ ] Manual regression: existing XSS detection still fires on path/query/cookie payloads (covered by retained tests #1-4)