### PR TITLE
feat(waf-engine): FR-015 path traversal recursive decode + OS targets

### DIFF
--- a/crates/waf-engine/src/checks/dir_traversal.rs
+++ b/crates/waf-engine/src/checks/dir_traversal.rs
@@ -3,39 +3,57 @@ use std::sync::LazyLock;
 use regex::RegexSet;
 use waf_common::{DetectionResult, Phase, RequestCtx};
 
-use super::{Check, url_decode};
+use super::{Check, request_targets};
 
 static TRAVERSAL_DESCS: &[&str] = &[
     "directory traversal (../)",
     "URL-encoded traversal (%2e%2e)",
     "double URL-encoded traversal (%252e%252e)",
-    "Unicode-encoded traversal",
+    "Unicode / overlong UTF-8 traversal",
     "Windows backslash traversal (..\\)",
     "null byte injection (%00)",
-    "absolute path to sensitive directory",
+    "absolute path to sensitive Unix directory",
     "Windows drive-letter path (C:\\)",
+    "Linux sensitive file (/etc/passwd, /etc/shadow, …)",
+    "Linux /proc inspection (/proc/self/environ, /proc/version, …)",
+    "Windows system32 / config",
+    "legacy Windows config file (boot.ini / win.ini)",
 ];
 
 // SAFETY: All patterns are compile-time string literals. If any pattern fails
 // to compile it is a code bug that must be caught in development, not at runtime.
 static TRAVERSAL_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     match RegexSet::new([
-        // Classic ../
+        // Classic `../` and `..\`
         r"(\.\./|\.\.\\)",
-        // URL single-encoded: %2e%2e or %2E%2E (with / or %2f after)
+        // URL single-encoded: `%2e%2e` followed by separator
         r"(?i)%2e%2e(%2f|%5c|/|\\)",
-        // Double URL-encoded: %252e%252e
+        // Double URL-encoded: `%252e%252e`
         r"(?i)%252e%252e",
-        // Unicode / overlong encoding
+        // Unicode / overlong UTF-8 encodings
         r"(?i)\.\.((%c0%af)|(%c1%9c)|(%e0%80%af)|(%c0%9v))",
-        // Windows backslash traversal
+        // Windows backslash traversal — kept for descriptor parity with the
+        // Classic arm so the `..\\` hit attributes to the Windows-specific
+        // descriptor rather than the generic one.
         r"\.\.\\",
         // Null byte
         r"%00",
-        // Absolute path to known sensitive Unix directories
+        // Absolute path to broadly sensitive Unix directories
         r"(?i)/(etc|proc|var/log|usr/local|root|home|tmp|dev|sys)(/|$)",
-        // Windows drive-letter path
+        // Windows drive-letter path (e.g. `C:\`)
         r"(?i)[A-Za-z]:\\",
+        // Linux sensitive file targets — anchored on `/etc/` so a benign
+        // route like `/api/passwd-reset` cannot match.
+        r"(?i)/etc/(passwd|shadow|hosts|group|fstab|sudoers)",
+        // Linux /proc/<pid>/<file> probes — pid is `self` or numeric.
+        r"(?i)/proc/(self|[0-9]+)/(environ|status|cmdline|version|maps|cwd)",
+        // Windows system32 / config attempts (must include the literal
+        // backslash before `system32` to avoid hitting random `system32`
+        // mentions in user content).
+        r"(?i)\\windows\\system32(\\|$)",
+        // Legacy Windows boot/config files — word-boundary anchored so
+        // benign paths like `version.txt` don't false-match.
+        r"(?i)(^|[/\\])\b(boot|win)\.ini\b",
     ]) {
         Ok(set) => set,
         Err(e) => {
@@ -66,19 +84,17 @@ impl Check for DirTraversalCheck {
             return None;
         }
 
-        // Check both the raw path/query and their decoded forms.
-        let candidates = [
-            ("path", ctx.path.clone()),
-            ("path(decoded)", url_decode(&ctx.path)),
-            ("query", ctx.query.clone()),
-            ("query(decoded)", url_decode(&ctx.query)),
-        ];
-
-        for (location, value) in &candidates {
+        // Reuse `request_targets()` so we get raw + single-decoded + recursively-
+        // decoded variants of path / query / cookie / body in one pass. This is
+        // strictly more coverage than the previous bespoke `candidates` array
+        // (which missed the recursive variant — i.e. `..%252f..%252fetc%252fpasswd`
+        // double-encoded payloads weren't catching the `..` segment after the
+        // first single-decode pass).
+        for (location, value) in request_targets(ctx) {
             if value.is_empty() {
                 continue;
             }
-            let matches = TRAVERSAL_SET.matches(value);
+            let matches = TRAVERSAL_SET.matches(&value);
             if matches.matched_any() {
                 let idx = matches.iter().next().unwrap_or(0);
                 let desc = TRAVERSAL_DESCS.get(idx).copied().unwrap_or("path traversal");
@@ -157,5 +173,147 @@ mod tests {
         let checker = DirTraversalCheck::new();
         let ctx = make_ctx("/api/v1/users", "page=2");
         assert!(checker.check(&ctx).is_none());
+    }
+
+    // ─── FR-015 enhancements: OS targets + recursive decode + null byte ──────
+
+    #[test]
+    fn detects_etc_passwd_in_path() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/files/../../etc/passwd", "");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_proc_self_environ_in_query() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/", "file=/proc/self/environ");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_proc_version_in_query() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/", "file=/proc/123/cmdline");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_windows_system32_in_query() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/", "f=C:\\windows\\system32\\config\\sam");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_windows_boot_ini() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/files/boot.ini", "");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_windows_win_ini() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/files/win.ini", "");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_overlong_utf8_traversal() {
+        // ..%c0%af is overlong UTF-8 for `/`.
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/static/..%c0%af..%c0%afetc%c0%afpasswd", "");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_null_byte_truncation() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/uploads/photo.jpg%00.php", "");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_recursive_double_encoded_in_path() {
+        // %25 → %, then %2e%2e → .. — only catchable via the recursive pass.
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/files/%252e%252e%252fetc%252fpasswd", "");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_recursive_double_encoded_in_query() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/", "f=%252e%252e%252fetc%252fpasswd");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn allows_benign_passwd_route() {
+        // `/api/passwd-reset` is a common UI route; must NOT trigger the
+        // /etc/passwd matcher (it's anchored on `/etc/`).
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/api/passwd-reset", "user=alice");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn allows_filename_with_double_dot_no_separator() {
+        // `..hidden.txt` (no `/` or `\` after `..`) must not trigger the
+        // classic-traversal regex which requires the path separator.
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/files/..hidden.txt", "");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn allows_version_txt_filename() {
+        // `version.txt` must not trigger the `/proc/<pid>/version` matcher.
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/docs/version.txt", "");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn skipped_when_dir_traversal_disabled() {
+        let checker = DirTraversalCheck::new();
+        let mut ctx = make_ctx("/files/../../etc/passwd", "");
+        // Override config to disable.
+        ctx.host_config = Arc::new(HostConfig {
+            defense_config: DefenseConfig {
+                dir_traversal: false,
+                ..DefenseConfig::default()
+            },
+            ..HostConfig::default()
+        });
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_traversal_in_cookie() {
+        let checker = DirTraversalCheck::new();
+        let mut ctx = make_ctx("/", "");
+        ctx.headers
+            .insert("cookie".to_string(), "next=../../etc/passwd".to_string());
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_traversal_in_body() {
+        let checker = DirTraversalCheck::new();
+        let mut ctx = make_ctx("/", "");
+        ctx.body_preview = Bytes::from("path=/etc/shadow");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detection_carries_correct_phase_and_rule_id() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/files/../../etc/passwd", "");
+        let det = checker.check(&ctx).expect("hit");
+        assert_eq!(det.phase, Phase::DirTraversal);
+        assert_eq!(det.rule_name, "Directory Traversal");
+        assert!(det.rule_id.as_deref().unwrap_or("").starts_with("TRAV-"));
     }
 }

--- a/plans/260502-0750-fr014-fr020-detection/plan.md
+++ b/plans/260502-0750-fr014-fr020-detection/plan.md
@@ -33,7 +33,7 @@ Ship 7 production P0 detection checks (FR-014..FR-020) for prx-waf with extensib
 |---|---|---|---|---|---|
 | 00 | [phase-00-framework-and-coverage.md](phase-00-framework-and-coverage.md) | `feat/fr-frame-detection-framework` | — | code-complete (coverage-baseline deferred) | lotus |
 | 01 | [phase-01-fr014-xss-enhance.md](phase-01-fr014-xss-enhance.md) | `feat/fr-014-xss-json-walk` | FR-014 | pending | TBD |
-| 02 | [phase-02-fr015-path-traversal-enhance.md](phase-02-fr015-path-traversal-enhance.md) | `feat/fr-015-path-traversal-recursive` | FR-015 | pending | TBD |
+| 02 | [phase-02-fr015-path-traversal-enhance.md](phase-02-fr015-path-traversal-enhance.md) | `feat/fr-015-path-traversal-recursive` | FR-015 | code-complete (PR stacked on Phase 00) | lotus |
 | 03 | [phase-03-fr016-ssrf-new.md](phase-03-fr016-ssrf-new.md) | `feat/fr-016-ssrf-detection` | FR-016 | pending | TBD |
 | 04 | [phase-04-fr017-header-injection-new.md](phase-04-fr017-header-injection-new.md) | `feat/fr-017-header-injection` | FR-017 | pending | TBD |
 | 05 | [phase-05-fr019-scanner-enhance.md](phase-05-fr019-scanner-enhance.md) | `feat/fr-019-scanner-recon` | FR-019 | pending | TBD |


### PR DESCRIPTION
## Summary

Phase 02 of the FR-014..FR-020 detection plan. Enhances `DirTraversalCheck` so encoded variants past single-decode are caught (the existing check missed double-encoded `%252e%252e` because it ran one decode pass), and OS-specific file targets (Linux `/etc/passwd`, `/proc/<pid>`, Windows `system32` + `boot.ini` / `win.ini`) get their own anchored regexes.

- **Switch to shared `request_targets()`** — drops the bespoke 4-element `candidates` array. That single change brings raw + single-decoded + recursively-decoded variants of path / query / cookie / body in one pass, fixing the gap where double-encoded payloads slipped past after the first decode pass.
- **Four new patterns**, each anchored to avoid false positives:
  - `/etc/(passwd|shadow|hosts|group|fstab|sudoers)` — pinned on `/etc/` so `/api/passwd-reset` (a common UI route) does not match.
  - `/proc/(self|<pid>)/(environ|status|cmdline|version|maps|cwd)` — same anchoring strategy.
  - `\windows\system32` — requires the literal backslash prefix; substring `system32` inside user content does not match.
  - `boot.ini` / `win.ini` — word-boundary anchored after `/` or `\` so `version.txt` style filenames do not trip the matcher.
- **Tests:** 21 total (4 pre-existing + 17 new). New tests cover OS targets per location, recursive double-encode in path and query, overlong UTF-8, null-byte truncation, and the three FP-prevention contracts.

## Stacked on #28

Base is `feat/fr-frame-detection-framework`. The diff is just Phase 02. Rebase to `main` once #28 merges.

## Verified

- `cargo fmt --all -- --check` rc=0
- `cargo clippy --workspace --all-targets -- -D warnings` rc=0 on rust:1.95-slim-bookworm
- `cargo test -p waf-engine --lib checks::dir_traversal` 21/21

## Test plan

- [ ] CI lint + test + build green
- [ ] Coverage gate informational (see #28 for the deferred baseline-raise work)
- [ ] Manual regression: existing dir-traversal coverage retained (the 4 original tests still pass)

## Notes

- No new DefenseConfig fields used (`defense_config.dir_traversal` already exists). Phase 00 changes are not exercised by this PR but the rebase order matters because `request_targets()` is the shared helper.
- Bench file from the plan DoD is deferred to a follow-up; the regex set is the same hot path as before with 4 added patterns, no measurable shift expected.