### PR TITLE
feat(waf-engine): FR-016 SSRF detection (RFC1918, metadata, obfuscated IPs)

### DIFF
--- a/crates/waf-engine/src/checks/mod.rs
+++ b/crates/waf-engine/src/checks/mod.rs
@@ -14,6 +14,8 @@ pub mod sql_injection;
 pub(crate) mod sql_injection_patterns;
 pub(crate) mod sql_injection_scanners;
 pub mod ssrf;
+pub(crate) mod ssrf_patterns;
+pub(crate) mod ssrf_scanners;
 pub mod xss;
 
 pub use anti_hotlink::AntiHotlinkCheck;

--- a/crates/waf-engine/src/checks/ssrf.rs
+++ b/crates/waf-engine/src/checks/ssrf.rs
@@ -1,15 +1,25 @@
-//! Server-Side Request Forgery (FR-016) — stub registered by Phase 00.
+//! Server-Side Request Forgery detection (FR-016).
 //!
-//! Real detection lands in Phase 03. The stub returns `None` so the check
-//! pipeline runs unchanged until then.
+//! Scans every `http(s)://…` URL it can find in body, query, cookie, and the
+//! SSRF-prone headers; resolves the host string via `url::Url::parse` (so the
+//! `user@host` userinfo bypass — Capital One 2019 — cannot smuggle a metadata
+//! IP past a substring filter); and flags the request when the resolved host
+//! is either a known cloud-metadata identifier or an RFC1918 / loopback /
+//! link-local IP, including obfuscated dword / hex / octal / IPv6-mapped
+//! forms.
+//!
+//! No DNS resolution in v1 — the DNS-rebinding mitigation requires an
+//! upstream resolver hook and is deferred (see plan §Out of Scope).
 
-use waf_common::{DetectionResult, RequestCtx};
+use std::net::IpAddr;
+
+use url::{Host, Url};
+use waf_common::{DetectionResult, Phase, RequestCtx};
 
 use super::Check;
+use super::ssrf_patterns::{METADATA_HOST_DESCS, METADATA_HOST_SET};
+use super::ssrf_scanners::{extract_urls, is_private_ip, parse_obfuscated_ip};
 
-/// Stub SSRF checker. Phase 03 (FR-016) replaces `check()` with the real
-/// `url::Url::host_str()` parser + RFC1918 / loopback / link-local CIDR
-/// match plus `ssrf_outbound_host_allowlist` bypass.
 pub struct SsrfCheck;
 
 impl SsrfCheck {
@@ -25,36 +35,105 @@ impl Default for SsrfCheck {
 }
 
 impl Check for SsrfCheck {
-    fn check(&self, _ctx: &RequestCtx) -> Option<DetectionResult> {
+    fn check(&self, ctx: &RequestCtx) -> Option<DetectionResult> {
+        if !ctx.host_config.defense_config.ssrf {
+            return None;
+        }
+
+        let allowlist = &ctx.host_config.defense_config.ssrf_outbound_host_allowlist;
+
+        for (location, candidate) in extract_urls(ctx) {
+            // Parse via `url::Url` so userinfo `user[:pass]@host` is split out
+            // and we get the real host — substring extraction would let
+            // `http://google.com@169.254.169.254/` look benign.
+            let Ok(url) = Url::parse(&candidate) else {
+                continue;
+            };
+            let Some(host) = url.host() else {
+                continue;
+            };
+
+            // Textual form for allowlist + metadata-regex matching. `url::Host`
+            // strips the IPv6 brackets so `[::1]` arrives here as `::1`, which
+            // is what we want.
+            let host_text = match &host {
+                Host::Domain(s) => (*s).to_string(),
+                Host::Ipv4(v4) => v4.to_string(),
+                Host::Ipv6(v6) => v6.to_string(),
+            };
+
+            if allowlist.iter().any(|allowed| allowed.eq_ignore_ascii_case(&host_text)) {
+                continue;
+            }
+
+            // Rule 1-3: literal metadata identifier — runs against the textual
+            // host so it catches both `metadata.google.internal` (Domain arm)
+            // and `100.100.100.200` (Ipv4 arm — not in a private CIDR).
+            if let Some(idx) = METADATA_HOST_SET.matches(&host_text).iter().next() {
+                let desc = METADATA_HOST_DESCS.get(idx).copied().unwrap_or("metadata host");
+                return Some(detection(idx + 1, desc, &location, &host_text));
+            }
+
+            // Rule 4-5: typed IPv4/IPv6 hosts go straight through the CIDR
+            // check; Domain hosts try the obfuscated-IP normaliser first.
+            let private_hit = match host {
+                Host::Ipv4(v4) => is_private_ip(IpAddr::V4(v4)),
+                Host::Ipv6(v6) => is_private_ip(IpAddr::V6(v6)),
+                Host::Domain(d) => parse_obfuscated_ip(d).is_some_and(is_private_ip),
+            };
+            if private_hit {
+                return Some(detection(
+                    METADATA_HOST_DESCS.len() + 1,
+                    "private / loopback / link-local IP",
+                    &location,
+                    &host_text,
+                ));
+            }
+        }
         None
+    }
+}
+
+fn detection(rule_seq: usize, desc: &str, location: &str, host: &str) -> DetectionResult {
+    DetectionResult {
+        rule_id: Some(format!("SSRF-{rule_seq:03}")),
+        rule_name: "SSRF".to_string(),
+        phase: Phase::Ssrf,
+        detail: format!("{desc} ({host}) referenced from {location}"),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::checks::scanner::ScannerCheck;
     use bytes::Bytes;
     use std::collections::HashMap;
     use std::net::IpAddr;
     use std::sync::Arc;
-    use waf_common::HostConfig;
+    use waf_common::{DefenseConfig, HostConfig};
 
-    fn make_ctx() -> RequestCtx {
+    fn make_ctx(query: &str, body: &str) -> RequestCtx {
+        make_ctx_with(query, body, HashMap::new(), DefenseConfig::default())
+    }
+
+    fn make_ctx_with(query: &str, body: &str, headers: HashMap<String, String>, dc: DefenseConfig) -> RequestCtx {
         RequestCtx {
             req_id: "test".to_string(),
             client_ip: "127.0.0.1".parse::<IpAddr>().unwrap(),
             client_port: 0,
-            method: "GET".to_string(),
+            method: "POST".to_string(),
             host: "example.com".to_string(),
             port: 80,
-            path: "/".to_string(),
-            query: String::new(),
-            headers: HashMap::new(),
-            body_preview: Bytes::new(),
-            content_length: 0,
+            path: "/api/webhook".to_string(),
+            query: query.to_string(),
+            headers,
+            body_preview: Bytes::from(body.to_string()),
+            content_length: body.len() as u64,
             is_tls: false,
-            host_config: Arc::new(HostConfig::default()),
+            host_config: Arc::new(HostConfig {
+                defense_config: dc,
+                ..HostConfig::default()
+            }),
             geo: None,
             tier: waf_common::tier::Tier::CatchAll,
             tier_policy: waf_common::RequestCtx::default_tier_policy(),
@@ -63,22 +142,219 @@ mod tests {
     }
 
     #[test]
-    fn stub_returns_none() {
-        let checker = SsrfCheck::new();
-        let ctx = make_ctx();
-        assert!(checker.check(&ctx).is_none());
+    fn detects_rfc1918_in_body_json() {
+        let ctx = make_ctx("", r#"{"webhook_url":"http://10.1.2.3/api"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
     }
 
     #[test]
-    fn on_response_default_is_no_op() {
-        // Stubs inherit the trait's default `on_response` no-op; this test
-        // pins the contract so future overrides don't silently regress.
-        let checker = SsrfCheck::new();
-        let ctx = make_ctx();
-        // Sanity: the *other* check we delegated default behaviour to also
-        // inherits the no-op — keeps both code paths exercised.
-        let scanner: Box<dyn Check> = Box::new(ScannerCheck::new());
-        checker.on_response(&ctx, 200);
-        scanner.on_response(&ctx, 200);
+    fn detects_172_16_range_in_query() {
+        let ctx = make_ctx("target=http://172.16.0.1/", "");
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_192_168_range_in_referer() {
+        let mut h = HashMap::new();
+        h.insert("referer".to_string(), "http://192.168.1.1/admin".to_string());
+        let ctx = make_ctx_with("", "", h, DefenseConfig::default());
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_loopback() {
+        let ctx = make_ctx("", r#"{"target":"http://127.0.0.1:8080/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_localhost() {
+        // url::Url::parse normalises localhost → 127.0.0.1 only for special schemes
+        // is not done; localhost stays as host_str. Explicit check for the literal
+        // ensures we still catch it. (Belt-and-suspenders: `localhost` resolves
+        // privately on virtually every deployment.)
+        let ctx = make_ctx("", r#"{"target":"http://localhost/admin"}"#);
+        // localhost is a hostname, not parseable as IP, and not in our metadata
+        // set — but it should still be considered an SSRF risk in production.
+        // For v1 we accept it as a known limitation: hostname-only SSRF goes
+        // through without detection. Documenting the gap explicitly.
+        let _ = SsrfCheck::new().check(&ctx);
+    }
+
+    #[test]
+    fn detects_aws_metadata() {
+        let ctx = make_ctx("", r#"{"u":"http://169.254.169.254/latest/meta-data/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_gcp_metadata() {
+        let ctx = make_ctx("", r#"{"u":"http://metadata.google.internal/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_alibaba_metadata() {
+        let ctx = make_ctx("", r#"{"u":"http://100.100.100.200/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_consul_metadata() {
+        let ctx = make_ctx("", r#"{"u":"http://metadata.service.consul/v1/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_ipv6_mapped_ipv4_metadata() {
+        let ctx = make_ctx("", r#"{"u":"http://[::ffff:169.254.169.254]/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_ipv6_loopback() {
+        let ctx = make_ctx("", r#"{"u":"http://[::1]/admin"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_obfuscated_decimal_dword() {
+        let ctx = make_ctx("", r#"{"u":"http://2130706433/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_obfuscated_hex_dword() {
+        let ctx = make_ctx("", r#"{"u":"http://0x7f000001/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_obfuscated_octal_dword() {
+        let ctx = make_ctx("", r#"{"u":"http://017700000001/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn allows_clean_public_url() {
+        let ctx = make_ctx("", r#"{"webhook":"https://api.stripe.com/v1/charges"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn allows_clean_example_com() {
+        let ctx = make_ctx("", r#"{"webhook":"https://example.com/hooks/abc"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn skipped_when_ssrf_disabled() {
+        let dc = DefenseConfig {
+            ssrf: false,
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx_with("", r#"{"u":"http://169.254.169.254/"}"#, HashMap::new(), dc);
+        assert!(SsrfCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_url_in_nested_json_object() {
+        let ctx = make_ctx("", r#"{"outer":{"inner":{"hook":"http://10.0.0.5/"}}}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_url_in_json_array() {
+        let ctx = make_ctx("", r#"{"hooks":["https://api.public.com/", "http://10.20.30.40/"]}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn empty_body_no_detection() {
+        let ctx = make_ctx("", "");
+        assert!(SsrfCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_form_urlencoded_body_after_decode() {
+        let ctx = make_ctx("", "webhook=http%3A//10.0.0.1/&user=alice");
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_userinfo_bypass_aws_metadata() {
+        // Capital One 2019 — substring filters defeated by `user@host`.
+        // url::Url::parse treats `google.com` as userinfo and the metadata IP
+        // as host, so detection still fires.
+        let ctx = make_ctx("", r#"{"u":"http://google.com@169.254.169.254/latest/meta-data/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn allows_metadata_ip_as_userinfo_only() {
+        // Inverse: 169.254.169.254 in the userinfo position is harmless
+        // because the actual host is google.com.
+        let ctx = make_ctx("", r#"{"u":"http://169.254.169.254@google.com/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn malformed_url_skipped_not_panicked() {
+        // Unclosed bracket — Url::parse fails, we skip rather than crash.
+        let ctx = make_ctx("", r#"{"u":"http://[::1"}"#);
+        let _ = SsrfCheck::new().check(&ctx);
+    }
+
+    #[test]
+    fn allowlist_bypasses_detection() {
+        let dc = DefenseConfig {
+            ssrf_outbound_host_allowlist: vec!["10.0.0.42".to_string()],
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx_with("", r#"{"u":"http://10.0.0.42/internal"}"#, HashMap::new(), dc);
+        assert!(SsrfCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn allowlist_match_is_case_insensitive_for_hostnames() {
+        let dc = DefenseConfig {
+            ssrf_outbound_host_allowlist: vec!["Internal.Service".to_string()],
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx_with("", r#"{"u":"http://internal.service/api"}"#, HashMap::new(), dc);
+        // Hostname only — no IP resolution — but allowlist match should
+        // exempt regardless. (Defense in depth: even if a future rule starts
+        // flagging hostnames, allowlist still wins.)
+        assert!(SsrfCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_destination_header() {
+        let mut h = HashMap::new();
+        h.insert("destination".to_string(), "http://10.0.0.5/".to_string());
+        let ctx = make_ctx_with("", "", h, DefenseConfig::default());
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detection_carries_correct_phase_and_rule_id() {
+        let ctx = make_ctx("", r#"{"u":"http://169.254.169.254/"}"#);
+        let det = SsrfCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.phase, Phase::Ssrf);
+        assert_eq!(det.rule_name, "SSRF");
+        assert!(det.rule_id.as_deref().unwrap_or("").starts_with("SSRF-"));
+    }
+
+    #[test]
+    fn allows_public_ip_addresses() {
+        let ctx = make_ctx("", r#"{"u":"http://8.8.8.8/dns"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn first_malicious_url_short_circuits() {
+        let ctx = make_ctx("", r#"{"a":"http://10.0.0.1/", "b":"https://api.public.com/"}"#);
+        let det = SsrfCheck::new().check(&ctx).expect("hit");
+        assert!(det.detail.contains("10.0.0.1"));
     }
 }

--- a/crates/waf-engine/src/checks/ssrf_patterns.rs
+++ b/crates/waf-engine/src/checks/ssrf_patterns.rs
@@ -1,0 +1,57 @@
+//! SSRF pattern data — metadata hostnames and private-network CIDRs.
+//!
+//! Kept in a sibling file so `ssrf.rs` stays under the modularization limit.
+
+use std::sync::LazyLock;
+
+use ipnet::Ipv4Net;
+use regex::RegexSet;
+
+/// Cloud / orchestrator metadata hostnames that should never be reachable
+/// from a user-supplied URL. Anchored with `^` so a request body containing
+/// `metadata.google.internal.attacker.com` does not slip past as a substring.
+pub static METADATA_HOST_DESCS: &[&str] = &[
+    "AWS / OpenStack metadata IP (169.254.169.254)",
+    "Google Cloud metadata host",
+    "Alibaba Cloud metadata IP (100.100.100.200)",
+    "Consul metadata service",
+    "DigitalOcean / generic 'metadata' host",
+];
+
+// SAFETY: Compile-time string literals; failure is a code bug.
+pub static METADATA_HOST_SET: LazyLock<RegexSet> = LazyLock::new(|| {
+    match RegexSet::new([
+        r"^169\.254\.169\.254$",
+        r"^metadata\.google\.internal$",
+        r"^100\.100\.100\.200$",
+        r"^metadata\.service\.consul$",
+        r"^metadata(\.|$)",
+    ]) {
+        Ok(set) => set,
+        Err(e) => {
+            tracing::error!("BUG: SSRF metadata host regex set failed to compile: {e}");
+            RegexSet::empty()
+        }
+    }
+});
+
+/// Private / loopback / link-local IPv4 ranges. Caller should also test the
+/// IPv4 form of an IPv6-mapped address against this set.
+///
+/// 100.64.0.0/10 (RFC 6598 carrier-grade NAT) is intentionally NOT included
+/// — only the exact metadata IP `100.100.100.200` is flagged via the regex
+/// set above. Treating the whole CGNAT range as SSRF would false-flag
+/// legitimate calls into ISP-shared address space.
+pub static PRIVATE_CIDRS: LazyLock<Vec<Ipv4Net>> = LazyLock::new(|| {
+    [
+        "10.0.0.0/8",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+        "127.0.0.0/8",
+        "169.254.0.0/16",
+        "0.0.0.0/8",
+    ]
+    .iter()
+    .filter_map(|s| s.parse::<Ipv4Net>().ok())
+    .collect()
+});

--- a/crates/waf-engine/src/checks/ssrf_scanners.rs
+++ b/crates/waf-engine/src/checks/ssrf_scanners.rs
@@ -1,0 +1,239 @@
+//! SSRF helpers — URL extraction, obfuscated-IP normalisation, RFC1918 check.
+//!
+//! Kept in a sibling file so `ssrf.rs` stays under the modularization limit.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::LazyLock;
+
+use regex::Regex;
+use waf_common::RequestCtx;
+
+use super::ssrf_patterns::PRIVATE_CIDRS;
+use super::url_decode_recursive;
+
+/// Headers that have historically been the SSRF foothold and are worth scanning
+/// even if the body is empty. Lowercase — `RequestCtx.headers` keys arrive
+/// lowercase from the gateway.
+const URL_BEARING_HEADERS: &[&str] = &[
+    "referer",
+    "location",
+    "x-original-url",
+    "x-rewrite-url",
+    "x-forwarded-host",
+    "x-forwarded-server",
+    "destination",
+    "forwarded",
+];
+
+// SAFETY: compile-time literal — failure is a code bug.
+static URL_RE: LazyLock<Regex> = LazyLock::new(|| {
+    match Regex::new(r#"(?i)https?://[^\s\x00-\x20\x7f"'<>\\]+"#) {
+        Ok(re) => re,
+        Err(e) => {
+            tracing::error!("BUG: SSRF URL extractor regex failed to compile: {e}");
+            // Returning a regex that matches nothing keeps the check from
+            // firing rather than panicking the engine.
+            #[allow(clippy::expect_used)]
+            Regex::new(r"$^").expect("trivial regex must compile")
+        }
+    }
+});
+
+/// Pull every `http(s)://…` substring from request body, query, cookie, and
+/// the SSRF-prone headers. Each candidate is recursively url-decoded before
+/// regex extraction so `webhook=http%3A//10.0.0.1/` is normalised first.
+pub fn extract_urls(ctx: &RequestCtx) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = Vec::new();
+
+    let mut push_from = |location: &str, text: &str| {
+        if text.is_empty() {
+            return;
+        }
+        let decoded = url_decode_recursive(text);
+        for m in URL_RE.find_iter(&decoded) {
+            out.push((location.to_string(), m.as_str().to_string()));
+        }
+    };
+
+    push_from("query", &ctx.query);
+    if !ctx.body_preview.is_empty() {
+        let body_str = String::from_utf8_lossy(&ctx.body_preview);
+        push_from("body", &body_str);
+    }
+    for header_name in URL_BEARING_HEADERS {
+        if let Some(value) = ctx.headers.get(*header_name) {
+            push_from(&format!("header.{header_name}"), value);
+        }
+    }
+    if let Some(cookie) = ctx.headers.get("cookie") {
+        push_from("cookie", cookie);
+    }
+    out
+}
+
+/// Parse a host string into an `IpAddr`, accepting the obfuscated forms that
+/// classic SSRF payloads use to bypass naive substring filters.
+///
+/// Recognised:
+/// - `127.0.0.1`, `::1` (canonical)
+/// - `0x7f000001` / `0X7F000001` (hex dword)
+/// - `017700000001` (leading-zero octal dword)
+/// - `2130706433` (decimal dword)
+///
+/// Mixed-radix dotted forms like `0x7F.0.0.1` are normalised by `Url::parse`
+/// before this function ever sees the `host_str`, so they reach this code as
+/// `127.0.0.1` already.
+pub fn parse_obfuscated_ip(s: &str) -> Option<IpAddr> {
+    if let Ok(addr) = s.parse::<IpAddr>() {
+        return Some(addr);
+    }
+    if let Some(rest) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X"))
+        && let Ok(n) = u32::from_str_radix(rest, 16)
+    {
+        return Some(IpAddr::V4(Ipv4Addr::from(n)));
+    }
+    if s.starts_with('0')
+        && s.len() > 1
+        && !s.starts_with("0x")
+        && !s.starts_with("0X")
+        && s.bytes().all(|b| (b'0'..=b'7').contains(&b))
+        && let Ok(n) = u32::from_str_radix(s, 8)
+    {
+        return Some(IpAddr::V4(Ipv4Addr::from(n)));
+    }
+    if s.bytes().all(|b| b.is_ascii_digit())
+        && let Ok(n) = s.parse::<u32>()
+    {
+        return Some(IpAddr::V4(Ipv4Addr::from(n)));
+    }
+    None
+}
+
+/// Return `true` if the IP belongs to a private / loopback / link-local
+/// range — i.e. should not be reachable from a user-supplied URL.
+///
+/// IPv6 addresses are first tested for loopback (`::1`) and IPv4-mapped form
+/// (`::ffff:a.b.c.d`); the mapped IPv4 is then run through the same CIDR set
+/// so `[::ffff:169.254.169.254]` is caught the same way `169.254.169.254` is.
+pub fn is_private_ip(addr: IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(v4) => PRIVATE_CIDRS.iter().any(|net| net.contains(&v4)),
+        IpAddr::V6(v6) => {
+            if v6.is_loopback() {
+                return true;
+            }
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return PRIVATE_CIDRS.iter().any(|net| net.contains(&v4));
+            }
+            // Reject IPv6 unique-local + link-local prefixes; everything
+            // else is treated as routable for v1.
+            let segs = v6.segments();
+            // fc00::/7 (unique-local)
+            if segs[0] & 0xfe00 == 0xfc00 {
+                return true;
+            }
+            // fe80::/10 (link-local)
+            if segs[0] & 0xffc0 == 0xfe80 {
+                return true;
+            }
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv6Addr;
+
+    #[test]
+    fn parse_obfuscated_ip_canonical_v4() {
+        let addr = parse_obfuscated_ip("127.0.0.1").expect("canonical");
+        assert!(addr.is_loopback());
+    }
+
+    #[test]
+    fn parse_obfuscated_ip_hex() {
+        let addr = parse_obfuscated_ip("0x7f000001").expect("hex");
+        assert_eq!(addr.to_string(), "127.0.0.1");
+    }
+
+    #[test]
+    fn parse_obfuscated_ip_hex_uppercase() {
+        let addr = parse_obfuscated_ip("0X7F000001").expect("HEX");
+        assert_eq!(addr.to_string(), "127.0.0.1");
+    }
+
+    #[test]
+    fn parse_obfuscated_ip_octal() {
+        let addr = parse_obfuscated_ip("017700000001").expect("octal");
+        assert_eq!(addr.to_string(), "127.0.0.1");
+    }
+
+    #[test]
+    fn parse_obfuscated_ip_dword_decimal() {
+        let addr = parse_obfuscated_ip("2130706433").expect("dword");
+        assert_eq!(addr.to_string(), "127.0.0.1");
+    }
+
+    #[test]
+    fn parse_obfuscated_ip_rejects_arbitrary_string() {
+        assert!(parse_obfuscated_ip("example.com").is_none());
+        assert!(parse_obfuscated_ip("notanip").is_none());
+    }
+
+    #[test]
+    fn parse_obfuscated_ip_v6_loopback() {
+        let addr = parse_obfuscated_ip("::1").expect("v6 loopback");
+        assert!(addr.is_loopback());
+    }
+
+    #[test]
+    fn is_private_ip_rfc1918() {
+        for s in [
+            "10.0.0.1",
+            "10.255.255.254",
+            "172.16.0.1",
+            "172.31.255.254",
+            "192.168.1.1",
+            "127.0.0.1",
+            "169.254.169.254",
+        ] {
+            let addr: IpAddr = s.parse().expect("test ip");
+            assert!(is_private_ip(addr), "{s} should be private");
+        }
+    }
+
+    #[test]
+    fn is_private_ip_public_v4_returns_false() {
+        for s in ["8.8.8.8", "1.1.1.1", "100.64.0.1", "100.100.100.1"] {
+            let addr: IpAddr = s.parse().expect("test ip");
+            assert!(!is_private_ip(addr), "{s} should not be private");
+        }
+    }
+
+    #[test]
+    fn is_private_ip_v6_mapped_v4() {
+        // ::ffff:169.254.169.254 — must catch the mapped form.
+        let v6: IpAddr = "::ffff:169.254.169.254".parse().expect("mapped");
+        assert!(is_private_ip(v6));
+    }
+
+    #[test]
+    fn is_private_ip_v6_unique_local() {
+        let v6 = IpAddr::V6(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 1));
+        assert!(is_private_ip(v6));
+    }
+
+    #[test]
+    fn is_private_ip_v6_link_local() {
+        let v6 = IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1));
+        assert!(is_private_ip(v6));
+    }
+
+    #[test]
+    fn is_private_ip_v6_public_returns_false() {
+        let v6: IpAddr = "2606:4700:4700::1111".parse().expect("public v6");
+        assert!(!is_private_ip(v6));
+    }
+}

--- a/plans/260502-0750-fr014-fr020-detection/plan.md
+++ b/plans/260502-0750-fr014-fr020-detection/plan.md
@@ -34,7 +34,7 @@ Ship 7 production P0 detection checks (FR-014..FR-020) for prx-waf with extensib
 | 00 | [phase-00-framework-and-coverage.md](phase-00-framework-and-coverage.md) | `feat/fr-frame-detection-framework` | — | code-complete (coverage-baseline deferred) | lotus |
 | 01 | [phase-01-fr014-xss-enhance.md](phase-01-fr014-xss-enhance.md) | `feat/fr-014-xss-json-walk` | FR-014 | pending | TBD |
 | 02 | [phase-02-fr015-path-traversal-enhance.md](phase-02-fr015-path-traversal-enhance.md) | `feat/fr-015-path-traversal-recursive` | FR-015 | pending | TBD |
-| 03 | [phase-03-fr016-ssrf-new.md](phase-03-fr016-ssrf-new.md) | `feat/fr-016-ssrf-detection` | FR-016 | pending | TBD |
+| 03 | [phase-03-fr016-ssrf-new.md](phase-03-fr016-ssrf-new.md) | `feat/fr-016-ssrf-detection` | FR-016 | code-complete (PR stacked on Phase 00) | lotus |
 | 04 | [phase-04-fr017-header-injection-new.md](phase-04-fr017-header-injection-new.md) | `feat/fr-017-header-injection` | FR-017 | pending | TBD |
 | 05 | [phase-05-fr019-scanner-enhance.md](phase-05-fr019-scanner-enhance.md) | `feat/fr-019-scanner-recon` | FR-019 | pending | TBD |
 | 06 | [phase-06-fr020-body-abuse-new.md](phase-06-fr020-body-abuse-new.md) | `feat/fr-020-body-abuse` | FR-020 | pending | TBD |


### PR DESCRIPTION
## Summary

Phase 03 of the FR-014..FR-020 detection plan. Replaces the Phase 00 SSRF stub with a full check that flags requests carrying internal-network URLs in the body, query, cookie, or any of the SSRF-prone headers.

### Detection rules

1. **RFC1918 / loopback / link-local** — `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `127.0.0.0/8`, `169.254.0.0/16`, `0.0.0.0/8`.
2. **Cloud / orchestrator metadata identifiers** — `169.254.169.254` (AWS / OpenStack), `metadata.google.internal` (GCP), `100.100.100.200` (Alibaba — exact IP only; RFC 6598 100.0.0.0/8 carrier-grade NAT is intentionally NOT flagged), `metadata.service.consul`, generic `metadata.*`.
3. **Obfuscated IPs** — hex `0x7f000001`, octal `017700000001`, decimal dword `2130706433`, IPv6-mapped IPv4 `[::ffff:169.254.169.254]`, IPv6 loopback `[::1]`, IPv6 unique-local (`fc00::/7`) and link-local (`fe80::/10`).
4. **Userinfo bypass** (Capital One 2019 / Red Team Finding #10) — `http://google.com@169.254.169.254/` resolves via `url::Url::parse` so the metadata IP is identified as the real host. The inverse (`http://169.254.169.254@google.com/`) does NOT trigger.

### Files

- `crates/waf-engine/src/checks/ssrf.rs` — replaces stub; dispatcher with allowlist + typed host matching.
- `crates/waf-engine/src/checks/ssrf_patterns.rs` (new) — `METADATA_HOST_SET` regex + `PRIVATE_CIDRS` list.
- `crates/waf-engine/src/checks/ssrf_scanners.rs` (new) — `extract_urls`, `parse_obfuscated_ip`, `is_private_ip`.
- `crates/waf-engine/src/checks/mod.rs` — declares the two new sibling modules.

### Tests

43 total: 13 in `ssrf_scanners.rs` (IP parsers + private classifier across v4/v6) + 30 in `ssrf.rs` (every detection rule + FP contracts + userinfo bypass and inverse + malformed-URL non-panic + allowlist bypass + correct phase/rule_id attribution).

### Out of scope (v1)

- **DNS resolution** — no DNS rebinding mitigation. Hostnames like `localhost` or attacker-controlled `ssrf.example.com` (which resolves to RFC1918) pass without detection. Documented in source; needs an upstream resolver hook.
- **Bench harness** (criterion) — deferred to follow-up; the regex-find on the body is the main hot path and worst-case scaling is bounded by the `max_body_size` cap from Phase 00.

## Stacked on #28

Base is `feat/fr-frame-detection-framework`. Rebase to `main` once #28 merges.

## Verified

- `cargo fmt --all -- --check` rc=0
- `cargo clippy --workspace --all-targets -- -D warnings` rc=0 on rust:1.95-slim-bookworm
- `cargo test -p waf-engine --lib checks::ssrf` 43/43

## Test plan

- [ ] CI lint + test + build green
- [ ] Coverage gate informational (see #28 for the deferred baseline-raise work)
- [ ] Manual regression: prior detection (xss, dir_traversal, sql_injection) unchanged