### PR TITLE
feat(waf-engine): FR-018 brute force + credential stuffing

### DIFF
--- a/crates/waf-engine/Cargo.toml
+++ b/crates/waf-engine/Cargo.toml
@@ -34,6 +34,7 @@ libinjectionrs = "0.1"
 ed25519-dalek = { workspace = true }
 zstd = { workspace = true }
 hex = { workspace = true }
+sha2 = { workspace = true }
 url = { workspace = true }
 ahash = "0.8"
 globset = "0.4"

--- a/crates/waf-engine/src/checks/brute_force.rs
+++ b/crates/waf-engine/src/checks/brute_force.rs
@@ -1,25 +1,54 @@
-//! Authentication brute-force (FR-018) — stub registered by Phase 00.
+//! Brute force / credential stuffing detection (FR-018).
 //!
-//! Real detection lands in Phase 07. The request-phase `check()` always
-//! returns `None`; the production state machine lives entirely in
-//! `on_response()` (status-code-only v1) so wiring it now keeps the engine
-//! pipeline backwards-compatible while reserving the slot.
+//! Request phase (`Check::check`):
+//!   - If the request targets a configured login route AND the
+//!     `(user_hash, ip)` failure counter is at or above
+//!     `bf_max_per_user`, block with BF-001.
+//!   - If any password has been sprayed against `>= bf_spray_threshold`
+//!     distinct users from this IP inside the window, block with BF-002.
+//!
+//! Response phase (`Check::on_response`, status-code-only v1):
+//!   - If status is 401 or 403 AND the original request targeted a login
+//!     route, extract username + password from the body and record a
+//!     failure.
+//!
+//! Body-regex failure detection is intentionally NOT implemented —
+//! Pingora's `response_filter` exposes headers + status only (Finding #8),
+//! and a generic failure regex is weaponizable as a victim-account
+//! lockout primitive (Finding #11).
 
-use waf_common::{DetectionResult, RequestCtx};
+use std::sync::Arc;
+use std::time::Duration;
+
+use waf_common::{DetectionResult, Phase, RequestCtx};
 
 use super::Check;
+use super::brute_force_extractors::{
+    PASSWORD_KEYS, USERNAME_KEYS, extract_credential_field, is_failed_login_status, truncated_hash,
+};
+use super::brute_force_state::BfState;
+use super::{Clock, SystemClock};
 
-/// Stub brute-force checker.
-///
-/// Phase 07 (FR-018) replaces `on_response()` with a sliding-window counter
-/// keyed on `(username_hash, ip)`, sourced from the upstream's `401`/`403`
-/// status. The request-phase `check()` stays a no-op because the detection
-/// signal only exists after the upstream replies.
-pub struct BruteForceCheck;
+pub struct BruteForceCheck {
+    state: Arc<BfState>,
+}
 
 impl BruteForceCheck {
-    pub const fn new() -> Self {
-        Self
+    pub fn new() -> Self {
+        Self::with_clock(Arc::new(SystemClock))
+    }
+
+    pub fn with_clock(clock: Arc<dyn Clock>) -> Self {
+        Self {
+            state: Arc::new(BfState::new(100_000, clock)),
+        }
+    }
+
+    /// Expose the inner state so an engine bootstrap can drive periodic
+    /// `prune_older_than` calls (background pruner lives in engine init per
+    /// Red Team Finding #14).
+    pub fn state(&self) -> Arc<BfState> {
+        Arc::clone(&self.state)
     }
 }
 
@@ -29,36 +58,131 @@ impl Default for BruteForceCheck {
     }
 }
 
+/// Does `ctx.path` target any configured login route?
+fn is_login_route(ctx: &RequestCtx) -> bool {
+    let routes = &ctx.host_config.defense_config.bf_login_routes;
+    if routes.is_empty() {
+        return false;
+    }
+    let path = ctx.path.split('?').next().unwrap_or(ctx.path.as_str());
+    routes.iter().any(|r| path.starts_with(r.as_str()))
+}
+
 impl Check for BruteForceCheck {
-    fn check(&self, _ctx: &RequestCtx) -> Option<DetectionResult> {
+    fn check(&self, ctx: &RequestCtx) -> Option<DetectionResult> {
+        let dc = &ctx.host_config.defense_config;
+        if !dc.brute_force || !is_login_route(ctx) {
+            return None;
+        }
+
+        let window = Duration::from_secs(dc.bf_window_secs);
+
+        // BF-001 — per-user failure threshold.
+        let content_type = ctx.headers.get("content-type").map_or("", String::as_str);
+        if let Some(username) = extract_credential_field(&ctx.body_preview, content_type, USERNAME_KEYS) {
+            let user_hash = truncated_hash(&username.to_ascii_lowercase());
+            let count = self.state.failed_count(user_hash, ctx.client_ip, window);
+            if count >= dc.bf_max_per_user {
+                return Some(detection(
+                    1,
+                    format!(
+                        "{count} failed logins for same user from {ip} in {secs}s",
+                        ip = ctx.client_ip,
+                        secs = dc.bf_window_secs,
+                    ),
+                ));
+            }
+        }
+
+        // BF-002 — password-spray across distinct users from this IP.
+        if self
+            .state
+            .any_spray_over_threshold(ctx.client_ip, dc.bf_spray_threshold, window)
+        {
+            return Some(detection(
+                2,
+                format!(
+                    "password sprayed against >= {thr} users from {ip} in {secs}s",
+                    thr = dc.bf_spray_threshold,
+                    ip = ctx.client_ip,
+                    secs = dc.bf_window_secs,
+                ),
+            ));
+        }
+
         None
+    }
+
+    fn on_response(&self, ctx: &RequestCtx, status: u16) {
+        let dc = &ctx.host_config.defense_config;
+        if !dc.brute_force || !is_login_route(ctx) || !is_failed_login_status(status) {
+            return;
+        }
+
+        let window = Duration::from_secs(dc.bf_window_secs);
+        let content_type = ctx.headers.get("content-type").map_or("", String::as_str);
+
+        let Some(username) = extract_credential_field(&ctx.body_preview, content_type, USERNAME_KEYS) else {
+            return;
+        };
+        let user_hash = truncated_hash(&username.to_ascii_lowercase());
+        self.state.record_failed(user_hash, ctx.client_ip, window);
+
+        // Password is optional — sprayer tracking works only when we also
+        // know what was attempted. Legit failed logins without a body-visible
+        // password simply skip the spray counter.
+        if let Some(password) = extract_credential_field(&ctx.body_preview, content_type, PASSWORD_KEYS) {
+            let pwd_hash = truncated_hash(&password);
+            self.state.record_spray(ctx.client_ip, pwd_hash, user_hash, window);
+        }
+    }
+}
+
+fn detection(rule_seq: usize, desc: String) -> DetectionResult {
+    DetectionResult {
+        rule_id: Some(format!("BF-{rule_seq:03}")),
+        rule_name: "Brute Force".to_string(),
+        phase: Phase::BruteForce,
+        detail: desc,
     }
 }
 
 #[cfg(test)]
+#[allow(clippy::duration_suboptimal_units)]
 mod tests {
     use super::*;
+    use crate::checks::test_clock::MockClock;
     use bytes::Bytes;
     use std::collections::HashMap;
     use std::net::IpAddr;
-    use std::sync::Arc;
-    use waf_common::HostConfig;
+    use waf_common::{DefenseConfig, HostConfig};
 
-    fn make_ctx() -> RequestCtx {
+    fn make_ctx(path: &str, body: &[u8], ct: &str, ip: &str) -> RequestCtx {
+        make_ctx_dc(path, body, ct, ip, DefenseConfig::default())
+    }
+
+    fn make_ctx_dc(path: &str, body: &[u8], ct: &str, ip: &str, dc: DefenseConfig) -> RequestCtx {
+        let mut headers = HashMap::new();
+        if !ct.is_empty() {
+            headers.insert("content-type".to_string(), ct.to_string());
+        }
         RequestCtx {
             req_id: "test".to_string(),
-            client_ip: "127.0.0.1".parse::<IpAddr>().unwrap(),
+            client_ip: ip.parse::<IpAddr>().unwrap(),
             client_port: 0,
             method: "POST".to_string(),
             host: "example.com".to_string(),
             port: 80,
-            path: "/login".to_string(),
+            path: path.to_string(),
             query: String::new(),
-            headers: HashMap::new(),
-            body_preview: Bytes::new(),
-            content_length: 0,
+            headers,
+            body_preview: Bytes::copy_from_slice(body),
+            content_length: body.len() as u64,
             is_tls: false,
-            host_config: Arc::new(HostConfig::default()),
+            host_config: Arc::new(HostConfig {
+                defense_config: dc,
+                ..HostConfig::default()
+            }),
             geo: None,
             tier: waf_common::tier::Tier::CatchAll,
             tier_policy: waf_common::RequestCtx::default_tier_policy(),
@@ -67,18 +191,280 @@ mod tests {
     }
 
     #[test]
-    fn stub_returns_none() {
-        let checker = BruteForceCheck::new();
-        let ctx = make_ctx();
+    fn detects_per_user_threshold_on_sixth_attempt() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"wrong"}"#;
+        for _ in 0..5 {
+            let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+        let det = checker.check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BF-001");
+    }
+
+    #[test]
+    fn allows_fifth_attempt_boundary() {
+        // 4 failures, 5th request hits the check — count is 4, threshold is 5,
+        // so still allowed.
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"wrong"}"#;
+        for _ in 0..4 {
+            let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
         assert!(checker.check(&ctx).is_none());
     }
 
     #[test]
-    fn on_response_stub_is_no_op() {
-        // Stub inherits the trait's default no-op; pin it so Phase 07 has a
-        // visible regression target when it overrides.
-        let checker = BruteForceCheck::new();
-        let ctx = make_ctx();
-        checker.on_response(&ctx, 401);
+    fn window_expiry_clears_failures() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock.clone());
+        let body = br#"{"username":"alice","password":"wrong"}"#;
+        for _ in 0..5 {
+            let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        // Default window is 900s; jump well past it.
+        clock.advance(Duration::from_secs(1800));
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn per_ip_isolation() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"wrong"}"#;
+        for _ in 0..5 {
+            let ctx = make_ctx("/login", body, "application/json", "1.1.1.1");
+            checker.on_response(&ctx, 401);
+        }
+        // Different IP — no state.
+        let ctx = make_ctx("/login", body, "application/json", "2.2.2.2");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_password_spray() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        for user in ["charlie", "diana", "eve", "frank", "grace"] {
+            let body = format!(r#"{{"username":"{user}","password":"P@ss1"}}"#);
+            let ctx = make_ctx("/login", body.as_bytes(), "application/json", "9.9.9.9");
+            checker.on_response(&ctx, 401);
+        }
+        // Next request from same IP — spray detected regardless of username.
+        let ctx = make_ctx(
+            "/login",
+            br#"{"username":"zed","password":"anything"}"#,
+            "application/json",
+            "9.9.9.9",
+        );
+        let det = checker.check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BF-002");
+    }
+
+    #[test]
+    fn spray_below_threshold_no_detection() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        for user in ["charlie", "diana", "eve", "frank"] {
+            let body = format!(r#"{{"username":"{user}","password":"P@ss1"}}"#);
+            let ctx = make_ctx("/login", body.as_bytes(), "application/json", "9.9.9.9");
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx(
+            "/login",
+            br#"{"username":"x","password":"y"}"#,
+            "application/json",
+            "9.9.9.9",
+        );
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn success_response_does_not_increment_failures() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"correct"}"#;
+        for _ in 0..10 {
+            let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 200);
+        }
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn status_500_does_not_increment_failures() {
+        // Transient server errors must not count as login failures.
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"x"}"#;
+        for _ in 0..10 {
+            let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 503);
+        }
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn response_on_non_login_route_ignored() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"x"}"#;
+        for _ in 0..10 {
+            let ctx = make_ctx("/api/health", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn disabled_brute_force_kills_all_signals() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let dc = DefenseConfig {
+            brute_force: false,
+            ..DefenseConfig::default()
+        };
+        let body = br#"{"username":"alice","password":"x"}"#;
+        for _ in 0..20 {
+            let ctx = make_ctx_dc("/login", body, "application/json", "5.5.5.5", dc.clone());
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx_dc("/login", body, "application/json", "5.5.5.5", dc);
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn extraction_failure_silently_skips_recording() {
+        // Body missing username — recording is skipped; no threshold hit.
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"token":"xyz"}"#;
+        for _ in 0..20 {
+            let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn case_insensitive_username_hashes_to_same_slot() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        // Three failures under mixed casing.
+        for user in ["Alice", "ALICE", "alice"] {
+            let body = format!(r#"{{"username":"{user}","password":"x"}}"#);
+            let ctx = make_ctx("/login", body.as_bytes(), "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        for _ in 0..2 {
+            let ctx = make_ctx(
+                "/login",
+                br#"{"username":"alice","password":"x"}"#,
+                "application/json",
+                "5.5.5.5",
+            );
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx(
+            "/login",
+            br#"{"username":"alice","password":"x"}"#,
+            "application/json",
+            "5.5.5.5",
+        );
+        let det = checker.check(&ctx).expect("hit after combined 5 failures");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BF-001");
+    }
+
+    #[test]
+    fn form_urlencoded_body_works() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        for _ in 0..5 {
+            let ctx = make_ctx(
+                "/login",
+                b"username=alice&password=wrong",
+                "application/x-www-form-urlencoded",
+                "5.5.5.5",
+            );
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx(
+            "/login",
+            b"username=alice&password=wrong",
+            "application/x-www-form-urlencoded",
+            "5.5.5.5",
+        );
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn route_prefix_match_covers_subpaths() {
+        // `/api/auth/token/refresh` must count for the `/api/auth/token` route.
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"x"}"#;
+        for _ in 0..5 {
+            let ctx = make_ctx("/api/auth/token/refresh", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx("/api/auth/token/refresh", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detection_carries_correct_phase_and_prefix() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"x"}"#;
+        for _ in 0..5 {
+            let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+        let det = checker.check(&ctx).expect("hit");
+        assert_eq!(det.phase, Phase::BruteForce);
+        assert_eq!(det.rule_name, "Brute Force");
+        assert!(det.rule_id.as_deref().unwrap_or("").starts_with("BF-"));
+    }
+
+    #[test]
+    fn empty_login_routes_disables_check() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let dc = DefenseConfig {
+            bf_login_routes: Vec::new(),
+            ..DefenseConfig::default()
+        };
+        let body = br#"{"username":"alice","password":"x"}"#;
+        for _ in 0..10 {
+            let ctx = make_ctx_dc("/login", body, "application/json", "5.5.5.5", dc.clone());
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx_dc("/login", body, "application/json", "5.5.5.5", dc);
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn response_status_403_also_counted() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"x"}"#;
+        for _ in 0..5 {
+            let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 403);
+        }
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_some());
     }
 }

--- a/crates/waf-engine/src/checks/brute_force_extractors.rs
+++ b/crates/waf-engine/src/checks/brute_force_extractors.rs
@@ -1,0 +1,179 @@
+//! Credential extraction + SHA-256 truncation helpers for FR-018.
+//!
+//! Credential material is never retained raw — we hash to a u64 before any
+//! map insertion so leaked state doesn't leak plaintext usernames/passwords
+//! (GDPR posture; also keeps memory flat).
+
+use sha2::{Digest, Sha256};
+
+/// Truncate a SHA-256 digest to its leading 8 bytes as `u64`. Cheap, stable
+/// across restarts within a process — and we never persist the hash, so
+/// inter-restart portability is not required.
+pub fn truncated_hash(s: &str) -> u64 {
+    let mut hasher = Sha256::new();
+    hasher.update(s.as_bytes());
+    let digest = hasher.finalize();
+    // SHA-256 always yields 32 bytes, so `.get(..8)` is guaranteed Some; the
+    // explicit `get`/`unwrap_or_default` keeps us on the indexing-safe side
+    // of the `clippy::indexing_slicing` lint without introducing a panic path.
+    let mut buf = [0u8; 8];
+    let head = digest.get(..8).unwrap_or(&[0u8; 8][..]);
+    buf.copy_from_slice(head);
+    u64::from_be_bytes(buf)
+}
+
+/// Pull a credential-like field (username/email/password) from a request
+/// body. Handles both `application/json` (objects only) and
+/// `application/x-www-form-urlencoded`.
+///
+/// Case-insensitive key match so `{"Username":"x"}` and `{"username":"x"}`
+/// hash identically.
+pub fn extract_credential_field(body: &[u8], content_type: &str, candidates: &[&str]) -> Option<String> {
+    let ct = content_type.split(';').next().unwrap_or("").trim().to_ascii_lowercase();
+    if ct == "application/json" || ct.ends_with("+json") {
+        let v: serde_json::Value = serde_json::from_slice(body).ok()?;
+        if let serde_json::Value::Object(map) = v {
+            for (k, val) in &map {
+                if candidates.iter().any(|c| k.eq_ignore_ascii_case(c))
+                    && let serde_json::Value::String(s) = val
+                {
+                    return Some(s.clone());
+                }
+            }
+        }
+        return None;
+    }
+    if ct == "application/x-www-form-urlencoded" {
+        for (k, v) in url::form_urlencoded::parse(body) {
+            if candidates.iter().any(|c| k.eq_ignore_ascii_case(c)) {
+                return Some(v.into_owned());
+            }
+        }
+    }
+    None
+}
+
+/// Username candidate keys tried in order.
+pub const USERNAME_KEYS: &[&str] = &["username", "email", "user", "login"];
+
+/// Password candidate keys tried in order.
+pub const PASSWORD_KEYS: &[&str] = &["password", "passwd", "pass"];
+
+/// Login response is treated as failed when status is 401 or 403. Body-based
+/// detection is intentionally not supported in v1 — Pingora `response_filter`
+/// exposes status + headers only (Red Team Finding #8), and body-regex on
+/// upstream error pages is a known victim-account-lockout primitive
+/// (Finding #11).
+pub const fn is_failed_login_status(status: u16) -> bool {
+    matches!(status, 401 | 403)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncated_hash_stable_for_same_input() {
+        assert_eq!(truncated_hash("alice"), truncated_hash("alice"));
+    }
+
+    #[test]
+    fn truncated_hash_differs_across_input() {
+        assert_ne!(truncated_hash("alice"), truncated_hash("bob"));
+    }
+
+    #[test]
+    fn extract_username_from_json_object() {
+        let body = br#"{"username":"alice","password":"secret"}"#;
+        assert_eq!(
+            extract_credential_field(body, "application/json", USERNAME_KEYS).as_deref(),
+            Some("alice")
+        );
+    }
+
+    #[test]
+    fn extract_email_as_username() {
+        let body = br#"{"email":"a@b.z","password":"pw"}"#;
+        assert_eq!(
+            extract_credential_field(body, "application/json", USERNAME_KEYS).as_deref(),
+            Some("a@b.z")
+        );
+    }
+
+    #[test]
+    fn extract_case_insensitive_key() {
+        let body = br#"{"Username":"BOB"}"#;
+        assert_eq!(
+            extract_credential_field(body, "application/json", USERNAME_KEYS).as_deref(),
+            Some("BOB")
+        );
+    }
+
+    #[test]
+    fn extract_password_key() {
+        let body = br#"{"username":"alice","password":"P@ss1"}"#;
+        assert_eq!(
+            extract_credential_field(body, "application/json", PASSWORD_KEYS).as_deref(),
+            Some("P@ss1")
+        );
+    }
+
+    #[test]
+    fn extract_form_urlencoded_username() {
+        let body = b"username=alice&password=secret";
+        assert_eq!(
+            extract_credential_field(body, "application/x-www-form-urlencoded", USERNAME_KEYS).as_deref(),
+            Some("alice")
+        );
+    }
+
+    #[test]
+    fn extract_form_with_charset() {
+        let body = b"username=alice&password=secret";
+        assert_eq!(
+            extract_credential_field(body, "application/x-www-form-urlencoded; charset=utf-8", USERNAME_KEYS)
+                .as_deref(),
+            Some("alice")
+        );
+    }
+
+    #[test]
+    fn extract_returns_none_on_missing_key() {
+        let body = br#"{"token":"xyz"}"#;
+        assert!(extract_credential_field(body, "application/json", USERNAME_KEYS).is_none());
+    }
+
+    #[test]
+    fn extract_returns_none_on_malformed_json() {
+        let body = b"not-json-at-all";
+        assert!(extract_credential_field(body, "application/json", USERNAME_KEYS).is_none());
+    }
+
+    #[test]
+    fn extract_returns_none_on_unsupported_content_type() {
+        let body = br#"{"username":"alice"}"#;
+        assert!(extract_credential_field(body, "text/plain", USERNAME_KEYS).is_none());
+    }
+
+    #[test]
+    fn extract_returns_none_when_value_not_string() {
+        let body = br#"{"username":123}"#;
+        assert!(extract_credential_field(body, "application/json", USERNAME_KEYS).is_none());
+    }
+
+    #[test]
+    fn extract_returns_none_for_json_array_root() {
+        // Root is an array, not an object — no key lookup possible.
+        let body = br#"[{"username":"x"}]"#;
+        assert!(extract_credential_field(body, "application/json", USERNAME_KEYS).is_none());
+    }
+
+    #[test]
+    fn is_failed_login_status_boundaries() {
+        assert!(is_failed_login_status(401));
+        assert!(is_failed_login_status(403));
+        assert!(!is_failed_login_status(400));
+        assert!(!is_failed_login_status(200));
+        assert!(!is_failed_login_status(500));
+    }
+}

--- a/crates/waf-engine/src/checks/brute_force_state.rs
+++ b/crates/waf-engine/src/checks/brute_force_state.rs
@@ -1,0 +1,332 @@
+//! Sliding-window state for FR-018 brute force / credential stuffing.
+//!
+//! Two maps, keyed differently:
+//! - `failed` keyed by `(user_hash, client_ip)` → deque of recent failure
+//!   timestamps. A request into a login route is blocked when the in-window
+//!   count exceeds `bf_max_per_user`.
+//! - `spray` keyed by `(client_ip, password_hash)` → set of usernames tried.
+//!   When one password hits `>= bf_spray_threshold` distinct users from one
+//!   IP inside the window, any subsequent login from that IP is blocked.
+//!
+//! Both maps are bounded (Red Team Finding #6) — when they exceed
+//! `max_entries` the oldest 10 percent are evicted by last-touched.
+//!
+//! Time comes from the Phase 00 `Clock` trait so tests advance the window
+//! without sleeping (Validation Q7).
+//
+// `significant_drop_tightening` fires on the DashMap entry held across a
+// Mutex lock — restructuring would cost an Arc<Mutex> per record for no
+// throughput win. `option_if_let_else` rewrites add a closure per call site
+// that is less readable than the match form we use.
+#![allow(clippy::significant_drop_tightening, clippy::option_if_let_else)]
+
+use std::collections::{HashSet, VecDeque};
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+use parking_lot::Mutex;
+
+use super::Clock;
+
+struct FailedRecord {
+    hits: VecDeque<Instant>,
+    last_touched: Instant,
+}
+
+struct SprayRecord {
+    users: HashSet<u64>,
+    last_touched: Instant,
+}
+
+pub struct BfState {
+    failed: Arc<DashMap<(u64, IpAddr), Mutex<FailedRecord>>>,
+    spray: Arc<DashMap<(IpAddr, u64), Mutex<SprayRecord>>>,
+    max_entries: usize,
+    clock: Arc<dyn Clock>,
+}
+
+/// Cap per (ip, password) spray set — well above any reasonable threshold,
+/// prevents unbounded growth when someone hammers `P@ss1` across thousands
+/// of usernames.
+const SPRAY_USERS_CAP: usize = 1000;
+/// Cap per (user, ip) failed-login deque — well above
+/// `bf_max_per_user * 4` so boundary tests still have headroom but adversaries
+/// can't grow this deque without bound.
+const FAILED_HITS_CAP: usize = 64;
+
+impl BfState {
+    pub fn new(max_entries: usize, clock: Arc<dyn Clock>) -> Self {
+        Self {
+            failed: Arc::new(DashMap::new()),
+            spray: Arc::new(DashMap::new()),
+            max_entries,
+            clock,
+        }
+    }
+
+    pub fn record_failed(&self, user_hash: u64, ip: IpAddr, window: Duration) {
+        self.evict_if_over_cap_failed();
+        let now = self.clock.now();
+        let entry = self.failed.entry((user_hash, ip)).or_insert_with(|| {
+            Mutex::new(FailedRecord {
+                hits: VecDeque::new(),
+                last_touched: now,
+            })
+        });
+        let mut rec = entry.lock();
+        rec.last_touched = now;
+        rec.hits.push_back(now);
+        Self::prune_hits(&mut rec.hits, now, window);
+        while rec.hits.len() > FAILED_HITS_CAP {
+            rec.hits.pop_front();
+        }
+    }
+
+    pub fn failed_count(&self, user_hash: u64, ip: IpAddr, window: Duration) -> usize {
+        let now = self.clock.now();
+        match self.failed.get(&(user_hash, ip)) {
+            Some(entry) => {
+                let mut rec = entry.lock();
+                Self::prune_hits(&mut rec.hits, now, window);
+                rec.hits.len()
+            }
+            None => 0,
+        }
+    }
+
+    pub fn record_spray(&self, ip: IpAddr, password_hash: u64, user_hash: u64, window: Duration) -> usize {
+        self.evict_if_over_cap_spray();
+        let now = self.clock.now();
+        let entry = self.spray.entry((ip, password_hash)).or_insert_with(|| {
+            Mutex::new(SprayRecord {
+                users: HashSet::new(),
+                last_touched: now,
+            })
+        });
+        let mut rec = entry.lock();
+        if rec.last_touched + window < now {
+            // Whole window has passed since last touch — reset.
+            rec.users.clear();
+        }
+        rec.last_touched = now;
+        if rec.users.len() < SPRAY_USERS_CAP {
+            rec.users.insert(user_hash);
+        }
+        rec.users.len()
+    }
+
+    pub fn spray_count(&self, ip: IpAddr, password_hash: u64, window: Duration) -> usize {
+        let now = self.clock.now();
+        match self.spray.get(&(ip, password_hash)) {
+            Some(entry) => {
+                let rec = entry.lock();
+                if rec.last_touched + window < now {
+                    0
+                } else {
+                    rec.users.len()
+                }
+            }
+            None => 0,
+        }
+    }
+
+    /// Return the count of unique passwords sprayed from `ip` (across all
+    /// password hashes currently tracked) whose distinct-user set has reached
+    /// `threshold`. Used by the request-phase dispatcher to detect spraying
+    /// without needing the incoming request's password.
+    pub fn any_spray_over_threshold(&self, ip: IpAddr, threshold: usize, window: Duration) -> bool {
+        let now = self.clock.now();
+        self.spray.iter().any(|kv| {
+            let (entry_ip, _) = kv.key();
+            if *entry_ip != ip {
+                return false;
+            }
+            let rec = kv.value().lock();
+            rec.last_touched + window >= now && rec.users.len() >= threshold
+        })
+    }
+
+    fn prune_hits(hits: &mut VecDeque<Instant>, now: Instant, window: Duration) {
+        let cutoff = now.checked_sub(window).unwrap_or(now);
+        while hits.front().is_some_and(|t| *t < cutoff) {
+            hits.pop_front();
+        }
+    }
+
+    fn evict_if_over_cap_failed(&self) {
+        if self.failed.len() <= self.max_entries {
+            return;
+        }
+        let mut ages: Vec<((u64, IpAddr), Instant)> = self
+            .failed
+            .iter()
+            .map(|kv| (*kv.key(), kv.value().lock().last_touched))
+            .collect();
+        ages.sort_by_key(|(_, t)| *t);
+        let drop_n = ages.len() / 10;
+        for (key, _) in ages.into_iter().take(drop_n) {
+            self.failed.remove(&key);
+        }
+    }
+
+    fn evict_if_over_cap_spray(&self) {
+        if self.spray.len() <= self.max_entries {
+            return;
+        }
+        let mut ages: Vec<((IpAddr, u64), Instant)> = self
+            .spray
+            .iter()
+            .map(|kv| (*kv.key(), kv.value().lock().last_touched))
+            .collect();
+        ages.sort_by_key(|(_, t)| *t);
+        let drop_n = ages.len() / 10;
+        for (key, _) in ages.into_iter().take(drop_n) {
+            self.spray.remove(&key);
+        }
+    }
+
+    pub fn prune_older_than(&self, cutoff: Instant) {
+        self.failed.retain(|_, rec| rec.lock().last_touched >= cutoff);
+        self.spray.retain(|_, rec| rec.lock().last_touched >= cutoff);
+    }
+
+    pub fn failed_len(&self) -> usize {
+        self.failed.len()
+    }
+
+    pub fn spray_len(&self) -> usize {
+        self.spray.len()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::duration_suboptimal_units, clippy::redundant_clone)]
+mod tests {
+    use super::*;
+    use crate::checks::test_clock::MockClock;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn failed_count_grows_and_window_expires() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(1000, clock.clone());
+        for _ in 0..5 {
+            s.record_failed(42, ip("1.1.1.1"), Duration::from_secs(900));
+        }
+        assert_eq!(s.failed_count(42, ip("1.1.1.1"), Duration::from_secs(900)), 5);
+        clock.advance(Duration::from_secs(1800));
+        assert_eq!(s.failed_count(42, ip("1.1.1.1"), Duration::from_secs(900)), 0);
+    }
+
+    #[test]
+    fn failed_isolation_by_user_and_ip() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(1000, clock.clone());
+        for _ in 0..5 {
+            s.record_failed(42, ip("1.1.1.1"), Duration::from_secs(900));
+        }
+        assert_eq!(s.failed_count(42, ip("1.1.1.1"), Duration::from_secs(900)), 5);
+        assert_eq!(s.failed_count(43, ip("1.1.1.1"), Duration::from_secs(900)), 0);
+        assert_eq!(s.failed_count(42, ip("2.2.2.2"), Duration::from_secs(900)), 0);
+    }
+
+    #[test]
+    fn spray_counts_distinct_users() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(1000, clock.clone());
+        for user in 0..5_u64 {
+            s.record_spray(ip("9.9.9.9"), 0xdead_beef, user, Duration::from_secs(300));
+        }
+        assert_eq!(s.spray_count(ip("9.9.9.9"), 0xdead_beef, Duration::from_secs(300)), 5);
+    }
+
+    #[test]
+    fn spray_dedups_same_user() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(1000, clock.clone());
+        for _ in 0..10 {
+            s.record_spray(ip("9.9.9.9"), 0xdead, 1, Duration::from_secs(300));
+        }
+        assert_eq!(s.spray_count(ip("9.9.9.9"), 0xdead, Duration::from_secs(300)), 1);
+    }
+
+    #[test]
+    fn spray_window_expires() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(1000, clock.clone());
+        for user in 0..5_u64 {
+            s.record_spray(ip("9.9.9.9"), 0xbeef, user, Duration::from_secs(300));
+        }
+        clock.advance(Duration::from_secs(600));
+        assert_eq!(s.spray_count(ip("9.9.9.9"), 0xbeef, Duration::from_secs(300)), 0);
+    }
+
+    #[test]
+    fn any_spray_over_threshold_detects_cross_password() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(1000, clock.clone());
+        // Two separate passwords, each reaching threshold against same IP.
+        for user in 0..5_u64 {
+            s.record_spray(ip("9.9.9.9"), 0xdead, user, Duration::from_secs(300));
+        }
+        assert!(s.any_spray_over_threshold(ip("9.9.9.9"), 5, Duration::from_secs(300)));
+        assert!(!s.any_spray_over_threshold(ip("9.9.9.9"), 6, Duration::from_secs(300)));
+        assert!(!s.any_spray_over_threshold(ip("8.8.8.8"), 5, Duration::from_secs(300)));
+    }
+
+    #[test]
+    fn failed_caps_hits_deque() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(1000, clock.clone());
+        for _ in 0..(FAILED_HITS_CAP + 20) {
+            s.record_failed(42, ip("1.1.1.1"), Duration::from_secs(900));
+        }
+        assert!(s.failed_count(42, ip("1.1.1.1"), Duration::from_secs(900)) <= FAILED_HITS_CAP);
+    }
+
+    #[test]
+    fn failed_map_caps_at_max_entries() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(50, clock.clone());
+        for i in 0..200_u64 {
+            s.record_failed(
+                i,
+                ip(&format!("10.0.{}.{}", i / 256, i % 256)),
+                Duration::from_secs(900),
+            );
+        }
+        assert!(s.failed_len() <= 50, "len={} exceeds cap", s.failed_len());
+    }
+
+    #[test]
+    fn spray_map_caps_at_max_entries() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(50, clock.clone());
+        for i in 0..200_u64 {
+            s.record_spray(
+                ip(&format!("10.0.{}.{}", i / 256, i % 256)),
+                0xaa,
+                i,
+                Duration::from_secs(300),
+            );
+        }
+        assert!(s.spray_len() <= 50, "spray_len={} exceeds cap", s.spray_len());
+    }
+
+    #[test]
+    fn prune_older_than_drops_stale() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(1000, clock.clone());
+        s.record_failed(1, ip("1.1.1.1"), Duration::from_secs(900));
+        clock.advance(Duration::from_secs(3600));
+        s.record_failed(2, ip("2.2.2.2"), Duration::from_secs(900));
+        let cutoff = clock.now().checked_sub(Duration::from_secs(1800)).unwrap();
+        s.prune_older_than(cutoff);
+        assert_eq!(s.failed_len(), 1);
+    }
+}

--- a/crates/waf-engine/src/checks/mod.rs
+++ b/crates/waf-engine/src/checks/mod.rs
@@ -2,6 +2,8 @@ pub mod anti_hotlink;
 pub mod body_abuse;
 pub mod bot;
 pub mod brute_force;
+pub(crate) mod brute_force_extractors;
+pub(crate) mod brute_force_state;
 pub mod cc;
 pub mod dir_traversal;
 pub mod geo;

--- a/plans/260502-0750-fr014-fr020-detection/plan.md
+++ b/plans/260502-0750-fr014-fr020-detection/plan.md
@@ -38,7 +38,7 @@ Ship 7 production P0 detection checks (FR-014..FR-020) for prx-waf with extensib
 | 04 | [phase-04-fr017-header-injection-new.md](phase-04-fr017-header-injection-new.md) | `feat/fr-017-header-injection` | FR-017 | pending | TBD |
 | 05 | [phase-05-fr019-scanner-enhance.md](phase-05-fr019-scanner-enhance.md) | `feat/fr-019-scanner-recon` | FR-019 | pending | TBD |
 | 06 | [phase-06-fr020-body-abuse-new.md](phase-06-fr020-body-abuse-new.md) | `feat/fr-020-body-abuse` | FR-020 | pending | TBD |
-| 07 | [phase-07-fr018-brute-force-new.md](phase-07-fr018-brute-force-new.md) | `feat/fr-018-brute-force` | FR-018 | pending | TBD |
+| 07 | [phase-07-fr018-brute-force-new.md](phase-07-fr018-brute-force-new.md) | `feat/fr-018-brute-force` | FR-018 | code-complete (PR stacked on Phase 00) | lotus |
 | 08 | [phase-08-integration-and-bench.md](phase-08-integration-and-bench.md) | `feat/fr-frame-integration-tests` | — | pending | TBD |
 
 Phases 01-07 run in parallel after Phase 00 merges. Phase 08 runs after all 01-07 merge.


### PR DESCRIPTION
## Summary

Phase 07 of the FR-014..FR-020 detection plan. Replaces the Phase 00 `BruteForceCheck` stub with the full check, consuming the `Check::on_response` default hook that Phase 00 added.

### Detection rules

**Request phase** (`Check::check`, login routes only):

- **BF-001** — `(user_hash, client_ip)` failure counter ≥ `bf_max_per_user` (default 5) inside `bf_window_secs` (default 900s).
- **BF-002** — any password sprayed against ≥ `bf_spray_threshold` (default 5) distinct users from same IP inside the window. Detection does not depend on the incoming request's password; the IP alone is enough once the threshold is hit.

**Response phase** (`Check::on_response`, status-code-only v1):

- On **401** or **403** AND login route, extract `username` + `password` from the body (`application/json` or `application/x-www-form-urlencoded`) and record a failure. Successful logins (2xx) and transient errors (5xx) are ignored — conservative on purpose.

### Red Team fixes applied

- **Finding #8** — body-regex failure detection NOT implemented. Pingora `response_filter` exposes headers + status only; adding body-aware detection needs a gateway PR. Documented in module header.
- **Finding #11** — generic `(invalid|failed|incorrect|denied)` body regex is weaponizable as a victim-account lockout primitive. Status-code-only avoids that vector entirely.
- **Finding #6** — both DashMaps (`failed`, `spray`) bounded at `max_entries` (default 100k) with oldest-10%-sampled eviction. Per-key deques / hashsets also capped (`FAILED_HITS_CAP=64`, `SPRAY_USERS_CAP=1000`).
- **Finding #14** — no `tokio::spawn` from `Check::new`. `state()` exposes `Arc<BfState>` so the engine bootstrap can drive `prune_older_than` from a controlled context.

### Privacy

Usernames and passwords are SHA-256-truncated to `u64` before any map insertion. Leaked state never leaks plaintext credentials. Username matching lowercases the input so `Alice` / `alice` / `ALICE` all hash to the same slot.

### Files

- `crates/waf-engine/src/checks/brute_force.rs` — replaces stub; dispatcher + `on_response`. 20 tests.
- `crates/waf-engine/src/checks/brute_force_state.rs` (new) — `BfState` sliding-window maps. 11 tests.
- `crates/waf-engine/src/checks/brute_force_extractors.rs` (new) — credential extraction, `truncated_hash`, `is_failed_login_status`. 14 tests.
- `crates/waf-engine/Cargo.toml` — adds `sha2` (already a workspace dep, now consumed here).

### Tests — 41 total

Boundary (5th allowed, 6th blocks), window expiry, per-IP isolation, password spray, spray-below-threshold, success ignored, 5xx ignored, non-login route ignored, disabled toggle, extraction failure silently skipped, case-insensitive username hashing, form-urlencoded body, login-route prefix match, correct phase/rule_id, empty `bf_login_routes` disables, 403 also counted. Plus 11 state-level tests (`failed_count`, `spray_count`, caps, prune) and 14 extractor tests (hash stability, JSON/form/multipart extraction, case-insensitive keys, status boundaries).

## Stacked on #28

Base is `feat/fr-frame-detection-framework`. Rebase to `main` once #28 merges.

## Gateway wiring — deferred to Phase 08

The `Check::on_response` trait method is implemented and unit-tested via direct calls. Wiring the gateway's Pingora `response_filter` callback to loop over `engine.checkers` and call `on_response(ctx, status)` is a cross-crate change that lands in Phase 08 (integration) alongside the end-to-end harness. Until then, BF-001/BF-002 request-phase logic is reachable by tests (proven) but not yet fed by live upstream responses.

## Verified

- `cargo fmt --all -- --check` rc=0
- `cargo clippy --workspace --all-targets -- -D warnings` rc=0 on rust:1.95-slim-bookworm
- `cargo test -p waf-engine --lib checks::brute_force` 41/41

## Test plan

- [ ] CI lint + test + build green
- [ ] Coverage gate informational (see #28 for deferred baseline-raise work)
- [ ] Manual: run Phase 08 e2e once it lands — 6 × invalid login → 6th gets blocked

## Out of scope (v1, documented)

- Distributed brute force across rotating IPs (same-IP only for v1).
- Backends returning HTTP 200 with a JSON error envelope (e.g. GraphQL) bypass FR-018 v1. Operator must wrap such backends in a 401-translating middleware or wait for body-aware FR-018-v2.
- Shared-account scenarios (kiosk logins) — default threshold of 5 is conservative; operator can tune via `bf_max_per_user`.