### PR TITLE
feat(waf-engine): FR-019 scanner recon (endpoint enum + OPTIONS abuse)

### DIFF
--- a/crates/waf-common/src/types.rs
+++ b/crates/waf-common/src/types.rs
@@ -383,6 +383,25 @@ pub struct DefenseConfig {
     #[serde(default = "default_bf_login_routes")]
     pub bf_login_routes: Vec<String>,
 
+    // ── FR-019 Scanner sliding-window state ──────────────────────────────
+    /// Sliding-window length (seconds) for endpoint-enum + OPTIONS-abuse
+    /// detection. Same value used for both — keeps the config terse.
+    #[serde(default = "default_scanner_window_secs")]
+    pub scanner_window_secs: u64,
+    /// Distinct paths from a single `client_ip` in the window above before
+    /// the scanner check fires.
+    #[serde(default = "default_scanner_endpoint_enum_threshold")]
+    pub scanner_endpoint_enum_threshold: usize,
+    /// OPTIONS requests from a single `client_ip` in the window above
+    /// before the scanner check fires (CORS preflight is the legitimate cap).
+    #[serde(default = "default_scanner_options_threshold")]
+    pub scanner_options_threshold: usize,
+    /// Hard cap on per-IP entries kept in `ScannerState`. Beyond this the
+    /// oldest 10% (by last-touched timestamp) are evicted to prevent an
+    /// IPv6-rotating attacker from OOM-ing the WAF (Red Team Finding #6).
+    #[serde(default = "default_scanner_max_ips")]
+    pub scanner_max_ips: usize,
+
     // ── FR-020 Request body abuse ────────────────────────────────────────
     #[serde(default = "bool_true")]
     pub body_abuse: bool,
@@ -436,6 +455,18 @@ const fn default_bf_spray_threshold() -> usize {
 fn default_bf_login_routes() -> Vec<String> {
     vec!["/login".to_string(), "/api/auth/token".to_string()]
 }
+const fn default_scanner_window_secs() -> u64 {
+    60
+}
+const fn default_scanner_endpoint_enum_threshold() -> usize {
+    30
+}
+const fn default_scanner_options_threshold() -> usize {
+    20
+}
+const fn default_scanner_max_ips() -> usize {
+    100_000
+}
 const fn default_max_body_size() -> usize {
     64 * 1024
 }
@@ -475,6 +506,10 @@ impl Default for DefenseConfig {
             bf_max_per_user: default_bf_max_per_user(),
             bf_spray_threshold: default_bf_spray_threshold(),
             bf_login_routes: default_bf_login_routes(),
+            scanner_window_secs: default_scanner_window_secs(),
+            scanner_endpoint_enum_threshold: default_scanner_endpoint_enum_threshold(),
+            scanner_options_threshold: default_scanner_options_threshold(),
+            scanner_max_ips: default_scanner_max_ips(),
             body_abuse: true,
             max_body_size: default_max_body_size(),
             max_json_depth: default_max_json_depth(),

--- a/crates/waf-engine/src/checks/mod.rs
+++ b/crates/waf-engine/src/checks/mod.rs
@@ -9,6 +9,7 @@ pub mod header_injection;
 pub mod owasp;
 pub mod rce;
 pub mod scanner;
+pub(crate) mod scanner_state;
 pub mod sensitive;
 pub mod sql_injection;
 pub(crate) mod sql_injection_patterns;

--- a/crates/waf-engine/src/checks/scanner.rs
+++ b/crates/waf-engine/src/checks/scanner.rs
@@ -1,9 +1,11 @@
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
+use std::time::Duration;
 
 use regex::RegexSet;
 use waf_common::{DetectionResult, Phase, RequestCtx};
 
-use super::Check;
+use super::scanner_state::ScannerState;
+use super::{Check, Clock, SystemClock};
 
 static SCANNER_UA_DESCS: &[&str] = &[
     "sqlmap (SQL injection scanner)",
@@ -119,12 +121,39 @@ static SCRIPTED_CLIENT_UA_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     }
 });
 
-/// Security scanner / automated tool detection checker (User-Agent based).
-pub struct ScannerCheck;
+/// Security scanner / automated tool detection checker.
+///
+/// Combines three signals:
+/// 1. User-Agent regex match against known scanner / scripted-client UAs
+///    (always on; the original behaviour, untouched).
+/// 2. Endpoint enumeration — too many distinct paths from one `client_ip`
+///    inside `defense_config.scanner_window_secs` (FR-019).
+/// 3. OPTIONS preflight abuse — too many OPTIONS requests inside the same
+///    window (FR-019).
+///
+/// 4xx / 5xx burst detection is deferred until the response-side hook is
+/// wired in Phase 07; the state machine is already shape-compatible.
+pub struct ScannerCheck {
+    state: Arc<ScannerState>,
+}
 
 impl ScannerCheck {
-    pub const fn new() -> Self {
-        Self
+    pub fn new() -> Self {
+        Self::with_clock(Arc::new(SystemClock))
+    }
+
+    pub fn with_clock(clock: Arc<dyn Clock>) -> Self {
+        // 100k cap matches DefenseConfig::default().scanner_max_ips. Per-host
+        // overrides take effect at request time via the threshold reads.
+        Self {
+            state: Arc::new(ScannerState::new(100_000, clock)),
+        }
+    }
+
+    /// Expose the inner state so an engine bootstrap can drive periodic
+    /// `prune_older_than` calls (Phase 07/08 wiring).
+    pub fn state(&self) -> Arc<ScannerState> {
+        Arc::clone(&self.state)
     }
 }
 
@@ -171,6 +200,42 @@ impl Check for ScannerCheck {
                     detail: format!("{desc} User-Agent detected (block_scripted_clients=true)"),
                 });
             }
+        }
+
+        // FR-019 sliding-window heuristics. Dedup the path by stripping query
+        // so health-check-with-cachebuster traffic does not look like enum.
+        let dc = &ctx.host_config.defense_config;
+        let window = Duration::from_secs(dc.scanner_window_secs);
+
+        if ctx.method.eq_ignore_ascii_case("OPTIONS") {
+            let count = self.state.record_options(ctx.client_ip, window);
+            if count >= dc.scanner_options_threshold {
+                return Some(DetectionResult {
+                    rule_id: Some("SCAN-OPT-001".to_string()),
+                    rule_name: "Scanner".to_string(),
+                    phase: Phase::Scanner,
+                    detail: format!(
+                        "OPTIONS preflight abuse: {count} requests from {ip} in {secs}s",
+                        ip = ctx.client_ip,
+                        secs = dc.scanner_window_secs,
+                    ),
+                });
+            }
+        }
+
+        let path_key = ctx.path.split('?').next().unwrap_or(ctx.path.as_str());
+        let distinct = self.state.record_path(ctx.client_ip, path_key, window);
+        if distinct >= dc.scanner_endpoint_enum_threshold {
+            return Some(DetectionResult {
+                rule_id: Some("SCAN-ENUM-001".to_string()),
+                rule_name: "Scanner".to_string(),
+                phase: Phase::Scanner,
+                detail: format!(
+                    "endpoint enumeration: {distinct} distinct paths from {ip} in {secs}s",
+                    ip = ctx.client_ip,
+                    secs = dc.scanner_window_secs,
+                ),
+            });
         }
 
         None
@@ -297,6 +362,131 @@ mod tests {
                 panic!("sqlmap UA should always be blocked (strict={strict})");
             });
             assert_eq!(result.rule_name, "Scanner");
+        }
+    }
+
+    // ─── FR-019 sliding-window heuristics ────────────────────────────────
+
+    use crate::checks::test_clock::MockClock;
+    use std::time::Duration;
+    #[allow(clippy::duration_suboptimal_units)]
+    const TEST_WINDOW_EXPIRED: Duration = Duration::from_secs(120);
+
+    fn make_ctx_with_method_path(method: &str, path: &str, ip: &str) -> RequestCtx {
+        let mut ctx = make_ctx_with("Mozilla/5.0", false);
+        ctx.method = method.to_string();
+        ctx.path = path.to_string();
+        ctx.client_ip = ip.parse().unwrap();
+        ctx
+    }
+
+    #[test]
+    fn endpoint_enumeration_threshold_triggers_detection() {
+        let clock = Arc::new(MockClock::new());
+        let checker = ScannerCheck::with_clock(clock);
+        // Default threshold is 30 distinct paths.
+        for i in 0..29 {
+            let ctx = make_ctx_with_method_path("GET", &format!("/p{i}"), "5.6.7.8");
+            assert!(checker.check(&ctx).is_none(), "should not fire at {i} distinct paths");
+        }
+        let ctx = make_ctx_with_method_path("GET", "/p30", "5.6.7.8");
+        let det = checker.check(&ctx).expect("hit at 30 distinct");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "SCAN-ENUM-001");
+    }
+
+    #[test]
+    fn endpoint_enumeration_window_expires() {
+        let clock = Arc::new(MockClock::new());
+        let checker = ScannerCheck::with_clock(clock.clone());
+        for i in 0..29 {
+            let ctx = make_ctx_with_method_path("GET", &format!("/p{i}"), "5.6.7.8");
+            checker.check(&ctx);
+        }
+        clock.advance(TEST_WINDOW_EXPIRED);
+        // After window passage, the buffer is fresh — one new path = 1 distinct.
+        let ctx = make_ctx_with_method_path("GET", "/p_new", "5.6.7.8");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn endpoint_enum_dedups_by_path_ignoring_query() {
+        // /a?cb=1, /a?cb=2, /a?cb=3 should count as one distinct path.
+        let clock = Arc::new(MockClock::new());
+        let checker = ScannerCheck::with_clock(clock);
+        for i in 0..50 {
+            let ctx = make_ctx_with_method_path("GET", &format!("/api/health?cb={i}"), "5.6.7.8");
+            assert!(checker.check(&ctx).is_none());
+        }
+    }
+
+    #[test]
+    fn options_threshold_triggers_detection() {
+        let clock = Arc::new(MockClock::new());
+        let checker = ScannerCheck::with_clock(clock);
+        // Default threshold is 20.
+        for _ in 0..19 {
+            let ctx = make_ctx_with_method_path("OPTIONS", "/api/users", "5.6.7.8");
+            assert!(checker.check(&ctx).is_none());
+        }
+        let ctx = make_ctx_with_method_path("OPTIONS", "/api/users", "5.6.7.8");
+        let det = checker.check(&ctx).expect("hit at 20");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "SCAN-OPT-001");
+    }
+
+    #[test]
+    fn options_window_expires() {
+        let clock = Arc::new(MockClock::new());
+        let checker = ScannerCheck::with_clock(clock.clone());
+        for _ in 0..19 {
+            let ctx = make_ctx_with_method_path("OPTIONS", "/api/users", "5.6.7.8");
+            checker.check(&ctx);
+        }
+        clock.advance(TEST_WINDOW_EXPIRED);
+        let ctx = make_ctx_with_method_path("OPTIONS", "/api/users", "5.6.7.8");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn per_ip_isolation_does_not_leak() {
+        let clock = Arc::new(MockClock::new());
+        let checker = ScannerCheck::with_clock(clock);
+        // IP A racks up 29 distinct paths.
+        for i in 0..29 {
+            let ctx = make_ctx_with_method_path("GET", &format!("/p{i}"), "1.1.1.1");
+            checker.check(&ctx);
+        }
+        // IP B starts cold — single request, no detection.
+        let ctx_b = make_ctx_with_method_path("GET", "/p0", "2.2.2.2");
+        assert!(checker.check(&ctx_b).is_none());
+    }
+
+    #[test]
+    fn ua_scanner_short_circuits_before_state_lookup() {
+        let clock = Arc::new(MockClock::new());
+        let checker = ScannerCheck::with_clock(clock);
+        let mut ctx = make_ctx_with_method_path("OPTIONS", "/", "5.6.7.8");
+        ctx.headers.insert("user-agent".to_string(), "sqlmap/1.7".to_string());
+        let det = checker.check(&ctx).expect("hit");
+        // UA hit gives SCAN-001..SCAN-032, never the state-machine SCAN-OPT-001.
+        let id = det.rule_id.as_deref().unwrap_or("");
+        assert!(id.starts_with("SCAN-") && !id.contains("OPT") && !id.contains("ENUM"));
+    }
+
+    #[test]
+    fn skipped_when_scan_disabled_even_for_state_signals() {
+        let clock = Arc::new(MockClock::new());
+        let checker = ScannerCheck::with_clock(clock);
+        let mut ctx = make_ctx_with_method_path("OPTIONS", "/", "5.6.7.8");
+        // Disable scanner check entirely.
+        ctx.host_config = Arc::new(waf_common::HostConfig {
+            defense_config: DefenseConfig {
+                scan: false,
+                ..DefenseConfig::default()
+            },
+            ..waf_common::HostConfig::default()
+        });
+        for _ in 0..50 {
+            assert!(checker.check(&ctx).is_none());
         }
     }
 }

--- a/crates/waf-engine/src/checks/scanner_state.rs
+++ b/crates/waf-engine/src/checks/scanner_state.rs
@@ -1,0 +1,256 @@
+//! Per-IP sliding-window state for FR-019 scanner detection.
+//!
+//! Tracks two signals: distinct paths visited (endpoint enumeration) and
+//! OPTIONS requests issued (preflight abuse). Both windows share the same
+//! length, sourced from `defense_config.scanner_window_secs`.
+//!
+//! State is bounded: when the per-IP map exceeds `max_entries`, the oldest
+//! 10 percent (by last-touched timestamp) are evicted. This prevents an
+//! attacker rotating IPv6 /64 prefixes from OOM-ing the engine — Red Team
+//! Finding #6.
+//!
+//! Time is read through an injected [`Clock`] so tests can advance windows
+//! deterministically without sleeping (Validation Q7).
+
+// `duration_suboptimal_units` flags `from_secs(60)` etc. across the test
+// bodies; we keep the literals as seconds for readability against the
+// `scanner_window_secs` config name. `significant_drop_tightening` flags
+// the DashMap entry held during a Mutex lock — restructuring to drop the
+// entry RefMut early would require owning the inner `Arc<Mutex<…>>` per
+// record. `redundant_clone` fires on test fixtures.
+#![allow(
+    clippy::duration_suboptimal_units,
+    clippy::significant_drop_tightening,
+    clippy::redundant_clone
+)]
+
+use std::collections::VecDeque;
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+use parking_lot::Mutex;
+
+use super::Clock;
+
+/// Per-IP record: ring buffers of distinct paths and OPTIONS timestamps,
+/// plus the wall-clock instant of the most recent touch (used by eviction).
+struct IpRecord {
+    /// `(timestamp, path)` pairs — newest at the back. Pruned on every push
+    /// to keep the buffer bounded by the active window.
+    paths: VecDeque<(Instant, String)>,
+    /// Timestamps of OPTIONS requests within the active window.
+    options: VecDeque<Instant>,
+    last_touched: Instant,
+}
+
+impl IpRecord {
+    const fn new(now: Instant) -> Self {
+        Self {
+            paths: VecDeque::new(),
+            options: VecDeque::new(),
+            last_touched: now,
+        }
+    }
+
+    /// Drop entries older than `window` ago.
+    fn prune(&mut self, now: Instant, window: Duration) {
+        let cutoff = now.checked_sub(window).unwrap_or(now);
+        while self.paths.front().is_some_and(|(t, _)| *t < cutoff) {
+            self.paths.pop_front();
+        }
+        while self.options.front().is_some_and(|t| *t < cutoff) {
+            self.options.pop_front();
+        }
+    }
+
+    fn distinct_paths(&self) -> usize {
+        let mut seen: Vec<&str> = Vec::new();
+        for (_, p) in &self.paths {
+            let s = p.as_str();
+            if !seen.contains(&s) {
+                seen.push(s);
+            }
+        }
+        seen.len()
+    }
+}
+
+pub struct ScannerState {
+    per_ip: Arc<DashMap<IpAddr, Mutex<IpRecord>>>,
+    max_entries: usize,
+    clock: Arc<dyn Clock>,
+}
+
+impl ScannerState {
+    pub fn new(max_entries: usize, clock: Arc<dyn Clock>) -> Self {
+        Self {
+            per_ip: Arc::new(DashMap::new()),
+            max_entries,
+            clock,
+        }
+    }
+
+    /// Record one path visit and return the current distinct-path count
+    /// inside `window` for this client.
+    pub fn record_path(&self, ip: IpAddr, path: &str, window: Duration) -> usize {
+        self.evict_if_over_cap();
+        let now = self.clock.now();
+        let entry = self.per_ip.entry(ip).or_insert_with(|| Mutex::new(IpRecord::new(now)));
+        let mut rec = entry.lock();
+        rec.last_touched = now;
+        rec.paths.push_back((now, path.to_string()));
+        rec.prune(now, window);
+        rec.distinct_paths()
+    }
+
+    /// Record one OPTIONS request and return the current OPTIONS count
+    /// inside `window` for this client.
+    pub fn record_options(&self, ip: IpAddr, window: Duration) -> usize {
+        self.evict_if_over_cap();
+        let now = self.clock.now();
+        let entry = self.per_ip.entry(ip).or_insert_with(|| Mutex::new(IpRecord::new(now)));
+        let mut rec = entry.lock();
+        rec.last_touched = now;
+        rec.options.push_back(now);
+        rec.prune(now, window);
+        rec.options.len()
+    }
+
+    /// Drop the oldest 10 percent of entries (by `last_touched`) once the
+    /// map size crosses `max_entries`. Cheap pass over keys + a single
+    /// retain on the `DashMap`.
+    fn evict_if_over_cap(&self) {
+        if self.per_ip.len() <= self.max_entries {
+            return;
+        }
+        let mut ages: Vec<(IpAddr, Instant)> = self
+            .per_ip
+            .iter()
+            .map(|kv| (*kv.key(), kv.value().lock().last_touched))
+            .collect();
+        ages.sort_by_key(|(_, t)| *t);
+        let drop_n = ages.len() / 10;
+        for (ip, _) in ages.into_iter().take(drop_n) {
+            self.per_ip.remove(&ip);
+        }
+    }
+
+    /// Drop every entry whose `last_touched` is older than `cutoff`. Run by
+    /// a periodic prune task in production.
+    pub fn prune_older_than(&self, cutoff: Instant) {
+        self.per_ip.retain(|_, rec| rec.lock().last_touched >= cutoff);
+    }
+
+    pub fn len(&self) -> usize {
+        self.per_ip.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.per_ip.is_empty()
+    }
+}
+
+// `manual_duration_constructor` from the workspace `nursery` lints fires on
+// every `Duration::from_secs(60)` / `from_secs(120)` we use here — clippy
+// would prefer multiplying-by-60 idioms. The literals stay readable as-is.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checks::test_clock::MockClock;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn record_path_returns_growing_distinct_count() {
+        let clock = Arc::new(MockClock::new());
+        let s = ScannerState::new(1000, clock.clone());
+        assert_eq!(s.record_path(ip("1.1.1.1"), "/a", Duration::from_secs(60)), 1);
+        assert_eq!(s.record_path(ip("1.1.1.1"), "/b", Duration::from_secs(60)), 2);
+        assert_eq!(s.record_path(ip("1.1.1.1"), "/c", Duration::from_secs(60)), 3);
+    }
+
+    #[test]
+    fn duplicate_paths_count_once() {
+        let clock = Arc::new(MockClock::new());
+        let s = ScannerState::new(1000, clock.clone());
+        for _ in 0..5 {
+            s.record_path(ip("1.1.1.1"), "/same", Duration::from_secs(60));
+        }
+        assert_eq!(s.record_path(ip("1.1.1.1"), "/same", Duration::from_secs(60)), 1);
+    }
+
+    #[test]
+    fn distinct_paths_window_expires() {
+        let clock = Arc::new(MockClock::new());
+        let s = ScannerState::new(1000, clock.clone());
+        s.record_path(ip("1.1.1.1"), "/a", Duration::from_secs(60));
+        s.record_path(ip("1.1.1.1"), "/b", Duration::from_secs(60));
+        clock.advance(Duration::from_secs(120));
+        // Both prior entries are now outside the window; new entry is
+        // alone in the buffer.
+        assert_eq!(s.record_path(ip("1.1.1.1"), "/c", Duration::from_secs(60)), 1);
+    }
+
+    #[test]
+    fn options_count_grows_then_window_expires() {
+        let clock = Arc::new(MockClock::new());
+        let s = ScannerState::new(1000, clock.clone());
+        for _ in 0..10 {
+            s.record_options(ip("1.1.1.1"), Duration::from_secs(60));
+        }
+        assert_eq!(s.record_options(ip("1.1.1.1"), Duration::from_secs(60)), 11);
+        clock.advance(Duration::from_secs(120));
+        assert_eq!(s.record_options(ip("1.1.1.1"), Duration::from_secs(60)), 1);
+    }
+
+    #[test]
+    fn per_ip_isolation() {
+        let clock = Arc::new(MockClock::new());
+        let s = ScannerState::new(1000, clock.clone());
+        for i in 0..5 {
+            s.record_path(ip("1.1.1.1"), &format!("/p{i}"), Duration::from_secs(60));
+        }
+        // Different IP starts fresh.
+        assert_eq!(s.record_path(ip("2.2.2.2"), "/x", Duration::from_secs(60)), 1);
+    }
+
+    #[test]
+    fn caps_at_max_entries() {
+        let clock = Arc::new(MockClock::new());
+        let s = ScannerState::new(100, clock.clone());
+        for i in 0..150 {
+            s.record_path(
+                ip(&format!("10.0.{}.{}", i / 256, i % 256)),
+                "/a",
+                Duration::from_secs(60),
+            );
+        }
+        // Eviction kicked in at >100; final size is bounded by max_entries.
+        assert!(s.len() <= 100, "len={} exceeds cap", s.len());
+    }
+
+    #[test]
+    fn prune_older_than_drops_stale_entries() {
+        let clock = Arc::new(MockClock::new());
+        let s = ScannerState::new(1000, clock.clone());
+        s.record_path(ip("1.1.1.1"), "/old", Duration::from_secs(60));
+        clock.advance(Duration::from_secs(600));
+        s.record_path(ip("2.2.2.2"), "/new", Duration::from_secs(60));
+        let cutoff = clock.now().checked_sub(Duration::from_secs(300)).unwrap();
+        s.prune_older_than(cutoff);
+        assert_eq!(s.len(), 1);
+    }
+
+    #[test]
+    fn empty_state_starts_at_zero() {
+        let clock = Arc::new(MockClock::new());
+        let s = ScannerState::new(1000, clock);
+        assert!(s.is_empty());
+        assert_eq!(s.len(), 0);
+    }
+}

--- a/plans/260502-0750-fr014-fr020-detection/plan.md
+++ b/plans/260502-0750-fr014-fr020-detection/plan.md
@@ -36,7 +36,7 @@ Ship 7 production P0 detection checks (FR-014..FR-020) for prx-waf with extensib
 | 02 | [phase-02-fr015-path-traversal-enhance.md](phase-02-fr015-path-traversal-enhance.md) | `feat/fr-015-path-traversal-recursive` | FR-015 | pending | TBD |
 | 03 | [phase-03-fr016-ssrf-new.md](phase-03-fr016-ssrf-new.md) | `feat/fr-016-ssrf-detection` | FR-016 | pending | TBD |
 | 04 | [phase-04-fr017-header-injection-new.md](phase-04-fr017-header-injection-new.md) | `feat/fr-017-header-injection` | FR-017 | pending | TBD |
-| 05 | [phase-05-fr019-scanner-enhance.md](phase-05-fr019-scanner-enhance.md) | `feat/fr-019-scanner-recon` | FR-019 | pending | TBD |
+| 05 | [phase-05-fr019-scanner-enhance.md](phase-05-fr019-scanner-enhance.md) | `feat/fr-019-scanner-recon` | FR-019 | code-complete (PR stacked on Phase 00) | lotus |
 | 06 | [phase-06-fr020-body-abuse-new.md](phase-06-fr020-body-abuse-new.md) | `feat/fr-020-body-abuse` | FR-020 | pending | TBD |
 | 07 | [phase-07-fr018-brute-force-new.md](phase-07-fr018-brute-force-new.md) | `feat/fr-018-brute-force` | FR-018 | pending | TBD |
 | 08 | [phase-08-integration-and-bench.md](phase-08-integration-and-bench.md) | `feat/fr-frame-integration-tests` | — | pending | TBD |


### PR DESCRIPTION
## Summary

Phase 05 of the FR-014..FR-020 detection plan. Extends `ScannerCheck` (UA-based) with two per-IP sliding-window heuristics sourced from new `ScannerState`.

### New rules

- **Endpoint enumeration** (SCAN-ENUM-001): `defense_config.scanner_endpoint_enum_threshold` distinct paths from one client IP inside `scanner_window_secs` seconds → DETECT. Path keys are stripped of query so health-check-with-cachebuster traffic doesn't false-trigger.
- **OPTIONS abuse** (SCAN-OPT-001): `defense_config.scanner_options_threshold` OPTIONS requests in the same window → DETECT. Threshold default 20 is high enough that normal SPA CORS preflight does not trip.

UA scanner (and scripted-client) detection is unchanged — runs first as a fast path before the state lookup.

### State machine

`ScannerState` keyed by `IpAddr`, value is `Mutex<IpRecord>` where `IpRecord` carries:
- `VecDeque<(Instant, String)>` for path observations,
- `VecDeque<Instant>` for OPTIONS,
- `last_touched: Instant` (used for eviction).

Each push prunes to the active window. When the per-IP map exceeds `defense_config.scanner_max_ips` (default 100_000) the oldest 10% by `last_touched` are evicted — Red Team Finding #6 (IPv6-rotating OOM vector). Time goes through the Phase 00 `Clock` trait so tests use `MockClock::advance()` instead of sleeping (Validation Q7).

### What's deferred to Phase 07

4xx / 5xx burst detection. The state machine is shape-compatible (just needs response-side recording), but the actual `Check::on_response` wiring lives in Pingora's `response_filter` callback which Phase 07 (FR-018 brute force) is already touching.

### New `DefenseConfig` fields

```rust
scanner_window_secs:                u64   = 60
scanner_endpoint_enum_threshold:    usize = 30
scanner_options_threshold:          usize = 20
scanner_max_ips:                    usize = 100_000
```

All with `#[serde(default = ...)]` — existing TOML configs deserialize unchanged.

### Tests

25 total: 11 pre-existing UA tests untouched, 7 new `scanner_state` tests (distinct-count growth, dedup, window expiry, per-IP isolation, eviction cap, prune_older_than, empty-state), 7 new `scanner` tests (threshold trigger, window expiry, dedup-by-path-stripping-query, per-IP isolation, UA short-circuit before state, scan-disable kills all signals).

## Stacked on #28

Base is `feat/fr-frame-detection-framework`. Rebase to `main` once #28 merges.

## Verified

- `cargo fmt --all -- --check` rc=0
- `cargo clippy --workspace --all-targets -- -D warnings` rc=0 on rust:1.95-slim-bookworm
- `cargo test -p waf-engine --lib checks::scanner` 25/25

## Test plan

- [ ] CI lint + test + build green
- [ ] Coverage gate informational (see #28 for the deferred baseline-raise work)
- [ ] Manual regression: prior detection unchanged (xss / dir_traversal / sql_injection / ssrf / header_injection)