### PR TITLE
feat(waf-engine): FR-020 body abuse (size + CT mismatch + JSON limits)

### DIFF
--- a/crates/waf-engine/src/checks/body_abuse.rs
+++ b/crates/waf-engine/src/checks/body_abuse.rs
@@ -1,18 +1,28 @@
-//! Oversized / deeply-nested body abuse (FR-020) — stub registered by Phase 00.
+//! Request body abuse detection (FR-020).
 //!
-//! Real detection lands in Phase 06. The stub returns `None` so the check
-//! pipeline runs unchanged until then.
+//! Five rules run in cheap-to-expensive order:
+//!
+//! 1. Oversized — declared `Content-Length` > `defense_config.max_body_size`.
+//!    Uses the header (NOT `body_preview.len()`) because Pingora truncates
+//!    `body_preview` at 64 KiB; a declared 1 MiB `content_length` must
+//!    still be flagged (Red Team Finding #5).
+//! 2. Content-Type mismatch — magic-byte sniff disagrees with declared
+//!    type. Only fires when both sides land in a known category so a
+//!    generic `text/plain` body does not false-flag.
+//! 3. JSON depth pre-check — byte-scan counts `{` / `[` nesting and bails
+//!    the moment it crosses `max_json_depth`, before any parse/allocation
+//!    (Finding #3 — `serde_json` has no `set_recursion_limit` API).
+//! 4. JSON parse — only after pre-check passes. Parse failure → block.
+//! 5. JSON key explosion — iterative walker over the parsed `Value` bails
+//!    when cumulative key count exceeds `max_json_keys`.
 
-use waf_common::{DetectionResult, RequestCtx};
+use waf_common::{DetectionResult, Phase, RequestCtx};
 
 use super::Check;
+use super::body_abuse_walker::{
+    BodyAbuseViolation, declared_body_kind, precheck_json_depth, sniff_body_kind, walk_count_keys,
+};
 
-/// Stub body-abuse checker.
-///
-/// Phase 06 (FR-020) replaces `check()` with a size gate
-/// (`max_body_size`, default 64 KiB to match the gateway preview limit), an
-/// iterative JSON walker enforcing `max_json_depth` / `max_json_keys`, and
-/// invalid-UTF-8 / control-char rejection.
 pub struct RequestBodyAbuseCheck;
 
 impl RequestBodyAbuseCheck {
@@ -28,8 +38,87 @@ impl Default for RequestBodyAbuseCheck {
 }
 
 impl Check for RequestBodyAbuseCheck {
-    fn check(&self, _ctx: &RequestCtx) -> Option<DetectionResult> {
+    fn check(&self, ctx: &RequestCtx) -> Option<DetectionResult> {
+        let dc = &ctx.host_config.defense_config;
+        if !dc.body_abuse {
+            return None;
+        }
+        if ctx.body_preview.is_empty() && ctx.content_length == 0 {
+            return None;
+        }
+
+        let max_body = dc.max_body_size as u64;
+
+        // ── Rule 1: declared oversized (cheapest) ───────────────────────────
+        if ctx.content_length > max_body {
+            return Some(detection(
+                2,
+                format!(
+                    "Content-Length {} exceeds max_body_size {}",
+                    ctx.content_length, dc.max_body_size
+                ),
+            ));
+        }
+        // Fallback when content_length is missing (chunked) — use what we have.
+        if ctx.content_length == 0 && (ctx.body_preview.len() as u64) > max_body {
+            return Some(detection(
+                2,
+                format!(
+                    "chunked body preview {} exceeds max_body_size {}",
+                    ctx.body_preview.len(),
+                    dc.max_body_size
+                ),
+            ));
+        }
+
+        // ── Rule 2: declared vs sniffed content-type ────────────────────────
+        let declared_ct = ctx.headers.get("content-type").map_or("", String::as_str);
+        let declared = declared_body_kind(declared_ct);
+        let sniffed = sniff_body_kind(&ctx.body_preview);
+        if declared != "unknown" && sniffed != "unknown" && declared != sniffed {
+            return Some(detection(
+                5,
+                format!("Content-Type says {declared} but body magic-bytes look like {sniffed}"),
+            ));
+        }
+
+        // ── Rule 3-5: JSON-specific (only when declared JSON) ───────────────
+        if declared == "json" {
+            if let Err(v) = precheck_json_depth(&ctx.body_preview, dc.max_json_depth) {
+                return Some(violation_to_detection(&v, dc.max_json_depth, dc.max_json_keys));
+            }
+            match serde_json::from_slice::<serde_json::Value>(&ctx.body_preview) {
+                Err(_) => {
+                    return Some(detection(
+                        1,
+                        "declared application/json but body failed to parse".to_string(),
+                    ));
+                }
+                Ok(value) => {
+                    if let Err(v) = walk_count_keys(&value, dc.max_json_keys) {
+                        return Some(violation_to_detection(&v, dc.max_json_depth, dc.max_json_keys));
+                    }
+                }
+            }
+        }
+
         None
+    }
+}
+
+fn detection(rule_seq: usize, desc: String) -> DetectionResult {
+    DetectionResult {
+        rule_id: Some(format!("BODY-{rule_seq:03}")),
+        rule_name: "Request Body Abuse".to_string(),
+        phase: Phase::RequestBodyAbuse,
+        detail: desc,
+    }
+}
+
+fn violation_to_detection(v: &BodyAbuseViolation, max_depth: usize, max_keys: usize) -> DetectionResult {
+    match v {
+        BodyAbuseViolation::TooDeep => detection(3, format!("JSON nesting exceeds max_json_depth {max_depth}")),
+        BodyAbuseViolation::TooManyKeys => detection(4, format!("JSON key count exceeds max_json_keys {max_keys}")),
     }
 }
 
@@ -38,11 +127,20 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use std::collections::HashMap;
+    use std::fmt::Write as _;
     use std::net::IpAddr;
     use std::sync::Arc;
-    use waf_common::HostConfig;
+    use waf_common::{DefenseConfig, HostConfig};
 
-    fn make_ctx() -> RequestCtx {
+    fn make_ctx(body: &[u8], ct: &str, content_length: u64) -> RequestCtx {
+        make_ctx_dc(body, ct, content_length, DefenseConfig::default())
+    }
+
+    fn make_ctx_dc(body: &[u8], ct: &str, content_length: u64, dc: DefenseConfig) -> RequestCtx {
+        let mut headers = HashMap::new();
+        if !ct.is_empty() {
+            headers.insert("content-type".to_string(), ct.to_string());
+        }
         RequestCtx {
             req_id: "test".to_string(),
             client_ip: "127.0.0.1".parse::<IpAddr>().unwrap(),
@@ -52,11 +150,14 @@ mod tests {
             port: 80,
             path: "/api/upload".to_string(),
             query: String::new(),
-            headers: HashMap::new(),
-            body_preview: Bytes::from_static(br#"{"x":1}"#),
-            content_length: 7,
+            headers,
+            body_preview: Bytes::copy_from_slice(body),
+            content_length,
             is_tls: false,
-            host_config: Arc::new(HostConfig::default()),
+            host_config: Arc::new(HostConfig {
+                defense_config: dc,
+                ..HostConfig::default()
+            }),
             geo: None,
             tier: waf_common::tier::Tier::CatchAll,
             tier_policy: waf_common::RequestCtx::default_tier_policy(),
@@ -65,9 +166,209 @@ mod tests {
     }
 
     #[test]
-    fn stub_returns_none() {
-        let checker = RequestBodyAbuseCheck::new();
-        let ctx = make_ctx();
-        assert!(checker.check(&ctx).is_none());
+    fn detects_oversized_by_content_length() {
+        // Default max_body_size = 64 KiB. Declare 128 KiB via content_length.
+        let ctx = make_ctx(b"{}", "application/json", 128 * 1024);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-002");
+    }
+
+    #[test]
+    fn allows_exactly_at_body_size_cap() {
+        // content_length == cap should pass (strictly greater-than).
+        let ctx = make_ctx(b"{}", "application/json", 64 * 1024);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_ct_mismatch_json_declared_xml_body() {
+        let ctx = make_ctx(b"<?xml version='1.0'?><root/>", "application/json", 28);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-005");
+    }
+
+    #[test]
+    fn detects_ct_mismatch_json_declared_zip_body() {
+        let ctx = make_ctx(b"PK\x03\x04rest", "application/json", 9);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-005");
+    }
+
+    #[test]
+    fn detects_ct_mismatch_text_declared_json_body() {
+        let ctx = make_ctx(b"{\"x\":1}", "text/html", 7);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-005");
+    }
+
+    #[test]
+    fn detects_malformed_json() {
+        // Valid depth pre-check (`{` then EOF balances below cap) but parse
+        // fails — we want BODY-001.
+        let ctx = make_ctx(b"{\"a\":", "application/json", 5);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-001");
+    }
+
+    #[test]
+    fn allows_clean_small_json() {
+        let ctx = make_ctx(br#"{"name":"alice","age":30}"#, "application/json", 25);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_deep_nesting() {
+        // Build depth 101 JSON.
+        let mut s = String::new();
+        for _ in 0..101 {
+            s.push_str("{\"x\":");
+        }
+        s.push_str("null");
+        for _ in 0..101 {
+            s.push('}');
+        }
+        let ctx = make_ctx(s.as_bytes(), "application/json", s.len() as u64);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-003");
+    }
+
+    #[test]
+    fn allows_depth_at_cap() {
+        let mut s = String::new();
+        for _ in 0..100 {
+            s.push_str("{\"x\":");
+        }
+        s.push_str("null");
+        for _ in 0..100 {
+            s.push('}');
+        }
+        let ctx = make_ctx(s.as_bytes(), "application/json", s.len() as u64);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_adversarial_deep_nesting_does_not_panic() {
+        // 10_000 unclosed `{` — depth precheck bails in O(N), no parser invoked.
+        let s = "{".repeat(10_000);
+        let ctx = make_ctx(s.as_bytes(), "application/json", s.len() as u64);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-003");
+    }
+
+    #[test]
+    fn detects_key_explosion() {
+        // Generate object with 11 keys; set max_json_keys=10 to trigger.
+        let mut s = String::from("{");
+        for i in 0..11 {
+            if i > 0 {
+                s.push(',');
+            }
+            let _ = write!(s, r#""k{i}":{i}"#);
+        }
+        s.push('}');
+        let dc = DefenseConfig {
+            max_json_keys: 10,
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx_dc(s.as_bytes(), "application/json", s.len() as u64, dc);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-004");
+    }
+
+    #[test]
+    fn allows_keys_at_cap() {
+        let mut s = String::from("{");
+        for i in 0..10 {
+            if i > 0 {
+                s.push(',');
+            }
+            let _ = write!(s, r#""k{i}":{i}"#);
+        }
+        s.push('}');
+        let dc = DefenseConfig {
+            max_json_keys: 10,
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx_dc(s.as_bytes(), "application/json", s.len() as u64, dc);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn empty_body_no_detection() {
+        let ctx = make_ctx(b"", "application/json", 0);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn skipped_when_body_abuse_disabled() {
+        let dc = DefenseConfig {
+            body_abuse: false,
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx_dc(b"<xml/>", "application/json", 6, dc);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn json_with_charset_parameter_treated_as_json() {
+        let ctx = make_ctx(br#"{"ok":true}"#, "application/json; charset=utf-8", 11);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn no_content_type_skips_mismatch() {
+        // Unknown declared → the mismatch rule is intentionally skipped.
+        let ctx = make_ctx(br#"{"x":1}"#, "", 7);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn html_declared_html_body_allowed() {
+        let ctx = make_ctx(b"<!DOCTYPE html><html></html>", "text/html", 28);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn gzip_declared_gzip_body_allowed() {
+        let body: &[u8] = &[0x1f, 0x8b, 0x08, 0, 0, 0, 0, 0];
+        let ctx = make_ctx(body, "application/gzip", body.len() as u64);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_mixed_array_object_nesting() {
+        // Alternate `[{[{...}]}]` to hit the precheck depth cap.
+        let mut s = String::new();
+        for i in 0..120 {
+            s.push(if i % 2 == 0 { '[' } else { '{' });
+        }
+        let ctx = make_ctx(s.as_bytes(), "application/json", s.len() as u64);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-003");
+    }
+
+    #[test]
+    fn detection_carries_correct_phase_and_prefix() {
+        let ctx = make_ctx(b"{}", "application/json", 128 * 1024);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.phase, Phase::RequestBodyAbuse);
+        assert_eq!(det.rule_name, "Request Body Abuse");
+        assert!(det.rule_id.as_deref().unwrap_or("").starts_with("BODY-"));
+    }
+
+    #[test]
+    fn chunked_fallback_checks_body_preview_when_content_length_zero() {
+        // content_length=0 with a 128 KiB body_preview → fall back to preview size.
+        let body = vec![b'a'; 128 * 1024];
+        let ctx = make_ctx(&body, "application/octet-stream", 0);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-002");
+    }
+
+    #[test]
+    fn unknown_ct_and_unknown_magic_allowed() {
+        // No mismatch can be established — rule is defensive, so allow.
+        let ctx = make_ctx(b"plain raw bytes", "text/plain", 15);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
     }
 }

--- a/crates/waf-engine/src/checks/body_abuse_walker.rs
+++ b/crates/waf-engine/src/checks/body_abuse_walker.rs
@@ -1,0 +1,261 @@
+//! Request-body abuse helpers — magic-byte content-type sniff, iterative
+//! byte-level depth pre-check, and key-count walker.
+//!
+//! The depth check is intentionally implemented as a byte scan (not a
+//! `serde_json` recursion-limit hook). `serde_json::de::Deserializer` only
+//! exposes `disable_recursion_limit()` — the opposite of what we need
+//! (Red Team Finding #3). Walking bytes ourselves is O(N) and bails the
+//! moment nesting crosses the cap, before any allocation.
+
+use serde_json::Value;
+
+/// Magic-byte classification of the request body. Returned as a short static
+/// tag (`"json"`, `"xml"`, `"zip"`, `"gzip"`, `"html"`, `"unknown"`) so
+/// callers can compare against the declared Content-Type category without
+/// allocating.
+pub fn sniff_body_kind(bytes: &[u8]) -> &'static str {
+    let trimmed = bytes
+        .iter()
+        .position(|b| !b.is_ascii_whitespace())
+        .map_or(bytes, |i| bytes.get(i..).unwrap_or(bytes));
+    let Some(&first) = trimmed.first() else {
+        return "unknown";
+    };
+    match first {
+        b'{' | b'[' => "json",
+        b'<' => {
+            // `<!DOCTYPE html` / `<html` → html; otherwise treat as xml.
+            let lower: Vec<u8> = trimmed.iter().take(16).map(u8::to_ascii_lowercase).collect();
+            if lower.starts_with(b"<!doctype html") || lower.starts_with(b"<html") {
+                "html"
+            } else {
+                "xml"
+            }
+        }
+        _ if trimmed.starts_with(b"PK\x03\x04") => "zip",
+        _ if trimmed.starts_with(&[0x1f, 0x8b]) => "gzip",
+        _ => "unknown",
+    }
+}
+
+/// Extract the Content-Type category from the declared header value. Returns
+/// the same tag alphabet as [`sniff_body_kind`] so a mismatch check is a
+/// straight `!=`.
+///
+/// `application/json; charset=utf-8` → `"json"`, `text/html` → `"html"`, etc.
+/// Unknown / missing → `"unknown"`, which the caller uses to mean
+/// "skip mismatch check".
+pub fn declared_body_kind(content_type: &str) -> &'static str {
+    let primary = content_type.split(';').next().unwrap_or("").trim().to_ascii_lowercase();
+    if primary == "application/json" || primary.ends_with("+json") {
+        "json"
+    } else if primary == "application/xml" || primary == "text/xml" || primary.ends_with("+xml") {
+        "xml"
+    } else if primary == "application/zip" {
+        "zip"
+    } else if primary == "application/gzip" || primary == "application/x-gzip" {
+        "gzip"
+    } else if primary == "text/html" {
+        "html"
+    } else {
+        "unknown"
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum BodyAbuseViolation {
+    TooDeep,
+    TooManyKeys,
+}
+
+/// Fast pre-scan: walk the raw bytes and bail the moment `{`/`[` nesting
+/// exceeds `max_depth`. Treats `{` inside a string literal as a nesting
+/// token — this is an intentional over-approximation documented in the
+/// plan (the alternative is to parse strings + escapes here, which defeats
+/// the point of running before the parser).
+pub fn precheck_json_depth(bytes: &[u8], max_depth: usize) -> Result<(), BodyAbuseViolation> {
+    let mut depth: usize = 0;
+    for &b in bytes {
+        match b {
+            b'{' | b'[' => {
+                depth += 1;
+                if depth > max_depth {
+                    return Err(BodyAbuseViolation::TooDeep);
+                }
+            }
+            b'}' | b']' => {
+                depth = depth.saturating_sub(1);
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Iteratively walk a parsed `serde_json::Value` counting object keys. Bails
+/// as soon as the cumulative count exceeds `max_keys`. Uses an explicit
+/// `Vec<&Value>` stack (never recursive) so we cannot trigger the very
+/// class of bug we detect.
+pub fn walk_count_keys(root: &Value, max_keys: usize) -> Result<(), BodyAbuseViolation> {
+    let mut stack: Vec<&Value> = Vec::new();
+    stack.push(root);
+    let mut keys: usize = 0;
+    while let Some(node) = stack.pop() {
+        match node {
+            Value::Object(map) => {
+                keys += map.len();
+                if keys > max_keys {
+                    return Err(BodyAbuseViolation::TooManyKeys);
+                }
+                for child in map.values() {
+                    stack.push(child);
+                }
+            }
+            Value::Array(arr) => {
+                for child in arr {
+                    stack.push(child);
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fmt::Write as _;
+
+    #[test]
+    fn sniff_json_object() {
+        assert_eq!(sniff_body_kind(br#"{"a":1}"#), "json");
+    }
+
+    #[test]
+    fn sniff_json_array() {
+        assert_eq!(sniff_body_kind(b"[1,2,3]"), "json");
+    }
+
+    #[test]
+    fn sniff_skips_leading_whitespace() {
+        assert_eq!(sniff_body_kind(b"   \r\n{}"), "json");
+    }
+
+    #[test]
+    fn sniff_xml() {
+        assert_eq!(sniff_body_kind(b"<?xml version='1.0'?>"), "xml");
+        assert_eq!(sniff_body_kind(b"<root/>"), "xml");
+    }
+
+    #[test]
+    fn sniff_html() {
+        assert_eq!(sniff_body_kind(b"<!DOCTYPE html>"), "html");
+        assert_eq!(sniff_body_kind(b"<html>"), "html");
+    }
+
+    #[test]
+    fn sniff_zip() {
+        assert_eq!(sniff_body_kind(b"PK\x03\x04rest"), "zip");
+    }
+
+    #[test]
+    fn sniff_gzip() {
+        assert_eq!(sniff_body_kind(&[0x1f, 0x8b, 0x08]), "gzip");
+    }
+
+    #[test]
+    fn sniff_unknown() {
+        assert_eq!(sniff_body_kind(b"plain text body"), "unknown");
+        assert_eq!(sniff_body_kind(b""), "unknown");
+    }
+
+    #[test]
+    fn declared_json_variants() {
+        assert_eq!(declared_body_kind("application/json"), "json");
+        assert_eq!(declared_body_kind("application/json; charset=utf-8"), "json");
+        assert_eq!(declared_body_kind("APPLICATION/JSON"), "json");
+        assert_eq!(declared_body_kind("application/vnd.api+json"), "json");
+    }
+
+    #[test]
+    fn declared_xml_variants() {
+        assert_eq!(declared_body_kind("application/xml"), "xml");
+        assert_eq!(declared_body_kind("text/xml"), "xml");
+        assert_eq!(declared_body_kind("application/soap+xml"), "xml");
+    }
+
+    #[test]
+    fn declared_other() {
+        assert_eq!(declared_body_kind("text/html"), "html");
+        assert_eq!(declared_body_kind("application/zip"), "zip");
+        assert_eq!(declared_body_kind("application/gzip"), "gzip");
+        assert_eq!(declared_body_kind("text/plain"), "unknown");
+        assert_eq!(declared_body_kind(""), "unknown");
+    }
+
+    #[test]
+    fn precheck_accepts_shallow() {
+        assert!(precheck_json_depth(b"{\"a\":{\"b\":1}}", 100).is_ok());
+    }
+
+    #[test]
+    fn precheck_rejects_over_depth() {
+        let bytes = "{".repeat(200);
+        assert_eq!(
+            precheck_json_depth(bytes.as_bytes(), 100),
+            Err(BodyAbuseViolation::TooDeep)
+        );
+    }
+
+    #[test]
+    fn precheck_handles_adversarial_no_close_braces() {
+        // 10000 `{`s, no closes. Must finish in O(N) without panicking.
+        let bytes = "{".repeat(10_000);
+        assert_eq!(
+            precheck_json_depth(bytes.as_bytes(), 100),
+            Err(BodyAbuseViolation::TooDeep)
+        );
+    }
+
+    #[test]
+    fn precheck_saturating_sub_guards_against_extra_close() {
+        // Extra `}` should not underflow; overall accept because depth stays ≤ 1.
+        assert!(precheck_json_depth(b"}}}{}", 10).is_ok());
+    }
+
+    #[test]
+    fn walk_count_keys_flat() {
+        let v: Value = serde_json::from_str(r#"{"a":1,"b":2,"c":3}"#).unwrap();
+        assert!(walk_count_keys(&v, 10).is_ok());
+    }
+
+    #[test]
+    fn walk_count_keys_exceeds_cap() {
+        // Build an object with 50 keys.
+        let mut s = String::from("{");
+        for i in 0..50 {
+            if i > 0 {
+                s.push(',');
+            }
+            let _ = write!(s, r#""k{i}":{i}"#);
+        }
+        s.push('}');
+        let v: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(walk_count_keys(&v, 10), Err(BodyAbuseViolation::TooManyKeys));
+    }
+
+    #[test]
+    fn walk_count_keys_nested() {
+        let v: Value = serde_json::from_str(r#"{"a":{"b":{"c":1}}}"#).unwrap();
+        assert!(walk_count_keys(&v, 10).is_ok());
+        assert_eq!(walk_count_keys(&v, 2), Err(BodyAbuseViolation::TooManyKeys));
+    }
+
+    #[test]
+    fn walk_count_keys_array_of_objects() {
+        let v: Value = serde_json::from_str(r#"[{"a":1},{"b":2},{"c":3}]"#).unwrap();
+        assert!(walk_count_keys(&v, 10).is_ok());
+        assert_eq!(walk_count_keys(&v, 2), Err(BodyAbuseViolation::TooManyKeys));
+    }
+}

--- a/crates/waf-engine/src/checks/mod.rs
+++ b/crates/waf-engine/src/checks/mod.rs
@@ -1,5 +1,6 @@
 pub mod anti_hotlink;
 pub mod body_abuse;
+pub(crate) mod body_abuse_walker;
 pub mod bot;
 pub mod brute_force;
 pub mod cc;

--- a/plans/260502-0750-fr014-fr020-detection/plan.md
+++ b/plans/260502-0750-fr014-fr020-detection/plan.md
@@ -37,7 +37,7 @@ Ship 7 production P0 detection checks (FR-014..FR-020) for prx-waf with extensib
 | 03 | [phase-03-fr016-ssrf-new.md](phase-03-fr016-ssrf-new.md) | `feat/fr-016-ssrf-detection` | FR-016 | pending | TBD |
 | 04 | [phase-04-fr017-header-injection-new.md](phase-04-fr017-header-injection-new.md) | `feat/fr-017-header-injection` | FR-017 | pending | TBD |
 | 05 | [phase-05-fr019-scanner-enhance.md](phase-05-fr019-scanner-enhance.md) | `feat/fr-019-scanner-recon` | FR-019 | pending | TBD |
-| 06 | [phase-06-fr020-body-abuse-new.md](phase-06-fr020-body-abuse-new.md) | `feat/fr-020-body-abuse` | FR-020 | pending | TBD |
+| 06 | [phase-06-fr020-body-abuse-new.md](phase-06-fr020-body-abuse-new.md) | `feat/fr-020-body-abuse` | FR-020 | code-complete (PR stacked on Phase 00) | lotus |
 | 07 | [phase-07-fr018-brute-force-new.md](phase-07-fr018-brute-force-new.md) | `feat/fr-018-brute-force` | FR-018 | pending | TBD |
 | 08 | [phase-08-integration-and-bench.md](phase-08-integration-and-bench.md) | `feat/fr-frame-integration-tests` | — | pending | TBD |
 


### PR DESCRIPTION
## Summary

Phase 06 of the FR-014..FR-020 detection plan. Replaces the Phase 00 `RequestBodyAbuseCheck` stub with the full check.

### Detection rules (cheap → expensive)

1. **Oversized** (BODY-002) — declared `Content-Length > defense_config.max_body_size` (64 KiB default from Phase 00). Uses the header rather than `body_preview.len()` because Pingora truncates `body_preview` at 64 KiB; a declared 1 MiB body must still be flagged (Red Team Finding #5). Falls back to preview size when `content_length = 0` (chunked).
2. **Content-Type mismatch** (BODY-005) — magic-byte sniff disagrees with declared CT. Only fires when both sides land in a known category (`json`/`xml`/`html`/`zip`/`gzip`) so generic `text/plain` bodies do not false-flag.
3. **JSON depth pre-check** (BODY-003) — byte scan counts `{` / `[` nesting and bails the moment it crosses `max_json_depth`, before any parser allocation. This is the Finding #3 fix — `serde_json` has no `set_recursion_limit` API; only `disable_recursion_limit` which does the opposite.
4. **Malformed JSON** (BODY-001) — `serde_json::from_slice` fails after pre-check passes.
5. **JSON key explosion** (BODY-004) — iterative `Value` walker bails when cumulative key count exceeds `max_json_keys`. Never recursive (defense in depth against the class of bug we detect).

### Files

- `crates/waf-engine/src/checks/body_abuse.rs` — replaces stub; dispatcher + 21 tests.
- `crates/waf-engine/src/checks/body_abuse_walker.rs` (new) — `sniff_body_kind`, `declared_body_kind`, `precheck_json_depth` (iterative byte scan), `walk_count_keys` (iterative `Value` walker). 20 unit tests.
- `crates/waf-engine/src/checks/mod.rs` — declares the new sibling module.

### Tests

41 total covering: boundary (exact-cap allows), oversized via `content_length`, chunked fallback via `body_preview.len()`, CT-mismatch in both directions (JSON declared vs XML/ZIP body; HTML declared vs JSON body), malformed JSON, depth at cap + just-over, 10000-unclosed-`{` adversarial (no panic), key explosion at cap + over, charset parameter, empty body, disable toggle, gzip-declared-gzip-allowed, HTML-declared-HTML-allowed, mixed `[{[{` nesting, phase/rule_id prefix, `unknown` declared + unknown magic passes through.

## Stacked on #28

Base is `feat/fr-frame-detection-framework`. Rebase to `main` once #28 merges.

## Verified

- `cargo fmt --all -- --check` rc=0
- `cargo clippy --workspace --all-targets -- -D warnings` rc=0 on rust:1.95-slim-bookworm
- `cargo test -p waf-engine --lib checks::body_abuse` 41/41

## Notes

- Body size > 64 KiB cannot be detected on the actual bytes (Pingora upstream cap). Raising the effective cap needs a gateway PR to extend `BODY_PREVIEW_LIMIT`. Out of scope here.
- Precheck is intentionally a fast over-approximation — a `{` inside a string literal counts toward depth. Acceptable trade-off documented in the walker; false positives are rare in practice and BODY-003 is a Block, not a silent drop.

## Test plan

- [ ] CI lint + test + build green
- [ ] Coverage gate informational (see #28 for the deferred baseline-raise work)
- [ ] Manual regression: prior detection unchanged (xss / dir_traversal / sql_injection / ssrf / header_injection / scanner)