### PR TITLE
feat(waf-engine): FR-014..FR-020 P0 detection suite (consolidated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,54 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   `plans/260504-1632-fr-012-transaction-velocity/`. Deferred follow-ups:
   response-side `ok` enrichment (failed-login signal), Redis-backed `TxStore`
   for cluster-shared state.
+- **FR-014 XSS enhance** — iterative JSON walker (hard depth cap 64 so the
+  engine cannot stack-overflow on malicious nesting), form-urlencoded
+  scanner, Content-Type-aware dispatch. `text/markdown` body-skip mitigates
+  false positives on code-block snippets.
+- **FR-015 path traversal enhance** — adopts shared `request_targets()` so
+  recursive-decoded variants are covered (`%252e%252e` no longer slips
+  past); new anchored patterns for `/etc/<sensitive>`, `/proc/<pid>/…`,
+  `\windows\system32`, `boot.ini` / `win.ini`.
+- **FR-016 SSRF detection (NEW)** — RFC1918 / loopback / link-local / cloud
+  metadata (AWS `169.254.169.254`, GCP, Alibaba `100.100.100.200`, Consul);
+  obfuscated IPs (hex, octal, decimal dword, IPv6-mapped). Userinfo bypass
+  `http://google.com@169.254.169.254/` resolves to the metadata IP via
+  `url::Url::host()`. Opt-in allowlist via
+  `defense_config.ssrf_outbound_host_allowlist`.
+- **FR-017 header injection (NEW)** — raw + `%0d%0a` / `%250d%250a` CRLF in
+  header values and names; `Host` header whitelist (`host_inbound_whitelist`)
+  with IPv6-bracket awareness; `X-Forwarded-For` leftmost-private + max-hops.
+- **FR-018 brute force + credential stuffing (NEW)** — consumes the
+  `Check::on_response` default hook. BF-001: `(user_hash, ip)` failure
+  counter ≥ `bf_max_per_user`. BF-002: password sprayed against ≥
+  `bf_spray_threshold` distinct users from same IP. Status-code-only v1
+  (401/403); body-regex deferred. Credentials hashed via keyed `ahash`
+  (stronger against precomputation than unkeyed SHA-256-truncated) — never
+  plaintext in state. **Wired-but-inert in v1**: `WafEngine::on_response`
+  dispatcher ships, but the gateway's Pingora `response_filter` does not yet
+  invoke it (cross-crate edit deferred to a follow-up PR). FR-018 detection
+  is dormant in production until that wiring lands; the periodic
+  `BfState::prune_older_than` task is also deferred to the same follow-up.
+- **FR-019 scanner recon enhance** — per-IP sliding-window state with
+  endpoint enumeration (distinct-path threshold) and OPTIONS preflight
+  abuse. Bounded at `scanner_max_ips` (default 100k) with oldest-10%
+  eviction against IPv6-rotating OOM vector.
+- **FR-020 request body abuse (NEW)** — declared `Content-Length` size
+  gate (64 KiB to match gateway `BODY_PREVIEW_LIMIT`), magic-byte
+  Content-Type mismatch (JSON/XML/HTML/ZIP/GZIP), iterative byte-scan JSON
+  depth pre-check (bails before any parser allocation), key-count explosion
+  via iterative `Value` walker.
+- **Detection framework** — `Phase` enum gets 4 new variants (`Ssrf`,
+  `HeaderInjection`, `BruteForce`, `RequestBodyAbuse`). `Check` trait
+  extended with default-impl `on_response(&self, _ctx, _status)` hook.
+  `WafEngine::on_response(ctx, status)` dispatcher for gateway wiring.
+  `Clock` trait + `SystemClock` + `MockClock` test fixture so stateful
+  checks advance time deterministically without sleeping.
+- **Coverage infra** — `Dockerfile.coverage` (rust:1.91 + `cargo-llvm-cov`
+  0.8.5 pinned), `scripts/coverage-gate.sh` + smoke fixtures,
+  `scripts/create-worktrees.sh` + `setup-worktree-env.sh`, CI `coverage`
+  job (informational — gate flips to enforcing after the waf-engine
+  baseline-raise follow-up lands).
 
 - **FR-008 access lists** — Phase-0 gate ahead of the 16-phase rule pipeline:
   per-tier IP whitelist (Patricia trie via `ip_network_table`), IP blacklist,

--- a/crates/waf-common/src/types.rs
+++ b/crates/waf-common/src/types.rs
@@ -165,6 +165,14 @@ pub enum Phase {
     Ddos = 19,
     /// Cumulative risk scoring (FR-025)
     RiskScore = 20,
+    /// Server-Side Request Forgery (FR-016)
+    Ssrf = 21,
+    /// HTTP header injection / smuggling (FR-017)
+    HeaderInjection = 22,
+    /// Authentication brute-force / credential spraying (FR-018)
+    BruteForce = 23,
+    /// Oversized / deeply-nested request body abuse (FR-020)
+    RequestBodyAbuse = 24,
 }
 
 impl std::fmt::Display for Phase {
@@ -190,6 +198,10 @@ impl std::fmt::Display for Phase {
             Self::Community => write!(f, "Community"),
             Self::Ddos => write!(f, "DDoS"),
             Self::RiskScore => write!(f, "Risk Score"),
+            Self::Ssrf => write!(f, "SSRF"),
+            Self::HeaderInjection => write!(f, "Header Injection"),
+            Self::BruteForce => write!(f, "Brute Force"),
+            Self::RequestBodyAbuse => write!(f, "Request Body Abuse"),
         }
     }
 }
@@ -352,6 +364,78 @@ pub struct DefenseConfig {
     /// always on regardless of this flag.
     #[serde(default = "bool_false")]
     pub block_scripted_clients: bool,
+
+    // ── FR-016 SSRF ──────────────────────────────────────────────────────
+    #[serde(default = "bool_true")]
+    pub ssrf: bool,
+    /// DNS resolution timeout (ms) for SSRF host validation.
+    ///
+    /// **v1**: DNS-rebinding mitigation is deferred (plan §Out of Scope).
+    /// Reserved for FR-016b; ignored in v1.
+    #[serde(default = "default_ssrf_dns_timeout_ms")]
+    pub ssrf_dns_timeout_ms: u64,
+    /// Outbound host allow-list: hosts permitted despite RFC1918 / loopback
+    /// match (e.g. internal services intentionally reached via private IP).
+    #[serde(default)]
+    pub ssrf_outbound_host_allowlist: Vec<String>,
+
+    // ── FR-017 Header injection ──────────────────────────────────────────
+    #[serde(default = "bool_true")]
+    pub header_injection: bool,
+    #[serde(default = "default_xf2_max_hops")]
+    pub xf2_max_hops: usize,
+    /// Inbound `Host` header whitelist. Empty disables host validation.
+    #[serde(default)]
+    pub host_inbound_whitelist: Vec<String>,
+
+    // ── FR-018 Brute force ───────────────────────────────────────────────
+    #[serde(default = "bool_true")]
+    pub brute_force: bool,
+    #[serde(default = "default_bf_window_secs")]
+    pub bf_window_secs: u64,
+    #[serde(default = "default_bf_max_per_user")]
+    pub bf_max_per_user: usize,
+    #[serde(default = "default_bf_spray_threshold")]
+    pub bf_spray_threshold: usize,
+    #[serde(default = "default_bf_login_routes")]
+    pub bf_login_routes: Vec<String>,
+
+    // ── FR-019 Scanner sliding-window state ──────────────────────────────
+    /// Sliding-window length (seconds) for endpoint-enum + OPTIONS-abuse
+    /// detection. Same value used for both — keeps the config terse.
+    #[serde(default = "default_scanner_window_secs")]
+    pub scanner_window_secs: u64,
+    /// Distinct paths from a single `client_ip` in the window above before
+    /// the scanner check fires.
+    #[serde(default = "default_scanner_endpoint_enum_threshold")]
+    pub scanner_endpoint_enum_threshold: usize,
+    /// OPTIONS requests from a single `client_ip` in the window above
+    /// before the scanner check fires (CORS preflight is the legitimate cap).
+    #[serde(default = "default_scanner_options_threshold")]
+    pub scanner_options_threshold: usize,
+    /// Hard cap on per-IP entries kept in `ScannerState`. Beyond this the
+    /// oldest 10% (by last-touched timestamp) are evicted to prevent an
+    /// IPv6-rotating attacker from OOM-ing the WAF (Red Team Finding #6).
+    ///
+    /// **v1**: per-host overrides are NOT threaded through to the
+    /// process-global `ScannerState`; the default (100k) is always used.
+    /// Setting this in per-host TOML is a no-op until a follow-up PR
+    /// wires per-host caps.
+    #[serde(default = "default_scanner_max_ips")]
+    pub scanner_max_ips: usize,
+
+    // ── FR-020 Request body abuse ────────────────────────────────────────
+    #[serde(default = "bool_true")]
+    pub body_abuse: bool,
+    /// Hard ceiling on inspected body bytes. Defaults to 64 KiB to match the
+    /// gateway's `BODY_PREVIEW_LIMIT`; bumping it only matters once that cap
+    /// is also raised upstream.
+    #[serde(default = "default_max_body_size")]
+    pub max_body_size: usize,
+    #[serde(default = "default_max_json_depth")]
+    pub max_json_depth: usize,
+    #[serde(default = "default_max_json_keys")]
+    pub max_json_keys: usize,
 }
 
 const fn bool_true() -> bool {
@@ -375,6 +459,45 @@ const fn default_cc_ban_duration_secs() -> u64 {
 const fn default_owasp_paranoia() -> u8 {
     1
 }
+const fn default_ssrf_dns_timeout_ms() -> u64 {
+    50
+}
+const fn default_xf2_max_hops() -> usize {
+    5
+}
+const fn default_bf_window_secs() -> u64 {
+    900
+}
+const fn default_bf_max_per_user() -> usize {
+    5
+}
+const fn default_bf_spray_threshold() -> usize {
+    5
+}
+fn default_bf_login_routes() -> Vec<String> {
+    vec!["/login".to_string(), "/api/auth/token".to_string()]
+}
+const fn default_scanner_window_secs() -> u64 {
+    60
+}
+const fn default_scanner_endpoint_enum_threshold() -> usize {
+    30
+}
+const fn default_scanner_options_threshold() -> usize {
+    20
+}
+const fn default_scanner_max_ips() -> usize {
+    100_000
+}
+const fn default_max_body_size() -> usize {
+    64 * 1024
+}
+const fn default_max_json_depth() -> usize {
+    100
+}
+const fn default_max_json_keys() -> usize {
+    10_000
+}
 
 impl Default for DefenseConfig {
     fn default() -> Self {
@@ -394,6 +517,25 @@ impl Default for DefenseConfig {
             cc_ban_duration_secs: default_cc_ban_duration_secs(),
             block_scripted_clients: false,
             owasp_paranoia: default_owasp_paranoia(),
+            ssrf: true,
+            ssrf_dns_timeout_ms: default_ssrf_dns_timeout_ms(),
+            ssrf_outbound_host_allowlist: Vec::new(),
+            header_injection: true,
+            xf2_max_hops: default_xf2_max_hops(),
+            host_inbound_whitelist: Vec::new(),
+            brute_force: true,
+            bf_window_secs: default_bf_window_secs(),
+            bf_max_per_user: default_bf_max_per_user(),
+            bf_spray_threshold: default_bf_spray_threshold(),
+            bf_login_routes: default_bf_login_routes(),
+            scanner_window_secs: default_scanner_window_secs(),
+            scanner_endpoint_enum_threshold: default_scanner_endpoint_enum_threshold(),
+            scanner_options_threshold: default_scanner_options_threshold(),
+            scanner_max_ips: default_scanner_max_ips(),
+            body_abuse: true,
+            max_body_size: default_max_body_size(),
+            max_json_depth: default_max_json_depth(),
+            max_json_keys: default_max_json_keys(),
         }
     }
 }

--- a/crates/waf-engine/src/checks/body_abuse.rs
+++ b/crates/waf-engine/src/checks/body_abuse.rs
@@ -1,0 +1,374 @@
+//! Request body abuse detection (FR-020).
+//!
+//! Five rules run in cheap-to-expensive order:
+//!
+//! 1. Oversized — declared `Content-Length` > `defense_config.max_body_size`.
+//!    Uses the header (NOT `body_preview.len()`) because Pingora truncates
+//!    `body_preview` at 64 KiB; a declared 1 MiB `content_length` must
+//!    still be flagged (Red Team Finding #5).
+//! 2. Content-Type mismatch — magic-byte sniff disagrees with declared
+//!    type. Only fires when both sides land in a known category so a
+//!    generic `text/plain` body does not false-flag.
+//! 3. JSON depth pre-check — byte-scan counts `{` / `[` nesting and bails
+//!    the moment it crosses `max_json_depth`, before any parse/allocation
+//!    (Finding #3 — `serde_json` has no `set_recursion_limit` API).
+//! 4. JSON parse — only after pre-check passes. Parse failure → block.
+//! 5. JSON key explosion — iterative walker over the parsed `Value` bails
+//!    when cumulative key count exceeds `max_json_keys`.
+
+use waf_common::{DetectionResult, Phase, RequestCtx};
+
+use super::Check;
+use super::body_abuse_walker::{
+    BodyAbuseViolation, declared_body_kind, precheck_json_depth, sniff_body_kind, walk_count_keys,
+};
+
+pub struct RequestBodyAbuseCheck;
+
+impl RequestBodyAbuseCheck {
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for RequestBodyAbuseCheck {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Check for RequestBodyAbuseCheck {
+    fn check(&self, ctx: &RequestCtx) -> Option<DetectionResult> {
+        let dc = &ctx.host_config.defense_config;
+        if !dc.body_abuse {
+            return None;
+        }
+        if ctx.body_preview.is_empty() && ctx.content_length == 0 {
+            return None;
+        }
+
+        let max_body = dc.max_body_size as u64;
+
+        // ── Rule 1: declared oversized (cheapest) ───────────────────────────
+        if ctx.content_length > max_body {
+            return Some(detection(
+                2,
+                format!(
+                    "Content-Length {} exceeds max_body_size {}",
+                    ctx.content_length, dc.max_body_size
+                ),
+            ));
+        }
+        // Fallback when content_length is missing (chunked) — use what we have.
+        if ctx.content_length == 0 && (ctx.body_preview.len() as u64) > max_body {
+            return Some(detection(
+                2,
+                format!(
+                    "chunked body preview {} exceeds max_body_size {}",
+                    ctx.body_preview.len(),
+                    dc.max_body_size
+                ),
+            ));
+        }
+
+        // ── Rule 2: declared vs sniffed content-type ────────────────────────
+        let declared_ct = ctx.headers.get("content-type").map_or("", String::as_str);
+        let declared = declared_body_kind(declared_ct);
+        let sniffed = sniff_body_kind(&ctx.body_preview);
+        if declared != "unknown" && sniffed != "unknown" && declared != sniffed {
+            return Some(detection(
+                5,
+                format!("Content-Type says {declared} but body magic-bytes look like {sniffed}"),
+            ));
+        }
+
+        // ── Rule 3-5: JSON-specific (only when declared JSON) ───────────────
+        if declared == "json" {
+            if let Err(v) = precheck_json_depth(&ctx.body_preview, dc.max_json_depth) {
+                return Some(violation_to_detection(&v, dc.max_json_depth, dc.max_json_keys));
+            }
+            match serde_json::from_slice::<serde_json::Value>(&ctx.body_preview) {
+                Err(_) => {
+                    return Some(detection(
+                        1,
+                        "declared application/json but body failed to parse".to_string(),
+                    ));
+                }
+                Ok(value) => {
+                    if let Err(v) = walk_count_keys(&value, dc.max_json_keys) {
+                        return Some(violation_to_detection(&v, dc.max_json_depth, dc.max_json_keys));
+                    }
+                }
+            }
+        }
+
+        None
+    }
+}
+
+fn detection(rule_seq: usize, desc: String) -> DetectionResult {
+    DetectionResult {
+        rule_id: Some(format!("BODY-{rule_seq:03}")),
+        rule_name: "Request Body Abuse".to_string(),
+        phase: Phase::RequestBodyAbuse,
+        detail: desc,
+    }
+}
+
+fn violation_to_detection(v: &BodyAbuseViolation, max_depth: usize, max_keys: usize) -> DetectionResult {
+    match v {
+        BodyAbuseViolation::TooDeep => detection(3, format!("JSON nesting exceeds max_json_depth {max_depth}")),
+        BodyAbuseViolation::TooManyKeys => detection(4, format!("JSON key count exceeds max_json_keys {max_keys}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use std::collections::HashMap;
+    use std::fmt::Write as _;
+    use std::net::IpAddr;
+    use std::sync::Arc;
+    use waf_common::{DefenseConfig, HostConfig};
+
+    fn make_ctx(body: &[u8], ct: &str, content_length: u64) -> RequestCtx {
+        make_ctx_dc(body, ct, content_length, DefenseConfig::default())
+    }
+
+    fn make_ctx_dc(body: &[u8], ct: &str, content_length: u64, dc: DefenseConfig) -> RequestCtx {
+        let mut headers = HashMap::new();
+        if !ct.is_empty() {
+            headers.insert("content-type".to_string(), ct.to_string());
+        }
+        RequestCtx {
+            req_id: "test".to_string(),
+            client_ip: "127.0.0.1".parse::<IpAddr>().unwrap(),
+            client_port: 0,
+            method: "POST".to_string(),
+            host: "example.com".to_string(),
+            port: 80,
+            path: "/api/upload".to_string(),
+            query: String::new(),
+            headers,
+            body_preview: Bytes::copy_from_slice(body),
+            content_length,
+            is_tls: false,
+            host_config: Arc::new(HostConfig {
+                defense_config: dc,
+                ..HostConfig::default()
+            }),
+            geo: None,
+            tier: waf_common::tier::Tier::CatchAll,
+            tier_policy: waf_common::RequestCtx::default_tier_policy(),
+            cookies: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn detects_oversized_by_content_length() {
+        // Default max_body_size = 64 KiB. Declare 128 KiB via content_length.
+        let ctx = make_ctx(b"{}", "application/json", 128 * 1024);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-002");
+    }
+
+    #[test]
+    fn allows_exactly_at_body_size_cap() {
+        // content_length == cap should pass (strictly greater-than).
+        let ctx = make_ctx(b"{}", "application/json", 64 * 1024);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_ct_mismatch_json_declared_xml_body() {
+        let ctx = make_ctx(b"<?xml version='1.0'?><root/>", "application/json", 28);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-005");
+    }
+
+    #[test]
+    fn detects_ct_mismatch_json_declared_zip_body() {
+        let ctx = make_ctx(b"PK\x03\x04rest", "application/json", 9);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-005");
+    }
+
+    #[test]
+    fn detects_ct_mismatch_text_declared_json_body() {
+        let ctx = make_ctx(b"{\"x\":1}", "text/html", 7);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-005");
+    }
+
+    #[test]
+    fn detects_malformed_json() {
+        // Valid depth pre-check (`{` then EOF balances below cap) but parse
+        // fails — we want BODY-001.
+        let ctx = make_ctx(b"{\"a\":", "application/json", 5);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-001");
+    }
+
+    #[test]
+    fn allows_clean_small_json() {
+        let ctx = make_ctx(br#"{"name":"alice","age":30}"#, "application/json", 25);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_deep_nesting() {
+        // Build depth 101 JSON.
+        let mut s = String::new();
+        for _ in 0..101 {
+            s.push_str("{\"x\":");
+        }
+        s.push_str("null");
+        for _ in 0..101 {
+            s.push('}');
+        }
+        let ctx = make_ctx(s.as_bytes(), "application/json", s.len() as u64);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-003");
+    }
+
+    #[test]
+    fn allows_depth_at_cap() {
+        let mut s = String::new();
+        for _ in 0..100 {
+            s.push_str("{\"x\":");
+        }
+        s.push_str("null");
+        for _ in 0..100 {
+            s.push('}');
+        }
+        let ctx = make_ctx(s.as_bytes(), "application/json", s.len() as u64);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_adversarial_deep_nesting_does_not_panic() {
+        // 10_000 unclosed `{` — depth precheck bails in O(N), no parser invoked.
+        let s = "{".repeat(10_000);
+        let ctx = make_ctx(s.as_bytes(), "application/json", s.len() as u64);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-003");
+    }
+
+    #[test]
+    fn detects_key_explosion() {
+        // Generate object with 11 keys; set max_json_keys=10 to trigger.
+        let mut s = String::from("{");
+        for i in 0..11 {
+            if i > 0 {
+                s.push(',');
+            }
+            let _ = write!(s, r#""k{i}":{i}"#);
+        }
+        s.push('}');
+        let dc = DefenseConfig {
+            max_json_keys: 10,
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx_dc(s.as_bytes(), "application/json", s.len() as u64, dc);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-004");
+    }
+
+    #[test]
+    fn allows_keys_at_cap() {
+        let mut s = String::from("{");
+        for i in 0..10 {
+            if i > 0 {
+                s.push(',');
+            }
+            let _ = write!(s, r#""k{i}":{i}"#);
+        }
+        s.push('}');
+        let dc = DefenseConfig {
+            max_json_keys: 10,
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx_dc(s.as_bytes(), "application/json", s.len() as u64, dc);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn empty_body_no_detection() {
+        let ctx = make_ctx(b"", "application/json", 0);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn skipped_when_body_abuse_disabled() {
+        let dc = DefenseConfig {
+            body_abuse: false,
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx_dc(b"<xml/>", "application/json", 6, dc);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn json_with_charset_parameter_treated_as_json() {
+        let ctx = make_ctx(br#"{"ok":true}"#, "application/json; charset=utf-8", 11);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn no_content_type_skips_mismatch() {
+        // Unknown declared → the mismatch rule is intentionally skipped.
+        let ctx = make_ctx(br#"{"x":1}"#, "", 7);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn html_declared_html_body_allowed() {
+        let ctx = make_ctx(b"<!DOCTYPE html><html></html>", "text/html", 28);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn gzip_declared_gzip_body_allowed() {
+        let body: &[u8] = &[0x1f, 0x8b, 0x08, 0, 0, 0, 0, 0];
+        let ctx = make_ctx(body, "application/gzip", body.len() as u64);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_mixed_array_object_nesting() {
+        // Alternate `[{[{...}]}]` to hit the precheck depth cap.
+        let mut s = String::new();
+        for i in 0..120 {
+            s.push(if i % 2 == 0 { '[' } else { '{' });
+        }
+        let ctx = make_ctx(s.as_bytes(), "application/json", s.len() as u64);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-003");
+    }
+
+    #[test]
+    fn detection_carries_correct_phase_and_prefix() {
+        let ctx = make_ctx(b"{}", "application/json", 128 * 1024);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.phase, Phase::RequestBodyAbuse);
+        assert_eq!(det.rule_name, "Request Body Abuse");
+        assert!(det.rule_id.as_deref().unwrap_or("").starts_with("BODY-"));
+    }
+
+    #[test]
+    fn chunked_fallback_checks_body_preview_when_content_length_zero() {
+        // content_length=0 with a 128 KiB body_preview → fall back to preview size.
+        let body = vec![b'a'; 128 * 1024];
+        let ctx = make_ctx(&body, "application/octet-stream", 0);
+        let det = RequestBodyAbuseCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BODY-002");
+    }
+
+    #[test]
+    fn unknown_ct_and_unknown_magic_allowed() {
+        // No mismatch can be established — rule is defensive, so allow.
+        let ctx = make_ctx(b"plain raw bytes", "text/plain", 15);
+        assert!(RequestBodyAbuseCheck::new().check(&ctx).is_none());
+    }
+}

--- a/crates/waf-engine/src/checks/body_abuse_walker.rs
+++ b/crates/waf-engine/src/checks/body_abuse_walker.rs
@@ -1,0 +1,261 @@
+//! Request-body abuse helpers — magic-byte content-type sniff, iterative
+//! byte-level depth pre-check, and key-count walker.
+//!
+//! The depth check is intentionally implemented as a byte scan (not a
+//! `serde_json` recursion-limit hook). `serde_json::de::Deserializer` only
+//! exposes `disable_recursion_limit()` — the opposite of what we need
+//! (Red Team Finding #3). Walking bytes ourselves is O(N) and bails the
+//! moment nesting crosses the cap, before any allocation.
+
+use serde_json::Value;
+
+/// Magic-byte classification of the request body. Returned as a short static
+/// tag (`"json"`, `"xml"`, `"zip"`, `"gzip"`, `"html"`, `"unknown"`) so
+/// callers can compare against the declared Content-Type category without
+/// allocating.
+pub fn sniff_body_kind(bytes: &[u8]) -> &'static str {
+    let trimmed = bytes
+        .iter()
+        .position(|b| !b.is_ascii_whitespace())
+        .map_or(bytes, |i| bytes.get(i..).unwrap_or(bytes));
+    let Some(&first) = trimmed.first() else {
+        return "unknown";
+    };
+    match first {
+        b'{' | b'[' => "json",
+        b'<' => {
+            // `<!DOCTYPE html` / `<html` → html; otherwise treat as xml.
+            let lower: Vec<u8> = trimmed.iter().take(16).map(u8::to_ascii_lowercase).collect();
+            if lower.starts_with(b"<!doctype html") || lower.starts_with(b"<html") {
+                "html"
+            } else {
+                "xml"
+            }
+        }
+        _ if trimmed.starts_with(b"PK\x03\x04") => "zip",
+        _ if trimmed.starts_with(&[0x1f, 0x8b]) => "gzip",
+        _ => "unknown",
+    }
+}
+
+/// Extract the Content-Type category from the declared header value. Returns
+/// the same tag alphabet as [`sniff_body_kind`] so a mismatch check is a
+/// straight `!=`.
+///
+/// `application/json; charset=utf-8` → `"json"`, `text/html` → `"html"`, etc.
+/// Unknown / missing → `"unknown"`, which the caller uses to mean
+/// "skip mismatch check".
+pub fn declared_body_kind(content_type: &str) -> &'static str {
+    let primary = content_type.split(';').next().unwrap_or("").trim().to_ascii_lowercase();
+    if primary == "application/json" || primary.ends_with("+json") {
+        "json"
+    } else if primary == "application/xml" || primary == "text/xml" || primary.ends_with("+xml") {
+        "xml"
+    } else if primary == "application/zip" {
+        "zip"
+    } else if primary == "application/gzip" || primary == "application/x-gzip" {
+        "gzip"
+    } else if primary == "text/html" {
+        "html"
+    } else {
+        "unknown"
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum BodyAbuseViolation {
+    TooDeep,
+    TooManyKeys,
+}
+
+/// Fast pre-scan: walk the raw bytes and bail the moment `{`/`[` nesting
+/// exceeds `max_depth`. Treats `{` inside a string literal as a nesting
+/// token — this is an intentional over-approximation documented in the
+/// plan (the alternative is to parse strings + escapes here, which defeats
+/// the point of running before the parser).
+pub fn precheck_json_depth(bytes: &[u8], max_depth: usize) -> Result<(), BodyAbuseViolation> {
+    let mut depth: usize = 0;
+    for &b in bytes {
+        match b {
+            b'{' | b'[' => {
+                depth += 1;
+                if depth > max_depth {
+                    return Err(BodyAbuseViolation::TooDeep);
+                }
+            }
+            b'}' | b']' => {
+                depth = depth.saturating_sub(1);
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Iteratively walk a parsed `serde_json::Value` counting object keys. Bails
+/// as soon as the cumulative count exceeds `max_keys`. Uses an explicit
+/// `Vec<&Value>` stack (never recursive) so we cannot trigger the very
+/// class of bug we detect.
+pub fn walk_count_keys(root: &Value, max_keys: usize) -> Result<(), BodyAbuseViolation> {
+    let mut stack: Vec<&Value> = Vec::new();
+    stack.push(root);
+    let mut keys: usize = 0;
+    while let Some(node) = stack.pop() {
+        match node {
+            Value::Object(map) => {
+                keys += map.len();
+                if keys > max_keys {
+                    return Err(BodyAbuseViolation::TooManyKeys);
+                }
+                for child in map.values() {
+                    stack.push(child);
+                }
+            }
+            Value::Array(arr) => {
+                for child in arr {
+                    stack.push(child);
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fmt::Write as _;
+
+    #[test]
+    fn sniff_json_object() {
+        assert_eq!(sniff_body_kind(br#"{"a":1}"#), "json");
+    }
+
+    #[test]
+    fn sniff_json_array() {
+        assert_eq!(sniff_body_kind(b"[1,2,3]"), "json");
+    }
+
+    #[test]
+    fn sniff_skips_leading_whitespace() {
+        assert_eq!(sniff_body_kind(b"   \r\n{}"), "json");
+    }
+
+    #[test]
+    fn sniff_xml() {
+        assert_eq!(sniff_body_kind(b"<?xml version='1.0'?>"), "xml");
+        assert_eq!(sniff_body_kind(b"<root/>"), "xml");
+    }
+
+    #[test]
+    fn sniff_html() {
+        assert_eq!(sniff_body_kind(b"<!DOCTYPE html>"), "html");
+        assert_eq!(sniff_body_kind(b"<html>"), "html");
+    }
+
+    #[test]
+    fn sniff_zip() {
+        assert_eq!(sniff_body_kind(b"PK\x03\x04rest"), "zip");
+    }
+
+    #[test]
+    fn sniff_gzip() {
+        assert_eq!(sniff_body_kind(&[0x1f, 0x8b, 0x08]), "gzip");
+    }
+
+    #[test]
+    fn sniff_unknown() {
+        assert_eq!(sniff_body_kind(b"plain text body"), "unknown");
+        assert_eq!(sniff_body_kind(b""), "unknown");
+    }
+
+    #[test]
+    fn declared_json_variants() {
+        assert_eq!(declared_body_kind("application/json"), "json");
+        assert_eq!(declared_body_kind("application/json; charset=utf-8"), "json");
+        assert_eq!(declared_body_kind("APPLICATION/JSON"), "json");
+        assert_eq!(declared_body_kind("application/vnd.api+json"), "json");
+    }
+
+    #[test]
+    fn declared_xml_variants() {
+        assert_eq!(declared_body_kind("application/xml"), "xml");
+        assert_eq!(declared_body_kind("text/xml"), "xml");
+        assert_eq!(declared_body_kind("application/soap+xml"), "xml");
+    }
+
+    #[test]
+    fn declared_other() {
+        assert_eq!(declared_body_kind("text/html"), "html");
+        assert_eq!(declared_body_kind("application/zip"), "zip");
+        assert_eq!(declared_body_kind("application/gzip"), "gzip");
+        assert_eq!(declared_body_kind("text/plain"), "unknown");
+        assert_eq!(declared_body_kind(""), "unknown");
+    }
+
+    #[test]
+    fn precheck_accepts_shallow() {
+        assert!(precheck_json_depth(b"{\"a\":{\"b\":1}}", 100).is_ok());
+    }
+
+    #[test]
+    fn precheck_rejects_over_depth() {
+        let bytes = "{".repeat(200);
+        assert_eq!(
+            precheck_json_depth(bytes.as_bytes(), 100),
+            Err(BodyAbuseViolation::TooDeep)
+        );
+    }
+
+    #[test]
+    fn precheck_handles_adversarial_no_close_braces() {
+        // 10000 `{`s, no closes. Must finish in O(N) without panicking.
+        let bytes = "{".repeat(10_000);
+        assert_eq!(
+            precheck_json_depth(bytes.as_bytes(), 100),
+            Err(BodyAbuseViolation::TooDeep)
+        );
+    }
+
+    #[test]
+    fn precheck_saturating_sub_guards_against_extra_close() {
+        // Extra `}` should not underflow; overall accept because depth stays ≤ 1.
+        assert!(precheck_json_depth(b"}}}{}", 10).is_ok());
+    }
+
+    #[test]
+    fn walk_count_keys_flat() {
+        let v: Value = serde_json::from_str(r#"{"a":1,"b":2,"c":3}"#).unwrap();
+        assert!(walk_count_keys(&v, 10).is_ok());
+    }
+
+    #[test]
+    fn walk_count_keys_exceeds_cap() {
+        // Build an object with 50 keys.
+        let mut s = String::from("{");
+        for i in 0..50 {
+            if i > 0 {
+                s.push(',');
+            }
+            let _ = write!(s, r#""k{i}":{i}"#);
+        }
+        s.push('}');
+        let v: Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(walk_count_keys(&v, 10), Err(BodyAbuseViolation::TooManyKeys));
+    }
+
+    #[test]
+    fn walk_count_keys_nested() {
+        let v: Value = serde_json::from_str(r#"{"a":{"b":{"c":1}}}"#).unwrap();
+        assert!(walk_count_keys(&v, 10).is_ok());
+        assert_eq!(walk_count_keys(&v, 2), Err(BodyAbuseViolation::TooManyKeys));
+    }
+
+    #[test]
+    fn walk_count_keys_array_of_objects() {
+        let v: Value = serde_json::from_str(r#"[{"a":1},{"b":2},{"c":3}]"#).unwrap();
+        assert!(walk_count_keys(&v, 10).is_ok());
+        assert_eq!(walk_count_keys(&v, 2), Err(BodyAbuseViolation::TooManyKeys));
+    }
+}

--- a/crates/waf-engine/src/checks/brute_force.rs
+++ b/crates/waf-engine/src/checks/brute_force.rs
@@ -1,0 +1,560 @@
+//! Brute force / credential stuffing detection (FR-018).
+//!
+//! Request phase (`Check::check`):
+//!   - If the request targets a configured login route AND the
+//!     `(user_hash, ip)` failure counter is at or above
+//!     `bf_max_per_user`, block with BF-001.
+//!   - If any password has been sprayed against `>= bf_spray_threshold`
+//!     distinct users from this IP inside the window, block with BF-002.
+//!
+//! Response phase (`Check::on_response`, status-code-only v1):
+//!   - If status is 401 or 403 AND the original request targeted a login
+//!     route, extract username + password from the body and record a
+//!     failure.
+//!
+//! Body-regex failure detection is intentionally NOT implemented —
+//! Pingora's `response_filter` exposes headers + status only (Finding #8),
+//! and a generic failure regex is weaponizable as a victim-account
+//! lockout primitive (Finding #11).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use waf_common::{DetectionResult, Phase, RequestCtx};
+
+use super::Check;
+use super::brute_force_extractors::{
+    PASSWORD_KEYS, USERNAME_KEYS, extract_credential_field, extract_credentials, is_failed_login_status, truncated_hash,
+};
+use super::brute_force_state::BfState;
+use super::{Clock, SystemClock};
+
+pub struct BruteForceCheck {
+    state: Arc<BfState>,
+}
+
+impl BruteForceCheck {
+    pub fn new() -> Self {
+        Self::with_clock(Arc::new(SystemClock))
+    }
+
+    pub fn with_clock(clock: Arc<dyn Clock>) -> Self {
+        Self {
+            state: Arc::new(BfState::new(100_000, clock)),
+        }
+    }
+
+    /// Expose the inner state so an engine bootstrap can drive periodic
+    /// `prune_older_than` calls (background pruner lives in engine init per
+    /// Red Team Finding #14).
+    pub fn state(&self) -> Arc<BfState> {
+        Arc::clone(&self.state)
+    }
+}
+
+impl Default for BruteForceCheck {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Does `ctx.path` target any configured login route?
+///
+/// Matches a configured route `/login` against `/login` (exact) and
+/// `/login/...` (prefix with segment boundary). Does NOT match `/login-page`
+/// or `/loginx` — those are independent routes and naive `starts_with`
+/// would both miss real login protection on them (if the app also serves
+/// them as login) and false-positive them otherwise.
+fn is_login_route(ctx: &RequestCtx) -> bool {
+    let routes = &ctx.host_config.defense_config.bf_login_routes;
+    if routes.is_empty() {
+        return false;
+    }
+    let path = ctx.path.split('?').next().unwrap_or(ctx.path.as_str());
+    routes.iter().any(|r| {
+        let rs = r.as_str();
+        path == rs || path.strip_prefix(rs).is_some_and(|rest| rest.starts_with('/'))
+    })
+}
+
+impl Check for BruteForceCheck {
+    fn check(&self, ctx: &RequestCtx) -> Option<DetectionResult> {
+        let dc = &ctx.host_config.defense_config;
+        if !dc.brute_force || !is_login_route(ctx) {
+            return None;
+        }
+
+        let window = Duration::from_secs(dc.bf_window_secs);
+
+        // BF-001 — per-user failure threshold.
+        let content_type = ctx.headers.get("content-type").map_or("", String::as_str);
+        if let Some(username) = extract_credential_field(&ctx.body_preview, content_type, USERNAME_KEYS) {
+            let user_hash = truncated_hash(&normalize_username(&username));
+            let count = self.state.failed_count(user_hash, ctx.client_ip, window);
+            if count >= dc.bf_max_per_user {
+                return Some(detection(
+                    1,
+                    format!(
+                        "{count} failed logins for same user from {ip} in {secs}s",
+                        ip = ctx.client_ip,
+                        secs = dc.bf_window_secs,
+                    ),
+                ));
+            }
+        }
+
+        // BF-002 — password-spray across distinct users from this IP.
+        if self
+            .state
+            .any_spray_over_threshold(ctx.client_ip, dc.bf_spray_threshold, window)
+        {
+            return Some(detection(
+                2,
+                format!(
+                    "password sprayed against >= {thr} users from {ip} in {secs}s",
+                    thr = dc.bf_spray_threshold,
+                    ip = ctx.client_ip,
+                    secs = dc.bf_window_secs,
+                ),
+            ));
+        }
+
+        None
+    }
+
+    fn on_response(&self, ctx: &RequestCtx, status: u16) {
+        let dc = &ctx.host_config.defense_config;
+        if !dc.brute_force || !is_login_route(ctx) || !is_failed_login_status(status) {
+            return;
+        }
+
+        let window = Duration::from_secs(dc.bf_window_secs);
+        let content_type = ctx.headers.get("content-type").map_or("", String::as_str);
+
+        // Single-parse extraction: pulls both username and (optional) password
+        // from the same parse tree — avoids parsing a 4 KiB login body twice
+        // on every failed-login response.
+        let mut fields = extract_credentials(&ctx.body_preview, content_type, &[USERNAME_KEYS, PASSWORD_KEYS]);
+        let Some(username) = fields.first_mut().and_then(Option::take) else {
+            return;
+        };
+        let user_hash = truncated_hash(&normalize_username(&username));
+        self.state.record_failed(user_hash, ctx.client_ip, window);
+
+        // Password is optional — sprayer tracking works only when we also
+        // know what was attempted. Legit failed logins without a body-visible
+        // password simply skip the spray counter.
+        if let Some(password) = fields.get_mut(1).and_then(Option::take) {
+            let pwd_hash = truncated_hash(&password);
+            self.state
+                .record_spray(ctx.client_ip, pwd_hash, user_hash, window, dc.bf_spray_threshold);
+        }
+    }
+}
+
+/// Lower-case + trim so `"alice"`, `"ALICE"`, and `"alice "` all hash to the
+/// same slot. Without this, an attacker can bypass BF-001 by appending a
+/// trailing space to the username (Red Team Finding L2).
+fn normalize_username(raw: &str) -> String {
+    raw.trim().to_ascii_lowercase()
+}
+
+fn detection(rule_seq: usize, desc: String) -> DetectionResult {
+    DetectionResult {
+        rule_id: Some(format!("BF-{rule_seq:03}")),
+        rule_name: "Brute Force".to_string(),
+        phase: Phase::BruteForce,
+        detail: desc,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::duration_suboptimal_units)]
+mod tests {
+    use super::*;
+    use crate::checks::test_clock::MockClock;
+    use bytes::Bytes;
+    use std::collections::HashMap;
+    use std::net::IpAddr;
+    use waf_common::{DefenseConfig, HostConfig};
+
+    fn make_ctx(path: &str, body: &[u8], ct: &str, ip: &str) -> RequestCtx {
+        make_ctx_dc(path, body, ct, ip, DefenseConfig::default())
+    }
+
+    fn make_ctx_dc(path: &str, body: &[u8], ct: &str, ip: &str, dc: DefenseConfig) -> RequestCtx {
+        let mut headers = HashMap::new();
+        if !ct.is_empty() {
+            headers.insert("content-type".to_string(), ct.to_string());
+        }
+        RequestCtx {
+            req_id: "test".to_string(),
+            client_ip: ip.parse::<IpAddr>().unwrap(),
+            client_port: 0,
+            method: "POST".to_string(),
+            host: "example.com".to_string(),
+            port: 80,
+            path: path.to_string(),
+            query: String::new(),
+            headers,
+            body_preview: Bytes::copy_from_slice(body),
+            content_length: body.len() as u64,
+            is_tls: false,
+            host_config: Arc::new(HostConfig {
+                defense_config: dc,
+                ..HostConfig::default()
+            }),
+            geo: None,
+            tier: waf_common::tier::Tier::CatchAll,
+            tier_policy: waf_common::RequestCtx::default_tier_policy(),
+            cookies: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn detects_per_user_threshold_on_sixth_attempt() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"wrong"}"#;
+        for _ in 0..5 {
+            let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+        let det = checker.check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BF-001");
+    }
+
+    #[test]
+    fn allows_fifth_attempt_boundary() {
+        // 4 failures, 5th request hits the check — count is 4, threshold is 5,
+        // so still allowed.
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"wrong"}"#;
+        for _ in 0..4 {
+            let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn window_expiry_clears_failures() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock.clone());
+        let body = br#"{"username":"alice","password":"wrong"}"#;
+        for _ in 0..5 {
+            let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        // Default window is 900s; jump well past it.
+        clock.advance(Duration::from_secs(1800));
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn per_ip_isolation() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"wrong"}"#;
+        for _ in 0..5 {
+            let ctx = make_ctx("/login", body, "application/json", "1.1.1.1");
+            checker.on_response(&ctx, 401);
+        }
+        // Different IP — no state.
+        let ctx = make_ctx("/login", body, "application/json", "2.2.2.2");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_password_spray() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        for user in ["charlie", "diana", "eve", "frank", "grace"] {
+            let body = format!(r#"{{"username":"{user}","password":"P@ss1"}}"#);
+            let ctx = make_ctx("/login", body.as_bytes(), "application/json", "9.9.9.9");
+            checker.on_response(&ctx, 401);
+        }
+        // Next request from same IP — spray detected regardless of username.
+        let ctx = make_ctx(
+            "/login",
+            br#"{"username":"zed","password":"anything"}"#,
+            "application/json",
+            "9.9.9.9",
+        );
+        let det = checker.check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BF-002");
+    }
+
+    #[test]
+    fn spray_below_threshold_no_detection() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        for user in ["charlie", "diana", "eve", "frank"] {
+            let body = format!(r#"{{"username":"{user}","password":"P@ss1"}}"#);
+            let ctx = make_ctx("/login", body.as_bytes(), "application/json", "9.9.9.9");
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx(
+            "/login",
+            br#"{"username":"x","password":"y"}"#,
+            "application/json",
+            "9.9.9.9",
+        );
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn success_response_does_not_increment_failures() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"correct"}"#;
+        for _ in 0..10 {
+            let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 200);
+        }
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn status_500_does_not_increment_failures() {
+        // Transient server errors must not count as login failures.
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"x"}"#;
+        for _ in 0..10 {
+            let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 503);
+        }
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn response_on_non_login_route_ignored() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"x"}"#;
+        for _ in 0..10 {
+            let ctx = make_ctx("/api/health", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn disabled_brute_force_kills_all_signals() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let dc = DefenseConfig {
+            brute_force: false,
+            ..DefenseConfig::default()
+        };
+        let body = br#"{"username":"alice","password":"x"}"#;
+        for _ in 0..20 {
+            let ctx = make_ctx_dc("/login", body, "application/json", "5.5.5.5", dc.clone());
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx_dc("/login", body, "application/json", "5.5.5.5", dc);
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn extraction_failure_silently_skips_recording() {
+        // Body missing username — recording is skipped; no threshold hit.
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"token":"xyz"}"#;
+        for _ in 0..20 {
+            let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn whitespace_padded_username_hashes_to_same_slot() {
+        // Red Team L2: attacker appends/prepends space to evade BF-001.
+        // normalize_username trims before hashing.
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        for user in ["alice", " alice", "alice ", "  alice  "] {
+            let body = format!(r#"{{"username":"{user}","password":"x"}}"#);
+            let ctx = make_ctx("/login", body.as_bytes(), "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        for _ in 0..1 {
+            let ctx = make_ctx(
+                "/login",
+                br#"{"username":"alice","password":"x"}"#,
+                "application/json",
+                "5.5.5.5",
+            );
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx(
+            "/login",
+            br#"{"username":"alice","password":"x"}"#,
+            "application/json",
+            "5.5.5.5",
+        );
+        let det = checker
+            .check(&ctx)
+            .expect("5 padded failures must collapse to same slot");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BF-001");
+    }
+
+    #[test]
+    fn case_insensitive_username_hashes_to_same_slot() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        // Three failures under mixed casing.
+        for user in ["Alice", "ALICE", "alice"] {
+            let body = format!(r#"{{"username":"{user}","password":"x"}}"#);
+            let ctx = make_ctx("/login", body.as_bytes(), "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        for _ in 0..2 {
+            let ctx = make_ctx(
+                "/login",
+                br#"{"username":"alice","password":"x"}"#,
+                "application/json",
+                "5.5.5.5",
+            );
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx(
+            "/login",
+            br#"{"username":"alice","password":"x"}"#,
+            "application/json",
+            "5.5.5.5",
+        );
+        let det = checker.check(&ctx).expect("hit after combined 5 failures");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "BF-001");
+    }
+
+    #[test]
+    fn form_urlencoded_body_works() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        for _ in 0..5 {
+            let ctx = make_ctx(
+                "/login",
+                b"username=alice&password=wrong",
+                "application/x-www-form-urlencoded",
+                "5.5.5.5",
+            );
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx(
+            "/login",
+            b"username=alice&password=wrong",
+            "application/x-www-form-urlencoded",
+            "5.5.5.5",
+        );
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn route_prefix_match_covers_subpaths() {
+        // `/api/auth/token/refresh` must count for the `/api/auth/token` route.
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"x"}"#;
+        for _ in 0..5 {
+            let ctx = make_ctx("/api/auth/token/refresh", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx("/api/auth/token/refresh", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detection_carries_correct_phase_and_prefix() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"x"}"#;
+        for _ in 0..5 {
+            let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+        let det = checker.check(&ctx).expect("hit");
+        assert_eq!(det.phase, Phase::BruteForce);
+        assert_eq!(det.rule_name, "Brute Force");
+        assert!(det.rule_id.as_deref().unwrap_or("").starts_with("BF-"));
+    }
+
+    #[test]
+    fn empty_login_routes_disables_check() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let dc = DefenseConfig {
+            bf_login_routes: Vec::new(),
+            ..DefenseConfig::default()
+        };
+        let body = br#"{"username":"alice","password":"x"}"#;
+        for _ in 0..10 {
+            let ctx = make_ctx_dc("/login", body, "application/json", "5.5.5.5", dc.clone());
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx_dc("/login", body, "application/json", "5.5.5.5", dc);
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn response_status_403_also_counted() {
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"x"}"#;
+        for _ in 0..5 {
+            let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 403);
+        }
+        let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn route_sibling_path_does_not_match_login_prefix() {
+        // Regression: `/login-page` must NOT be treated as a login route just
+        // because it shares a `/login` prefix. Naive `starts_with` would miss
+        // real protection on `/login-page` (if the app serves it as login)
+        // AND false-positive unrelated routes like `/login-help`.
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"x"}"#;
+        // Load up failed-login state on `/login` so counters are primed.
+        for _ in 0..10 {
+            let ctx = make_ctx("/login", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        // Hit a sibling — should NOT be seen as a login route, so no block.
+        let ctx = make_ctx("/login-page", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_none());
+        let ctx = make_ctx("/loginx", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn api_auth_token_sibling_not_blocked() {
+        // Inverse of C1: `/api/auth/tokens-admin` is a sibling route of
+        // `/api/auth/token`, must not be false-positived by BF counters
+        // that were accumulated against `/api/auth/token`.
+        let clock = Arc::new(MockClock::new());
+        let checker = BruteForceCheck::with_clock(clock);
+        let body = br#"{"username":"alice","password":"x"}"#;
+        for _ in 0..10 {
+            let ctx = make_ctx("/api/auth/token", body, "application/json", "5.5.5.5");
+            checker.on_response(&ctx, 401);
+        }
+        let ctx = make_ctx("/api/auth/tokens-admin", body, "application/json", "5.5.5.5");
+        assert!(checker.check(&ctx).is_none());
+    }
+}

--- a/crates/waf-engine/src/checks/brute_force_extractors.rs
+++ b/crates/waf-engine/src/checks/brute_force_extractors.rs
@@ -1,0 +1,226 @@
+//! Credential extraction + keyed-hash helpers for FR-018.
+//!
+//! Credential material is never retained raw — we hash to a u64 before any
+//! map insertion so leaked state doesn't leak plaintext usernames/passwords
+//! (GDPR posture; also keeps memory flat).
+//!
+//! The hash is `ahash::RandomState` keyed with a per-process random seed.
+//! Unkeyed SHA-256 truncated to 64 bits is offline-grindable: an attacker
+//! can precompute a username that collides with a victim and use it to
+//! trip the victim's brute-force counter (victim-lockout primitive). The
+//! per-process random key blocks that: the attacker must interact with
+//! the live WAF to mount the collision, at which point they've already
+//! hit the rate limit they're trying to grind around.
+
+use std::sync::LazyLock;
+
+use ahash::RandomState;
+
+static HASH_KEY: LazyLock<RandomState> = LazyLock::new(RandomState::new);
+
+/// Hash `s` with the per-process keyed `ahash` state. Stable within one
+/// process lifetime, randomised across restarts — and never persisted,
+/// so restart portability is not required.
+pub fn truncated_hash(s: &str) -> u64 {
+    HASH_KEY.hash_one(s.as_bytes())
+}
+
+/// Pull a credential-like field (username/email/password) from a request
+/// body. Handles both `application/json` (objects only) and
+/// `application/x-www-form-urlencoded`.
+///
+/// Case-insensitive key match so `{"Username":"x"}` and `{"username":"x"}`
+/// hash identically.
+pub fn extract_credential_field(body: &[u8], content_type: &str, candidates: &[&str]) -> Option<String> {
+    extract_credentials_impl(body, content_type, &[candidates])
+        .into_iter()
+        .next()
+        .flatten()
+}
+
+/// Parse the body ONCE and resolve multiple credential lookups against the
+/// same parse tree. Returns one `Option<String>` per `key_groups` entry, in
+/// the same order.
+///
+/// Used on the FR-018 response hot path where we need both username and
+/// password from the same login body — the single-field entry point parses
+/// JSON twice which doubles CPU per failed-login response.
+pub fn extract_credentials(body: &[u8], content_type: &str, key_groups: &[&[&str]]) -> Vec<Option<String>> {
+    extract_credentials_impl(body, content_type, key_groups)
+}
+
+fn extract_credentials_impl(body: &[u8], content_type: &str, key_groups: &[&[&str]]) -> Vec<Option<String>> {
+    let mut out: Vec<Option<String>> = vec![None; key_groups.len()];
+    let ct = content_type.split(';').next().unwrap_or("").trim().to_ascii_lowercase();
+
+    if ct == "application/json" || ct.ends_with("+json") {
+        let Ok(v) = serde_json::from_slice::<serde_json::Value>(body) else {
+            return out;
+        };
+        if let serde_json::Value::Object(map) = v {
+            for (k, val) in &map {
+                let serde_json::Value::String(s) = val else {
+                    continue;
+                };
+                for (slot, group) in out.iter_mut().zip(key_groups.iter()) {
+                    if slot.is_none() && group.iter().any(|c| k.eq_ignore_ascii_case(c)) {
+                        *slot = Some(s.clone());
+                    }
+                }
+            }
+        }
+        return out;
+    }
+
+    if ct == "application/x-www-form-urlencoded" {
+        for (k, v) in url::form_urlencoded::parse(body) {
+            for (slot, group) in out.iter_mut().zip(key_groups.iter()) {
+                if slot.is_none() && group.iter().any(|c| k.eq_ignore_ascii_case(c)) {
+                    *slot = Some(v.clone().into_owned());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Username candidate keys tried in order.
+pub const USERNAME_KEYS: &[&str] = &["username", "email", "user", "login"];
+
+/// Password candidate keys tried in order.
+pub const PASSWORD_KEYS: &[&str] = &["password", "passwd", "pass"];
+
+/// Login response is treated as failed when status is 401 or 403. Body-based
+/// detection is intentionally not supported in v1 — Pingora `response_filter`
+/// exposes status + headers only (Red Team Finding #8), and body-regex on
+/// upstream error pages is a known victim-account-lockout primitive
+/// (Finding #11).
+pub const fn is_failed_login_status(status: u16) -> bool {
+    matches!(status, 401 | 403)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncated_hash_stable_for_same_input() {
+        assert_eq!(truncated_hash("alice"), truncated_hash("alice"));
+    }
+
+    #[test]
+    fn truncated_hash_differs_across_input() {
+        assert_ne!(truncated_hash("alice"), truncated_hash("bob"));
+    }
+
+    #[test]
+    fn truncated_hash_is_keyed_not_precomputable() {
+        // Keyed with per-process random state — the hash of `"alice"` MUST
+        // NOT equal the unkeyed SHA-256 truncation an offline attacker
+        // would precompute. Without the random key, an attacker who knows
+        // the hash function can grind a colliding username to trip any
+        // victim's brute-force counter.
+        //
+        // Unkeyed SHA-256 leading 8 bytes of "alice" as big-endian u64:
+        const UNKEYED_SHA256_ALICE: u64 = 0x2bd8_06c9_7f0e_00af;
+        // Vanishing-small probability of a random-state collision on this
+        // specific 8-byte prefix; if this test ever flakes we'll know the
+        // key entropy has regressed.
+        assert_ne!(truncated_hash("alice"), UNKEYED_SHA256_ALICE);
+    }
+
+    #[test]
+    fn extract_username_from_json_object() {
+        let body = br#"{"username":"alice","password":"secret"}"#;
+        assert_eq!(
+            extract_credential_field(body, "application/json", USERNAME_KEYS).as_deref(),
+            Some("alice")
+        );
+    }
+
+    #[test]
+    fn extract_email_as_username() {
+        let body = br#"{"email":"a@b.z","password":"pw"}"#;
+        assert_eq!(
+            extract_credential_field(body, "application/json", USERNAME_KEYS).as_deref(),
+            Some("a@b.z")
+        );
+    }
+
+    #[test]
+    fn extract_case_insensitive_key() {
+        let body = br#"{"Username":"BOB"}"#;
+        assert_eq!(
+            extract_credential_field(body, "application/json", USERNAME_KEYS).as_deref(),
+            Some("BOB")
+        );
+    }
+
+    #[test]
+    fn extract_password_key() {
+        let body = br#"{"username":"alice","password":"P@ss1"}"#;
+        assert_eq!(
+            extract_credential_field(body, "application/json", PASSWORD_KEYS).as_deref(),
+            Some("P@ss1")
+        );
+    }
+
+    #[test]
+    fn extract_form_urlencoded_username() {
+        let body = b"username=alice&password=secret";
+        assert_eq!(
+            extract_credential_field(body, "application/x-www-form-urlencoded", USERNAME_KEYS).as_deref(),
+            Some("alice")
+        );
+    }
+
+    #[test]
+    fn extract_form_with_charset() {
+        let body = b"username=alice&password=secret";
+        assert_eq!(
+            extract_credential_field(body, "application/x-www-form-urlencoded; charset=utf-8", USERNAME_KEYS)
+                .as_deref(),
+            Some("alice")
+        );
+    }
+
+    #[test]
+    fn extract_returns_none_on_missing_key() {
+        let body = br#"{"token":"xyz"}"#;
+        assert!(extract_credential_field(body, "application/json", USERNAME_KEYS).is_none());
+    }
+
+    #[test]
+    fn extract_returns_none_on_malformed_json() {
+        let body = b"not-json-at-all";
+        assert!(extract_credential_field(body, "application/json", USERNAME_KEYS).is_none());
+    }
+
+    #[test]
+    fn extract_returns_none_on_unsupported_content_type() {
+        let body = br#"{"username":"alice"}"#;
+        assert!(extract_credential_field(body, "text/plain", USERNAME_KEYS).is_none());
+    }
+
+    #[test]
+    fn extract_returns_none_when_value_not_string() {
+        let body = br#"{"username":123}"#;
+        assert!(extract_credential_field(body, "application/json", USERNAME_KEYS).is_none());
+    }
+
+    #[test]
+    fn extract_returns_none_for_json_array_root() {
+        // Root is an array, not an object — no key lookup possible.
+        let body = br#"[{"username":"x"}]"#;
+        assert!(extract_credential_field(body, "application/json", USERNAME_KEYS).is_none());
+    }
+
+    #[test]
+    fn is_failed_login_status_boundaries() {
+        assert!(is_failed_login_status(401));
+        assert!(is_failed_login_status(403));
+        assert!(!is_failed_login_status(400));
+        assert!(!is_failed_login_status(200));
+        assert!(!is_failed_login_status(500));
+    }
+}

--- a/crates/waf-engine/src/checks/brute_force_state.rs
+++ b/crates/waf-engine/src/checks/brute_force_state.rs
@@ -1,0 +1,479 @@
+//! Sliding-window state for FR-018 brute force / credential stuffing.
+//!
+//! Two maps, keyed differently:
+//! - `failed` keyed by `(user_hash, client_ip)` → deque of recent failure
+//!   timestamps. A request into a login route is blocked when the in-window
+//!   count exceeds `bf_max_per_user`.
+//! - `spray` keyed by `(client_ip, password_hash)` → set of usernames tried.
+//!   When one password hits `>= bf_spray_threshold` distinct users from one
+//!   IP inside the window, any subsequent login from that IP is blocked.
+//!
+//! Both maps are bounded (Red Team Finding #6) — when they exceed
+//! `max_entries` the oldest 10 percent are evicted by last-touched.
+//!
+//! Time comes from the Phase 00 `Clock` trait so tests advance the window
+//! without sleeping (Validation Q7).
+//
+// `significant_drop_tightening` fires on the DashMap entry held across a
+// Mutex lock — restructuring would cost an Arc<Mutex> per record for no
+// throughput win. `option_if_let_else` rewrites add a closure per call site
+// that is less readable than the match form we use.
+#![allow(clippy::significant_drop_tightening, clippy::option_if_let_else)]
+
+use std::collections::{HashSet, VecDeque};
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+use parking_lot::Mutex;
+
+use super::Clock;
+
+struct FailedRecord {
+    hits: VecDeque<Instant>,
+    last_touched: Instant,
+}
+
+struct SprayRecord {
+    users: HashSet<u64>,
+    last_touched: Instant,
+}
+
+pub struct BfState {
+    failed: Arc<DashMap<(u64, IpAddr), Mutex<FailedRecord>>>,
+    spray: Arc<DashMap<(IpAddr, u64), Mutex<SprayRecord>>>,
+    /// Secondary index: count of `(ip, password_hash)` records that have
+    /// currently reached `bf_spray_threshold`. Lets the request-phase
+    /// dispatcher answer "any spray over threshold for this IP?" in O(1)
+    /// instead of scanning the whole `spray` map (100k entries worst case).
+    spray_hits_per_ip: Arc<DashMap<IpAddr, AtomicUsize>>,
+    /// Per-IP → set of `password_hash`es currently tracked for that IP.
+    /// Lets the slow-path re-verify in `any_spray_over_threshold` iterate
+    /// only O(passwords-from-this-ip) instead of O(all-IPs * all-passwords)
+    /// — without this, one attacker IP that crosses threshold amplifies
+    /// every subsequent login into a full 100k-entry scan.
+    spray_passwords_per_ip: Arc<DashMap<IpAddr, Mutex<HashSet<u64>>>>,
+    max_entries: usize,
+    evict_ticker: AtomicUsize,
+    clock: Arc<dyn Clock>,
+}
+
+/// Cap per (ip, password) spray set — well above any reasonable threshold,
+/// prevents unbounded growth when someone hammers `P@ss1` across thousands
+/// of usernames.
+const SPRAY_USERS_CAP: usize = 1000;
+/// Cap per (user, ip) failed-login deque — well above
+/// `bf_max_per_user * 4` so boundary tests still have headroom but adversaries
+/// can't grow this deque without bound.
+const FAILED_HITS_CAP: usize = 64;
+/// Amortize eviction: only every N-th call while over cap pays the sort.
+const EVICT_INTERVAL: usize = 1024;
+
+impl BfState {
+    pub fn new(max_entries: usize, clock: Arc<dyn Clock>) -> Self {
+        Self {
+            failed: Arc::new(DashMap::new()),
+            spray: Arc::new(DashMap::new()),
+            spray_hits_per_ip: Arc::new(DashMap::new()),
+            spray_passwords_per_ip: Arc::new(DashMap::new()),
+            max_entries,
+            evict_ticker: AtomicUsize::new(0),
+            clock,
+        }
+    }
+
+    pub fn record_failed(&self, user_hash: u64, ip: IpAddr, window: Duration) {
+        self.evict_if_over_cap_failed();
+        let now = self.clock.now();
+        let entry = self.failed.entry((user_hash, ip)).or_insert_with(|| {
+            Mutex::new(FailedRecord {
+                hits: VecDeque::new(),
+                last_touched: now,
+            })
+        });
+        let mut rec = entry.lock();
+        rec.last_touched = now;
+        rec.hits.push_back(now);
+        Self::prune_hits(&mut rec.hits, now, window);
+        while rec.hits.len() > FAILED_HITS_CAP {
+            rec.hits.pop_front();
+        }
+    }
+
+    pub fn failed_count(&self, user_hash: u64, ip: IpAddr, window: Duration) -> usize {
+        let now = self.clock.now();
+        match self.failed.get(&(user_hash, ip)) {
+            Some(entry) => {
+                let mut rec = entry.lock();
+                Self::prune_hits(&mut rec.hits, now, window);
+                rec.hits.len()
+            }
+            None => 0,
+        }
+    }
+
+    pub fn record_spray(
+        &self,
+        ip: IpAddr,
+        password_hash: u64,
+        user_hash: u64,
+        window: Duration,
+        threshold: usize,
+    ) -> usize {
+        self.evict_if_over_cap_spray();
+        let now = self.clock.now();
+        let (user_count, transitioned) = {
+            // Scope the DashMap entry so its shard guard is dropped before
+            // we touch a second DashMap (`spray_hits_per_ip`). Without this
+            // scoping, a hash collision on the same shard deadlocks.
+            let entry = self.spray.entry((ip, password_hash)).or_insert_with(|| {
+                Mutex::new(SprayRecord {
+                    users: HashSet::new(),
+                    last_touched: now,
+                })
+            });
+            let mut rec = entry.lock();
+            let was_over_threshold = rec.last_touched + window >= now && rec.users.len() >= threshold;
+            if rec.last_touched + window < now {
+                // Whole window has passed since last touch — reset.
+                rec.users.clear();
+            }
+            rec.last_touched = now;
+            if rec.users.len() < SPRAY_USERS_CAP {
+                rec.users.insert(user_hash);
+            }
+            let now_count = rec.users.len();
+            let transitioned = !was_over_threshold && now_count >= threshold;
+            (now_count, transitioned)
+        };
+        // Idempotent insert into the per-IP password index — the slow-path
+        // re-verify in `any_spray_over_threshold` uses this to bound its
+        // scan to O(passwords-from-this-ip).
+        {
+            let pwd_entry = self
+                .spray_passwords_per_ip
+                .entry(ip)
+                .or_insert_with(|| Mutex::new(HashSet::new()));
+            pwd_entry.lock().insert(password_hash);
+        }
+        if transitioned {
+            self.spray_hits_per_ip
+                .entry(ip)
+                .or_insert_with(|| AtomicUsize::new(0))
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        user_count
+    }
+
+    pub fn spray_count(&self, ip: IpAddr, password_hash: u64, window: Duration) -> usize {
+        let now = self.clock.now();
+        match self.spray.get(&(ip, password_hash)) {
+            Some(entry) => {
+                let rec = entry.lock();
+                if rec.last_touched + window < now {
+                    0
+                } else {
+                    rec.users.len()
+                }
+            }
+            None => 0,
+        }
+    }
+
+    /// Return true when at least one `(ip, password)` record has currently
+    /// reached `threshold` distinct users inside `window`. O(1) fast path via
+    /// the `spray_hits_per_ip` secondary index (an approximate counter),
+    /// falling back to a scoped iteration only over this IP's own spray
+    /// entries when the counter indicates a candidate — avoiding the full
+    /// map scan that would otherwise make this O(N) on every login.
+    pub fn any_spray_over_threshold(&self, ip: IpAddr, threshold: usize, window: Duration) -> bool {
+        // Fast negative path — if the counter is 0, no record ever crossed
+        // the threshold for this IP. Avoids the spray map scan entirely for
+        // the vast majority of legitimate traffic.
+        let candidate_count = self.spray_hits_per_ip.get(&ip).map_or(0, |e| e.load(Ordering::Relaxed));
+        if candidate_count == 0 {
+            return false;
+        }
+        // Slow path — re-verify against live state (counter may be stale
+        // after window expiry). Uses the per-IP password index so we scan
+        // ONLY this IP's records — O(passwords-from-this-ip) not
+        // O(all-IPs * all-passwords). Without this, a single attacker IP
+        // that has ever crossed threshold turns every legitimate login into
+        // a full 100k-entry DashMap scan.
+        let now = self.clock.now();
+        let pwd_hashes: Vec<u64> = self
+            .spray_passwords_per_ip
+            .get(&ip)
+            .map(|e| e.lock().iter().copied().collect())
+            .unwrap_or_default();
+        let hit = pwd_hashes.iter().any(|pwd| {
+            self.spray.get(&(ip, *pwd)).is_some_and(|kv| {
+                let rec = kv.lock();
+                rec.last_touched + window >= now && rec.users.len() >= threshold
+            })
+        });
+        if !hit {
+            // Counter was stale (all candidate records expired). Reset so
+            // future queries take the fast negative path.
+            if let Some(e) = self.spray_hits_per_ip.get(&ip) {
+                e.store(0, Ordering::Relaxed);
+            }
+        }
+        hit
+    }
+
+    fn prune_hits(hits: &mut VecDeque<Instant>, now: Instant, window: Duration) {
+        let cutoff = now.checked_sub(window).unwrap_or(now);
+        while hits.front().is_some_and(|t| *t < cutoff) {
+            hits.pop_front();
+        }
+    }
+
+    fn should_evict_now(&self) -> bool {
+        let tick = self.evict_ticker.fetch_add(1, Ordering::Relaxed);
+        tick.is_multiple_of(EVICT_INTERVAL)
+    }
+
+    fn evict_if_over_cap_failed(&self) {
+        if self.failed.len() <= self.max_entries || !self.should_evict_now() {
+            return;
+        }
+        let mut ages: Vec<((u64, IpAddr), Instant)> = self
+            .failed
+            .iter()
+            .map(|kv| (*kv.key(), kv.value().lock().last_touched))
+            .collect();
+        let over = self.failed.len().saturating_sub(self.max_entries);
+        let drop_n = over.max(ages.len() / 10).min(ages.len());
+        if drop_n == 0 {
+            return;
+        }
+        // Partial-sort: we only need the oldest `drop_n` entries; full sort
+        // is O(N log N) and makes eviction itself a CPU-DoS primitive.
+        if drop_n < ages.len() {
+            ages.select_nth_unstable_by_key(drop_n - 1, |(_, t)| *t);
+        }
+        for (key, _) in ages.into_iter().take(drop_n) {
+            self.failed.remove(&key);
+        }
+    }
+
+    fn evict_if_over_cap_spray(&self) {
+        if self.spray.len() <= self.max_entries || !self.should_evict_now() {
+            return;
+        }
+        let mut ages: Vec<((IpAddr, u64), Instant)> = self
+            .spray
+            .iter()
+            .map(|kv| (*kv.key(), kv.value().lock().last_touched))
+            .collect();
+        let over = self.spray.len().saturating_sub(self.max_entries);
+        let drop_n = over.max(ages.len() / 10).min(ages.len());
+        if drop_n == 0 {
+            return;
+        }
+        if drop_n < ages.len() {
+            ages.select_nth_unstable_by_key(drop_n - 1, |(_, t)| *t);
+        }
+        for (key, _) in ages.into_iter().take(drop_n) {
+            self.spray.remove(&key);
+        }
+    }
+
+    pub fn prune_older_than(&self, cutoff: Instant) {
+        self.failed.retain(|_, rec| rec.lock().last_touched >= cutoff);
+        self.spray.retain(|_, rec| rec.lock().last_touched >= cutoff);
+        // Rebuild the per-IP password index from the surviving spray
+        // records. This is the only place the full spray map is scanned —
+        // kept off the request hot path. `prune_older_than` is a periodic
+        // maintenance call (minutes-scale), not request-phase.
+        self.spray_passwords_per_ip.clear();
+        for kv in self.spray.iter() {
+            let (ip, pwd) = *kv.key();
+            let entry = self
+                .spray_passwords_per_ip
+                .entry(ip)
+                .or_insert_with(|| Mutex::new(HashSet::new()));
+            entry.lock().insert(pwd);
+        }
+        // Secondary counter index is approximate; drop entries for IPs with
+        // no remaining spray records.
+        self.spray_hits_per_ip
+            .retain(|ip, _| self.spray_passwords_per_ip.contains_key(ip));
+    }
+
+    pub fn failed_len(&self) -> usize {
+        self.failed.len()
+    }
+
+    pub fn spray_len(&self) -> usize {
+        self.spray.len()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::duration_suboptimal_units, clippy::redundant_clone)]
+mod tests {
+    use super::*;
+    use crate::checks::test_clock::MockClock;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn failed_count_grows_and_window_expires() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(1000, clock.clone());
+        for _ in 0..5 {
+            s.record_failed(42, ip("1.1.1.1"), Duration::from_secs(900));
+        }
+        assert_eq!(s.failed_count(42, ip("1.1.1.1"), Duration::from_secs(900)), 5);
+        clock.advance(Duration::from_secs(1800));
+        assert_eq!(s.failed_count(42, ip("1.1.1.1"), Duration::from_secs(900)), 0);
+    }
+
+    #[test]
+    fn failed_isolation_by_user_and_ip() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(1000, clock.clone());
+        for _ in 0..5 {
+            s.record_failed(42, ip("1.1.1.1"), Duration::from_secs(900));
+        }
+        assert_eq!(s.failed_count(42, ip("1.1.1.1"), Duration::from_secs(900)), 5);
+        assert_eq!(s.failed_count(43, ip("1.1.1.1"), Duration::from_secs(900)), 0);
+        assert_eq!(s.failed_count(42, ip("2.2.2.2"), Duration::from_secs(900)), 0);
+    }
+
+    const TH: usize = 5;
+
+    #[test]
+    fn spray_counts_distinct_users() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(1000, clock.clone());
+        for user in 0..5_u64 {
+            s.record_spray(ip("9.9.9.9"), 0xdead_beef, user, Duration::from_secs(300), TH);
+        }
+        assert_eq!(s.spray_count(ip("9.9.9.9"), 0xdead_beef, Duration::from_secs(300)), 5);
+    }
+
+    #[test]
+    fn spray_dedups_same_user() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(1000, clock.clone());
+        for _ in 0..10 {
+            s.record_spray(ip("9.9.9.9"), 0xdead, 1, Duration::from_secs(300), TH);
+        }
+        assert_eq!(s.spray_count(ip("9.9.9.9"), 0xdead, Duration::from_secs(300)), 1);
+    }
+
+    #[test]
+    fn spray_window_expires() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(1000, clock.clone());
+        for user in 0..5_u64 {
+            s.record_spray(ip("9.9.9.9"), 0xbeef, user, Duration::from_secs(300), TH);
+        }
+        clock.advance(Duration::from_secs(600));
+        assert_eq!(s.spray_count(ip("9.9.9.9"), 0xbeef, Duration::from_secs(300)), 0);
+    }
+
+    #[test]
+    fn any_spray_over_threshold_detects_cross_password() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(1000, clock.clone());
+        for user in 0..5_u64 {
+            s.record_spray(ip("9.9.9.9"), 0xdead, user, Duration::from_secs(300), TH);
+        }
+        assert!(s.any_spray_over_threshold(ip("9.9.9.9"), 5, Duration::from_secs(300)));
+        assert!(!s.any_spray_over_threshold(ip("9.9.9.9"), 6, Duration::from_secs(300)));
+        assert!(!s.any_spray_over_threshold(ip("8.8.8.8"), 5, Duration::from_secs(300)));
+    }
+
+    #[test]
+    fn any_spray_over_threshold_clears_when_window_expires() {
+        // Validates the approximate-counter reset path: after the window
+        // expires, the secondary index is stale but a single query will
+        // self-correct and subsequent queries return fast-path false.
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(1000, clock.clone());
+        for user in 0..5_u64 {
+            s.record_spray(ip("9.9.9.9"), 0xcafe, user, Duration::from_secs(300), TH);
+        }
+        assert!(s.any_spray_over_threshold(ip("9.9.9.9"), TH, Duration::from_secs(300)));
+        clock.advance(Duration::from_secs(600));
+        assert!(!s.any_spray_over_threshold(ip("9.9.9.9"), TH, Duration::from_secs(300)));
+        // Second query takes the fast-path negative because counter was reset.
+        assert!(!s.any_spray_over_threshold(ip("9.9.9.9"), TH, Duration::from_secs(300)));
+    }
+
+    #[test]
+    fn failed_caps_hits_deque() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(1000, clock.clone());
+        for _ in 0..(FAILED_HITS_CAP + 20) {
+            s.record_failed(42, ip("1.1.1.1"), Duration::from_secs(900));
+        }
+        assert!(s.failed_count(42, ip("1.1.1.1"), Duration::from_secs(900)) <= FAILED_HITS_CAP);
+    }
+
+    #[test]
+    fn failed_map_bounded_by_amortized_eviction() {
+        // Eviction is amortized — every EVICT_INTERVAL calls while over cap.
+        // Worst-case headroom above `max_entries` is one interval's worth.
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(50, clock.clone());
+        let total = 50 + EVICT_INTERVAL + 100;
+        for i in 0..total {
+            let i = i as u64;
+            s.record_failed(
+                i,
+                ip(&format!("10.{}.{}.{}", (i >> 16) & 0xff, (i >> 8) & 0xff, i & 0xff)),
+                Duration::from_secs(900),
+            );
+        }
+        assert!(s.failed_len() < total, "no sweep fired: len={}", s.failed_len());
+        assert!(
+            s.failed_len() <= 50 + EVICT_INTERVAL,
+            "headroom exceeded: len={}",
+            s.failed_len()
+        );
+    }
+
+    #[test]
+    fn spray_map_bounded_by_amortized_eviction() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(50, clock.clone());
+        let total = 50 + EVICT_INTERVAL + 100;
+        for i in 0..total {
+            let i = i as u64;
+            s.record_spray(
+                ip(&format!("10.{}.{}.{}", (i >> 16) & 0xff, (i >> 8) & 0xff, i & 0xff)),
+                0xaa,
+                i,
+                Duration::from_secs(300),
+                TH,
+            );
+        }
+        assert!(s.spray_len() < total, "no sweep fired: len={}", s.spray_len());
+        assert!(
+            s.spray_len() <= 50 + EVICT_INTERVAL,
+            "headroom exceeded: len={}",
+            s.spray_len()
+        );
+    }
+
+    #[test]
+    fn prune_older_than_drops_stale() {
+        let clock = Arc::new(MockClock::new());
+        let s = BfState::new(1000, clock.clone());
+        s.record_failed(1, ip("1.1.1.1"), Duration::from_secs(900));
+        clock.advance(Duration::from_secs(3600));
+        s.record_failed(2, ip("2.2.2.2"), Duration::from_secs(900));
+        let cutoff = clock.now().checked_sub(Duration::from_secs(1800)).unwrap();
+        s.prune_older_than(cutoff);
+        assert_eq!(s.failed_len(), 1);
+    }
+}

--- a/crates/waf-engine/src/checks/dir_traversal.rs
+++ b/crates/waf-engine/src/checks/dir_traversal.rs
@@ -3,39 +3,57 @@ use std::sync::LazyLock;
 use regex::RegexSet;
 use waf_common::{DetectionResult, Phase, RequestCtx};
 
-use super::{Check, url_decode};
+use super::{Check, request_targets};
 
 static TRAVERSAL_DESCS: &[&str] = &[
     "directory traversal (../)",
     "URL-encoded traversal (%2e%2e)",
     "double URL-encoded traversal (%252e%252e)",
-    "Unicode-encoded traversal",
+    "Unicode / overlong UTF-8 traversal",
     "Windows backslash traversal (..\\)",
     "null byte injection (%00)",
-    "absolute path to sensitive directory",
+    "absolute path to sensitive Unix directory",
     "Windows drive-letter path (C:\\)",
+    "Linux sensitive file (/etc/passwd, /etc/shadow, …)",
+    "Linux /proc inspection (/proc/self/environ, /proc/version, …)",
+    "Windows system32 / config",
+    "legacy Windows config file (boot.ini / win.ini)",
 ];
 
 // SAFETY: All patterns are compile-time string literals. If any pattern fails
 // to compile it is a code bug that must be caught in development, not at runtime.
 static TRAVERSAL_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     match RegexSet::new([
-        // Classic ../
+        // Classic `../` and `..\`
         r"(\.\./|\.\.\\)",
-        // URL single-encoded: %2e%2e or %2E%2E (with / or %2f after)
+        // URL single-encoded: `%2e%2e` followed by separator
         r"(?i)%2e%2e(%2f|%5c|/|\\)",
-        // Double URL-encoded: %252e%252e
+        // Double URL-encoded: `%252e%252e`
         r"(?i)%252e%252e",
-        // Unicode / overlong encoding
+        // Unicode / overlong UTF-8 encodings
         r"(?i)\.\.((%c0%af)|(%c1%9c)|(%e0%80%af)|(%c0%9v))",
-        // Windows backslash traversal
+        // Windows backslash traversal — kept for descriptor parity with the
+        // Classic arm so the `..\\` hit attributes to the Windows-specific
+        // descriptor rather than the generic one.
         r"\.\.\\",
         // Null byte
         r"%00",
-        // Absolute path to known sensitive Unix directories
+        // Absolute path to broadly sensitive Unix directories
         r"(?i)/(etc|proc|var/log|usr/local|root|home|tmp|dev|sys)(/|$)",
-        // Windows drive-letter path
+        // Windows drive-letter path (e.g. `C:\`)
         r"(?i)[A-Za-z]:\\",
+        // Linux sensitive file targets — anchored on `/etc/` so a benign
+        // route like `/api/passwd-reset` cannot match.
+        r"(?i)/etc/(passwd|shadow|hosts|group|fstab|sudoers)",
+        // Linux /proc/<pid>/<file> probes — pid is `self` or numeric.
+        r"(?i)/proc/(self|[0-9]+)/(environ|status|cmdline|version|maps|cwd)",
+        // Windows system32 / config attempts (must include the literal
+        // backslash before `system32` to avoid hitting random `system32`
+        // mentions in user content).
+        r"(?i)\\windows\\system32(\\|$)",
+        // Legacy Windows boot/config files — word-boundary anchored so
+        // benign paths like `version.txt` don't false-match.
+        r"(?i)(^|[/\\])\b(boot|win)\.ini\b",
     ]) {
         Ok(set) => set,
         Err(e) => {
@@ -66,19 +84,17 @@ impl Check for DirTraversalCheck {
             return None;
         }
 
-        // Check both the raw path/query and their decoded forms.
-        let candidates = [
-            ("path", ctx.path.clone()),
-            ("path(decoded)", url_decode(&ctx.path)),
-            ("query", ctx.query.clone()),
-            ("query(decoded)", url_decode(&ctx.query)),
-        ];
-
-        for (location, value) in &candidates {
+        // Reuse `request_targets()` so we get raw + single-decoded + recursively-
+        // decoded variants of path / query / cookie / body in one pass. This is
+        // strictly more coverage than the previous bespoke `candidates` array
+        // (which missed the recursive variant — i.e. `..%252f..%252fetc%252fpasswd`
+        // double-encoded payloads weren't catching the `..` segment after the
+        // first single-decode pass).
+        for (location, value) in request_targets(ctx) {
             if value.is_empty() {
                 continue;
             }
-            let matches = TRAVERSAL_SET.matches(value);
+            let matches = TRAVERSAL_SET.matches(&value);
             if matches.matched_any() {
                 let idx = matches.iter().next().unwrap_or(0);
                 let desc = TRAVERSAL_DESCS.get(idx).copied().unwrap_or("path traversal");
@@ -157,5 +173,147 @@ mod tests {
         let checker = DirTraversalCheck::new();
         let ctx = make_ctx("/api/v1/users", "page=2");
         assert!(checker.check(&ctx).is_none());
+    }
+
+    // ─── FR-015 enhancements: OS targets + recursive decode + null byte ──────
+
+    #[test]
+    fn detects_etc_passwd_in_path() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/files/../../etc/passwd", "");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_proc_self_environ_in_query() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/", "file=/proc/self/environ");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_proc_version_in_query() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/", "file=/proc/123/cmdline");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_windows_system32_in_query() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/", "f=C:\\windows\\system32\\config\\sam");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_windows_boot_ini() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/files/boot.ini", "");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_windows_win_ini() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/files/win.ini", "");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_overlong_utf8_traversal() {
+        // ..%c0%af is overlong UTF-8 for `/`.
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/static/..%c0%af..%c0%afetc%c0%afpasswd", "");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_null_byte_truncation() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/uploads/photo.jpg%00.php", "");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_recursive_double_encoded_in_path() {
+        // %25 → %, then %2e%2e → .. — only catchable via the recursive pass.
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/files/%252e%252e%252fetc%252fpasswd", "");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_recursive_double_encoded_in_query() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/", "f=%252e%252e%252fetc%252fpasswd");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn allows_benign_passwd_route() {
+        // `/api/passwd-reset` is a common UI route; must NOT trigger the
+        // /etc/passwd matcher (it's anchored on `/etc/`).
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/api/passwd-reset", "user=alice");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn allows_filename_with_double_dot_no_separator() {
+        // `..hidden.txt` (no `/` or `\` after `..`) must not trigger the
+        // classic-traversal regex which requires the path separator.
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/files/..hidden.txt", "");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn allows_version_txt_filename() {
+        // `version.txt` must not trigger the `/proc/<pid>/version` matcher.
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/docs/version.txt", "");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn skipped_when_dir_traversal_disabled() {
+        let checker = DirTraversalCheck::new();
+        let mut ctx = make_ctx("/files/../../etc/passwd", "");
+        // Override config to disable.
+        ctx.host_config = Arc::new(HostConfig {
+            defense_config: DefenseConfig {
+                dir_traversal: false,
+                ..DefenseConfig::default()
+            },
+            ..HostConfig::default()
+        });
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_traversal_in_cookie() {
+        let checker = DirTraversalCheck::new();
+        let mut ctx = make_ctx("/", "");
+        ctx.headers
+            .insert("cookie".to_string(), "next=../../etc/passwd".to_string());
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_traversal_in_body() {
+        let checker = DirTraversalCheck::new();
+        let mut ctx = make_ctx("/", "");
+        ctx.body_preview = Bytes::from("path=/etc/shadow");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detection_carries_correct_phase_and_rule_id() {
+        let checker = DirTraversalCheck::new();
+        let ctx = make_ctx("/files/../../etc/passwd", "");
+        let det = checker.check(&ctx).expect("hit");
+        assert_eq!(det.phase, Phase::DirTraversal);
+        assert_eq!(det.rule_name, "Directory Traversal");
+        assert!(det.rule_id.as_deref().unwrap_or("").starts_with("TRAV-"));
     }
 }

--- a/crates/waf-engine/src/checks/header_injection.rs
+++ b/crates/waf-engine/src/checks/header_injection.rs
@@ -1,0 +1,524 @@
+//! HTTP header injection detection (FR-017).
+//!
+//! Scans every request header for raw / percent-encoded CRLF (response-splitting
+//! primitive), validates the `Host` header against a per-host whitelist, and
+//! sanity-checks `X-Forwarded-For` for leftmost-private and excessive-hop-count
+//! patterns.
+//!
+//! SNI-vs-Host comparison is intentionally NOT implemented in v1 — `RequestCtx`
+//! has no `sni` field (Red Team Finding #12). Whitelist-only validation is the
+//! ship target; operators must populate `defense_config.host_inbound_whitelist`
+//! per host or the Host check is a no-op for that host.
+
+use std::net::IpAddr;
+
+use waf_common::{DetectionResult, Phase, RequestCtx};
+
+use super::Check;
+use super::header_injection_patterns::{HDR_ENCODED_CRLF_DESCS, HDR_ENCODED_CRLF_SET};
+
+/// HTTP header injection checker.
+pub struct HeaderInjectionCheck;
+
+impl HeaderInjectionCheck {
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for HeaderInjectionCheck {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Check for HeaderInjectionCheck {
+    fn check(&self, ctx: &RequestCtx) -> Option<DetectionResult> {
+        if !ctx.host_config.defense_config.header_injection {
+            return None;
+        }
+
+        // ── Rules 1, 2, 5: CRLF in any header (name or value) ──────────────
+        for (name, value) in &ctx.headers {
+            if has_raw_crlf_or_nul(name) {
+                return Some(detection(
+                    5,
+                    "CRLF/NUL in header name (response splitting primitive)",
+                    name,
+                ));
+            }
+            if has_raw_crlf_or_nul(value) {
+                return Some(detection(1, "raw CRLF/NUL in header value", name));
+            }
+            if let Some(idx) = HDR_ENCODED_CRLF_SET.matches(value).iter().next() {
+                let desc = HDR_ENCODED_CRLF_DESCS.get(idx).copied().unwrap_or("encoded CRLF");
+                return Some(detection(2, desc, name));
+            }
+        }
+
+        // ── Rule 3: Host header validation ─────────────────────────────────
+        if let Some(host_value) = ctx.headers.get("host") {
+            if !is_valid_host_header(host_value) {
+                return Some(detection(3, "malformed Host header", "host"));
+            }
+            let whitelist = &ctx.host_config.defense_config.host_inbound_whitelist;
+            if !whitelist.is_empty() && !host_in_whitelist(host_value, whitelist) {
+                return Some(detection(3, "Host not in inbound whitelist", "host"));
+            }
+        }
+
+        // ── Rule 4: X-Forwarded-For chain checks ───────────────────────────
+        if let Some(xff) = ctx.headers.get("x-forwarded-for") {
+            let max_hops = ctx.host_config.defense_config.xf2_max_hops;
+            if let Some(reason) = validate_x_forwarded_for(xff, ctx.client_ip, max_hops) {
+                return Some(detection(4, reason, "x-forwarded-for"));
+            }
+        }
+
+        None
+    }
+}
+
+fn detection(rule_seq: usize, desc: &str, location: &str) -> DetectionResult {
+    DetectionResult {
+        rule_id: Some(format!("HDR-{rule_seq:03}")),
+        rule_name: "Header Injection".to_string(),
+        phase: Phase::HeaderInjection,
+        detail: format!("{desc} in {location}"),
+    }
+}
+
+/// Raw CR (`\r`), LF (`\n`), or NUL (`\0`) in the byte stream of a header
+/// value or name. NUL is included because some proxies treat it as a
+/// terminator the same way a CRLF splits the header section.
+fn has_raw_crlf_or_nul(s: &str) -> bool {
+    s.bytes().any(|b| matches!(b, b'\r' | b'\n' | 0))
+}
+
+/// A Host header is considered well-formed when:
+/// - it is non-empty,
+/// - contains no whitespace, no `,`, no `@`, no CR/LF/NUL,
+/// - has at most one `:` (the port separator) outside of an IPv6 literal.
+///
+/// IPv6 literals are wrapped in brackets `[…]:port`, which we recognise so we
+/// don't false-flag them.
+fn is_valid_host_header(host: &str) -> bool {
+    if host.is_empty() {
+        return false;
+    }
+    if has_raw_crlf_or_nul(host) {
+        return false;
+    }
+    if host.bytes().any(|b| matches!(b, b' ' | b'\t' | b',' | b'@')) {
+        return false;
+    }
+    // IPv6 literal form: must be `[...]` optionally followed by `:port`.
+    if host.starts_with('[') {
+        let Some(close) = host.find(']') else {
+            return false;
+        };
+        // Body inside the brackets must contain at least one `:` (IPv6 has them).
+        if close == 1 {
+            return false;
+        }
+        // After `]`, allow nothing or `:digits`.
+        match host.get(close + 1..) {
+            Some("") | None => return true,
+            Some(rest) if rest.starts_with(':') && rest[1..].bytes().all(|b| b.is_ascii_digit()) => return true,
+            _ => return false,
+        }
+    }
+    // Otherwise: at most one `:` (port separator).
+    host.matches(':').count() <= 1
+}
+
+/// Case-insensitive whitelist match. Strips the `:port` suffix before comparison
+/// so `Host: example.com:8080` matches `example.com` in the whitelist.
+fn host_in_whitelist(host: &str, whitelist: &[String]) -> bool {
+    let host_no_port = strip_port(host);
+    whitelist.iter().any(|allowed| {
+        let allowed_no_port = strip_port(allowed);
+        host_no_port.eq_ignore_ascii_case(allowed_no_port)
+    })
+}
+
+/// Strip `:port` from a host string, respecting IPv6 bracketed form.
+///
+/// Unbracketed IPv6 (`::1`, `fe80::1`) has multiple `:` and cannot have a
+/// port — strip nothing and return as-is, so whitelist comparison falls
+/// through to a full-string match rather than silently truncating.
+fn strip_port(host: &str) -> &str {
+    if let Some(rest) = host.strip_prefix('[') {
+        if let Some(close) = rest.find(']') {
+            return &rest[..close];
+        }
+        return host;
+    }
+    if host.matches(':').count() > 1 {
+        return host;
+    }
+    match host.rsplit_once(':') {
+        Some((head, tail)) if tail.bytes().all(|b| b.is_ascii_digit()) => head,
+        _ => host,
+    }
+}
+
+/// Validate `X-Forwarded-For`. Returns `Some(reason)` when malformed or
+/// suspicious; `None` for clean.
+fn validate_x_forwarded_for<'a>(value: &str, client_ip: IpAddr, max_hops: usize) -> Option<&'a str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let hops: Vec<&str> = trimmed.split(',').map(str::trim).filter(|s| !s.is_empty()).collect();
+    if hops.is_empty() {
+        return None;
+    }
+    if max_hops > 0 && hops.len() > max_hops {
+        return Some("X-Forwarded-For chain exceeds max_hops");
+    }
+    // Leftmost hop — the originating client. If our actual client_ip is public
+    // and the leftmost claims to be private, the request is lying about its
+    // origin (classic XFF spoofing primitive).
+    if !is_private_or_loopback(client_ip)
+        && let Some(first) = hops.first()
+        && let Ok(addr) = first.parse::<IpAddr>()
+        && is_private_or_loopback(addr)
+    {
+        return Some("X-Forwarded-For leftmost is private but client_ip is public");
+    }
+    None
+}
+
+const fn is_private_or_loopback(addr: IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(v4) => v4.is_loopback() || v4.is_private() || v4.is_link_local(),
+        IpAddr::V6(v6) => {
+            if v6.is_loopback() {
+                return true;
+            }
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return v4.is_loopback() || v4.is_private() || v4.is_link_local();
+            }
+            let segs = v6.segments();
+            (segs[0] & 0xfe00 == 0xfc00) || (segs[0] & 0xffc0 == 0xfe80)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use waf_common::{DefenseConfig, HostConfig};
+
+    fn make_ctx(headers: HashMap<String, String>, client_ip: &str, dc: DefenseConfig) -> RequestCtx {
+        RequestCtx {
+            req_id: "test".to_string(),
+            client_ip: client_ip.parse().unwrap(),
+            client_port: 0,
+            method: "GET".to_string(),
+            host: "example.com".to_string(),
+            port: 80,
+            path: "/".to_string(),
+            query: String::new(),
+            headers,
+            body_preview: Bytes::new(),
+            content_length: 0,
+            is_tls: false,
+            host_config: Arc::new(HostConfig {
+                defense_config: dc,
+                ..HostConfig::default()
+            }),
+            geo: None,
+            tier: waf_common::tier::Tier::CatchAll,
+            tier_policy: waf_common::RequestCtx::default_tier_policy(),
+            cookies: HashMap::new(),
+        }
+    }
+
+    fn mk(name: &str, value: &str) -> HashMap<String, String> {
+        let mut h = HashMap::new();
+        h.insert(name.to_string(), value.to_string());
+        h
+    }
+
+    // ─── Rule 1: raw CRLF in value ───────────────────────────────────────
+
+    #[test]
+    fn detects_raw_crlf_in_referer() {
+        let ctx = make_ctx(
+            mk("referer", "foo\r\nSet-Cookie: admin=1"),
+            "8.8.8.8",
+            DefenseConfig::default(),
+        );
+        let det = HeaderInjectionCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "HDR-001");
+    }
+
+    #[test]
+    fn detects_raw_lf_only() {
+        let ctx = make_ctx(mk("user-agent", "evil\nfoo"), "8.8.8.8", DefenseConfig::default());
+        assert!(HeaderInjectionCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_nul_byte_in_value() {
+        let ctx = make_ctx(mk("x-custom", "abc\0def"), "8.8.8.8", DefenseConfig::default());
+        assert!(HeaderInjectionCheck::new().check(&ctx).is_some());
+    }
+
+    // ─── Rule 2: encoded CRLF ────────────────────────────────────────────
+
+    #[test]
+    fn detects_single_encoded_crlf() {
+        let ctx = make_ctx(
+            mk("user-agent", "foo%0d%0aSet-Cookie: x"),
+            "8.8.8.8",
+            DefenseConfig::default(),
+        );
+        let det = HeaderInjectionCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "HDR-002");
+    }
+
+    #[test]
+    fn detects_double_encoded_crlf() {
+        let ctx = make_ctx(
+            mk("cookie", "a=b%250d%250aSet-Cookie:y"),
+            "8.8.8.8",
+            DefenseConfig::default(),
+        );
+        let det = HeaderInjectionCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "HDR-002");
+    }
+
+    // ─── Rule 5: CRLF in header NAME ─────────────────────────────────────
+
+    #[test]
+    fn detects_crlf_in_header_name() {
+        let mut h = HashMap::new();
+        h.insert("evil\nname".to_string(), "value".to_string());
+        let ctx = make_ctx(h, "8.8.8.8", DefenseConfig::default());
+        let det = HeaderInjectionCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "HDR-005");
+    }
+
+    // ─── Rule 3: Host header validation ──────────────────────────────────
+
+    #[test]
+    fn detects_host_with_at_sign() {
+        let ctx = make_ctx(mk("host", "evil.com@target.com"), "8.8.8.8", DefenseConfig::default());
+        let det = HeaderInjectionCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "HDR-003");
+    }
+
+    #[test]
+    fn detects_host_with_space() {
+        let ctx = make_ctx(
+            mk("host", "target.com target2.com"),
+            "8.8.8.8",
+            DefenseConfig::default(),
+        );
+        let det = HeaderInjectionCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "HDR-003");
+    }
+
+    #[test]
+    fn detects_host_with_comma() {
+        let ctx = make_ctx(mk("host", "a.com,b.com"), "8.8.8.8", DefenseConfig::default());
+        assert!(HeaderInjectionCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn allows_clean_host_with_port() {
+        let ctx = make_ctx(mk("host", "example.com:8080"), "8.8.8.8", DefenseConfig::default());
+        assert!(HeaderInjectionCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn allows_clean_ipv6_host() {
+        let ctx = make_ctx(mk("host", "[2606:4700::1111]:443"), "8.8.8.8", DefenseConfig::default());
+        assert!(HeaderInjectionCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_host_not_in_whitelist() {
+        let dc = DefenseConfig {
+            host_inbound_whitelist: vec!["legit.com".to_string()],
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx(mk("host", "evil.com"), "8.8.8.8", dc);
+        let det = HeaderInjectionCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "HDR-003");
+    }
+
+    #[test]
+    fn allows_host_in_whitelist() {
+        let dc = DefenseConfig {
+            host_inbound_whitelist: vec!["legit.com".to_string()],
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx(mk("host", "legit.com"), "8.8.8.8", dc);
+        assert!(HeaderInjectionCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn whitelist_match_strips_port() {
+        let dc = DefenseConfig {
+            host_inbound_whitelist: vec!["legit.com".to_string()],
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx(mk("host", "legit.com:8443"), "8.8.8.8", dc);
+        assert!(HeaderInjectionCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn empty_whitelist_skips_host_check() {
+        // Default whitelist is empty — Host validation falls through to syntax
+        // checks only. Operators must opt in per host.
+        let ctx = make_ctx(mk("host", "anything.example"), "8.8.8.8", DefenseConfig::default());
+        assert!(HeaderInjectionCheck::new().check(&ctx).is_none());
+    }
+
+    // ─── Rule 4: X-Forwarded-For ─────────────────────────────────────────
+
+    #[test]
+    fn detects_xff_leftmost_private_with_public_client() {
+        let ctx = make_ctx(
+            mk("x-forwarded-for", "10.0.0.1, 1.2.3.4"),
+            "1.2.3.4",
+            DefenseConfig::default(),
+        );
+        let det = HeaderInjectionCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "HDR-004");
+    }
+
+    #[test]
+    fn allows_xff_leftmost_public() {
+        let ctx = make_ctx(
+            mk("x-forwarded-for", "1.2.3.4, 5.6.7.8"),
+            "5.6.7.8",
+            DefenseConfig::default(),
+        );
+        assert!(HeaderInjectionCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_xff_chain_exceeds_max_hops() {
+        let chain = "1.1.1.1, 2.2.2.2, 3.3.3.3, 4.4.4.4, 5.5.5.5, 6.6.6.6";
+        let dc = DefenseConfig {
+            xf2_max_hops: 5,
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx(mk("x-forwarded-for", chain), "1.1.1.1", dc);
+        let det = HeaderInjectionCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "HDR-004");
+    }
+
+    #[test]
+    fn allows_xff_under_max_hops() {
+        let dc = DefenseConfig {
+            xf2_max_hops: 5,
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx(mk("x-forwarded-for", "1.1.1.1, 2.2.2.2, 3.3.3.3"), "3.3.3.3", dc);
+        assert!(HeaderInjectionCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn allows_empty_xff() {
+        let ctx = make_ctx(mk("x-forwarded-for", ""), "8.8.8.8", DefenseConfig::default());
+        assert!(HeaderInjectionCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn allows_xff_when_client_ip_is_private() {
+        // If our ingress is itself private (e.g. internal mesh request), a
+        // private leftmost is plausible — don't false-flag.
+        let ctx = make_ctx(
+            mk("x-forwarded-for", "10.0.0.1, 192.168.1.5"),
+            "10.0.0.1",
+            DefenseConfig::default(),
+        );
+        assert!(HeaderInjectionCheck::new().check(&ctx).is_none());
+    }
+
+    // ─── Cross-cutting ────────────────────────────────────────────────────
+
+    #[test]
+    fn allows_clean_authorization_jwt() {
+        let ctx = make_ctx(
+            mk("authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIx.foo"),
+            "8.8.8.8",
+            DefenseConfig::default(),
+        );
+        assert!(HeaderInjectionCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn allows_clean_user_agent() {
+        let ctx = make_ctx(
+            mk("user-agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"),
+            "8.8.8.8",
+            DefenseConfig::default(),
+        );
+        assert!(HeaderInjectionCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn skipped_when_check_disabled() {
+        let dc = DefenseConfig {
+            header_injection: false,
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx(mk("referer", "foo\r\nSet-Cookie: x"), "8.8.8.8", dc);
+        assert!(HeaderInjectionCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn empty_headers_no_detection() {
+        let ctx = make_ctx(HashMap::new(), "8.8.8.8", DefenseConfig::default());
+        assert!(HeaderInjectionCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn allows_utf8_value_with_no_crlf() {
+        let ctx = make_ctx(mk("x-custom", "héllo wörld 你好"), "8.8.8.8", DefenseConfig::default());
+        assert!(HeaderInjectionCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detection_carries_correct_phase() {
+        let ctx = make_ctx(mk("referer", "foo\r\n"), "8.8.8.8", DefenseConfig::default());
+        let det = HeaderInjectionCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.phase, Phase::HeaderInjection);
+        assert_eq!(det.rule_name, "Header Injection");
+    }
+
+    // ─── strip_port unit tests ──────────────────────────────────────────
+
+    #[test]
+    fn strip_port_plain_host() {
+        assert_eq!(strip_port("example.com"), "example.com");
+        assert_eq!(strip_port("example.com:8080"), "example.com");
+    }
+
+    #[test]
+    fn strip_port_ipv6_bracketed() {
+        assert_eq!(strip_port("[::1]"), "::1");
+        assert_eq!(strip_port("[::1]:8080"), "::1");
+    }
+
+    #[test]
+    fn strip_port_unbracketed_ipv6_left_as_is() {
+        // Unbracketed IPv6 has multiple `:` — the last segment is NOT a
+        // port. Truncating it (as the naive rsplit_once would) turns a
+        // whitelist entry of `::1` into `""`, which then matches any
+        // empty-Host input. Regression for I4.
+        assert_eq!(strip_port("::1"), "::1");
+        assert_eq!(strip_port("fe80::1"), "fe80::1");
+        assert_eq!(strip_port("2606:4700:4700::1111"), "2606:4700:4700::1111");
+    }
+}

--- a/crates/waf-engine/src/checks/header_injection_patterns.rs
+++ b/crates/waf-engine/src/checks/header_injection_patterns.rs
@@ -1,0 +1,28 @@
+//! Header-injection pattern data — encoded CRLF detection.
+//!
+//! Raw CRLF is bytewise-scanned in `header_injection.rs`; this file holds the
+//! regex set that catches single- and double-percent-encoded forms.
+
+use std::sync::LazyLock;
+
+use regex::RegexSet;
+
+/// Description text aligned with `HDR_ENCODED_CRLF_SET` patterns by index.
+pub static HDR_ENCODED_CRLF_DESCS: &[&str] = &[
+    "single-encoded CRLF (%0d%0a)",
+    "double-encoded CRLF (%250d%250a)",
+    "single-encoded LF only (%0a) — header smuggling primitive",
+    "double-encoded LF only (%250a)",
+];
+
+// SAFETY: Compile-time string literals; failure is a code bug.
+pub static HDR_ENCODED_CRLF_SET: LazyLock<RegexSet> =
+    LazyLock::new(
+        || match RegexSet::new([r"(?i)%0d%0a", r"(?i)%250d%250a", r"(?i)%0a", r"(?i)%250a"]) {
+            Ok(set) => set,
+            Err(e) => {
+                tracing::error!("BUG: header-injection encoded-CRLF regex set failed to compile: {e}");
+                RegexSet::empty()
+            }
+        },
+    );

--- a/crates/waf-engine/src/checks/mod.rs
+++ b/crates/waf-engine/src/checks/mod.rs
@@ -1,30 +1,46 @@
 pub mod anti_hotlink;
+pub mod body_abuse;
+pub(crate) mod body_abuse_walker;
 pub mod bot;
+pub mod brute_force;
+pub(crate) mod brute_force_extractors;
+pub(crate) mod brute_force_state;
 pub mod ddos;
 pub mod dir_traversal;
 pub mod geo;
+pub mod header_injection;
+pub(crate) mod header_injection_patterns;
 pub mod owasp;
 pub mod rate_limit;
 pub mod rce;
 pub mod scanner;
+pub(crate) mod scanner_state;
 pub mod sensitive;
 pub mod sql_injection;
 pub(crate) mod sql_injection_patterns;
 pub(crate) mod sql_injection_scanners;
+pub mod ssrf;
+pub(crate) mod ssrf_patterns;
+pub(crate) mod ssrf_scanners;
 pub mod tx_velocity;
 pub mod xss;
+pub(crate) mod xss_scanners;
 
 pub use anti_hotlink::AntiHotlinkCheck;
+pub use body_abuse::RequestBodyAbuseCheck;
 pub use bot::BotCheck;
+pub use brute_force::BruteForceCheck;
 pub use ddos::{DdosCheck, DdosConfig, DdosFileConfig, DdosMetrics, DdosReloader};
 pub use dir_traversal::DirTraversalCheck;
 pub use geo::{GeoCheck, GeoRule, GeoRuleMode};
+pub use header_injection::HeaderInjectionCheck;
 pub use owasp::OWASPCheck;
 pub use rate_limit::{RateLimitCheck, RateLimitConfig};
 pub use rce::RceCheck;
 pub use scanner::ScannerCheck;
 pub use sensitive::SensitiveCheck;
 pub use sql_injection::SqlInjectionCheck;
+pub use ssrf::SsrfCheck;
 pub use xss::XssCheck;
 
 use waf_common::{DetectionResult, RequestCtx};
@@ -32,10 +48,72 @@ use waf_common::{DetectionResult, RequestCtx};
 /// Trait implemented by every WAF checker module.
 ///
 /// Each checker is stateless (detection patterns) or uses interior mutability
-/// (CC rate limiter). The pipeline calls `check()` in sequence and
-/// short-circuits on the first `Some(result)`.
+/// (rate limiter, brute-force state). The pipeline calls `check()` in
+/// sequence and short-circuits on the first `Some(result)`.
 pub trait Check: Send + Sync {
     fn check(&self, ctx: &RequestCtx) -> Option<DetectionResult>;
+
+    /// Default no-op response hook. Override in checks that need upstream
+    /// status (FR-018 brute force, FR-019 4xx-burst). Body is NOT exposed in
+    /// v1: Pingora `response_filter` gives headers + status only; the body
+    /// path via `response_body_filter` is deferred.
+    fn on_response(&self, _ctx: &RequestCtx, _status: u16) {}
+}
+
+/// Monotonic clock abstraction so stateful checks (FR-018 brute-force,
+/// FR-019 scanner sliding-window) can be tested without sleeping.
+///
+/// Production wires `SystemClock`; tests inject `MockClock` and call
+/// `advance()` to move time forward deterministically.
+pub trait Clock: Send + Sync {
+    fn now(&self) -> std::time::Instant;
+}
+
+/// Real-time `Clock` implementation backed by `Instant::now()`.
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> std::time::Instant {
+        std::time::Instant::now()
+    }
+}
+
+#[cfg(test)]
+pub mod test_clock {
+    use super::Clock;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Test fixture clock — advances only when `advance()` is called.
+    pub struct MockClock {
+        offset_nanos: AtomicU64,
+        base: std::time::Instant,
+    }
+
+    impl MockClock {
+        pub fn new() -> Self {
+            Self {
+                offset_nanos: AtomicU64::new(0),
+                base: std::time::Instant::now(),
+            }
+        }
+
+        pub fn advance(&self, dur: std::time::Duration) {
+            let nanos = u64::try_from(dur.as_nanos()).unwrap_or(u64::MAX);
+            self.offset_nanos.fetch_add(nanos, Ordering::SeqCst);
+        }
+    }
+
+    impl Default for MockClock {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl Clock for MockClock {
+        fn now(&self) -> std::time::Instant {
+            self.base + std::time::Duration::from_nanos(self.offset_nanos.load(Ordering::SeqCst))
+        }
+    }
 }
 
 // ─── Shared utilities ─────────────────────────────────────────────────────────

--- a/crates/waf-engine/src/checks/scanner.rs
+++ b/crates/waf-engine/src/checks/scanner.rs
@@ -1,9 +1,11 @@
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
+use std::time::Duration;
 
 use regex::RegexSet;
 use waf_common::{DetectionResult, Phase, RequestCtx};
 
-use super::Check;
+use super::scanner_state::ScannerState;
+use super::{Check, Clock, SystemClock};
 
 static SCANNER_UA_DESCS: &[&str] = &[
     "sqlmap (SQL injection scanner)",
@@ -119,12 +121,39 @@ static SCRIPTED_CLIENT_UA_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     }
 });
 
-/// Security scanner / automated tool detection checker (User-Agent based).
-pub struct ScannerCheck;
+/// Security scanner / automated tool detection checker.
+///
+/// Combines three signals:
+/// 1. User-Agent regex match against known scanner / scripted-client UAs
+///    (always on; the original behaviour, untouched).
+/// 2. Endpoint enumeration — too many distinct paths from one `client_ip`
+///    inside `defense_config.scanner_window_secs` (FR-019).
+/// 3. OPTIONS preflight abuse — too many OPTIONS requests inside the same
+///    window (FR-019).
+///
+/// 4xx / 5xx burst detection is deferred until the response-side hook is
+/// wired in Phase 07; the state machine is already shape-compatible.
+pub struct ScannerCheck {
+    state: Arc<ScannerState>,
+}
 
 impl ScannerCheck {
-    pub const fn new() -> Self {
-        Self
+    pub fn new() -> Self {
+        Self::with_clock(Arc::new(SystemClock))
+    }
+
+    pub fn with_clock(clock: Arc<dyn Clock>) -> Self {
+        // 100k cap matches DefenseConfig::default().scanner_max_ips. Per-host
+        // overrides take effect at request time via the threshold reads.
+        Self {
+            state: Arc::new(ScannerState::new(100_000, clock)),
+        }
+    }
+
+    /// Expose the inner state so an engine bootstrap can drive periodic
+    /// `prune_older_than` calls (Phase 07/08 wiring).
+    pub fn state(&self) -> Arc<ScannerState> {
+        Arc::clone(&self.state)
     }
 }
 
@@ -171,6 +200,42 @@ impl Check for ScannerCheck {
                     detail: format!("{desc} User-Agent detected (block_scripted_clients=true)"),
                 });
             }
+        }
+
+        // FR-019 sliding-window heuristics. Dedup the path by stripping query
+        // so health-check-with-cachebuster traffic does not look like enum.
+        let dc = &ctx.host_config.defense_config;
+        let window = Duration::from_secs(dc.scanner_window_secs);
+
+        if ctx.method.eq_ignore_ascii_case("OPTIONS") {
+            let count = self.state.record_options(ctx.client_ip, window);
+            if count >= dc.scanner_options_threshold {
+                return Some(DetectionResult {
+                    rule_id: Some("SCAN-OPT-001".to_string()),
+                    rule_name: "Scanner".to_string(),
+                    phase: Phase::Scanner,
+                    detail: format!(
+                        "OPTIONS preflight abuse: {count} requests from {ip} in {secs}s",
+                        ip = ctx.client_ip,
+                        secs = dc.scanner_window_secs,
+                    ),
+                });
+            }
+        }
+
+        let path_key = ctx.path.split('?').next().unwrap_or(ctx.path.as_str());
+        let distinct = self.state.record_path(ctx.client_ip, path_key, window);
+        if distinct >= dc.scanner_endpoint_enum_threshold {
+            return Some(DetectionResult {
+                rule_id: Some("SCAN-ENUM-001".to_string()),
+                rule_name: "Scanner".to_string(),
+                phase: Phase::Scanner,
+                detail: format!(
+                    "endpoint enumeration: {distinct} distinct paths from {ip} in {secs}s",
+                    ip = ctx.client_ip,
+                    secs = dc.scanner_window_secs,
+                ),
+            });
         }
 
         None
@@ -297,6 +362,131 @@ mod tests {
                 panic!("sqlmap UA should always be blocked (strict={strict})");
             });
             assert_eq!(result.rule_name, "Scanner");
+        }
+    }
+
+    // ─── FR-019 sliding-window heuristics ────────────────────────────────
+
+    use crate::checks::test_clock::MockClock;
+    use std::time::Duration;
+    #[allow(clippy::duration_suboptimal_units)]
+    const TEST_WINDOW_EXPIRED: Duration = Duration::from_secs(120);
+
+    fn make_ctx_with_method_path(method: &str, path: &str, ip: &str) -> RequestCtx {
+        let mut ctx = make_ctx_with("Mozilla/5.0", false);
+        ctx.method = method.to_string();
+        ctx.path = path.to_string();
+        ctx.client_ip = ip.parse().unwrap();
+        ctx
+    }
+
+    #[test]
+    fn endpoint_enumeration_threshold_triggers_detection() {
+        let clock = Arc::new(MockClock::new());
+        let checker = ScannerCheck::with_clock(clock);
+        // Default threshold is 30 distinct paths.
+        for i in 0..29 {
+            let ctx = make_ctx_with_method_path("GET", &format!("/p{i}"), "5.6.7.8");
+            assert!(checker.check(&ctx).is_none(), "should not fire at {i} distinct paths");
+        }
+        let ctx = make_ctx_with_method_path("GET", "/p30", "5.6.7.8");
+        let det = checker.check(&ctx).expect("hit at 30 distinct");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "SCAN-ENUM-001");
+    }
+
+    #[test]
+    fn endpoint_enumeration_window_expires() {
+        let clock = Arc::new(MockClock::new());
+        let checker = ScannerCheck::with_clock(clock.clone());
+        for i in 0..29 {
+            let ctx = make_ctx_with_method_path("GET", &format!("/p{i}"), "5.6.7.8");
+            checker.check(&ctx);
+        }
+        clock.advance(TEST_WINDOW_EXPIRED);
+        // After window passage, the buffer is fresh — one new path = 1 distinct.
+        let ctx = make_ctx_with_method_path("GET", "/p_new", "5.6.7.8");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn endpoint_enum_dedups_by_path_ignoring_query() {
+        // /a?cb=1, /a?cb=2, /a?cb=3 should count as one distinct path.
+        let clock = Arc::new(MockClock::new());
+        let checker = ScannerCheck::with_clock(clock);
+        for i in 0..50 {
+            let ctx = make_ctx_with_method_path("GET", &format!("/api/health?cb={i}"), "5.6.7.8");
+            assert!(checker.check(&ctx).is_none());
+        }
+    }
+
+    #[test]
+    fn options_threshold_triggers_detection() {
+        let clock = Arc::new(MockClock::new());
+        let checker = ScannerCheck::with_clock(clock);
+        // Default threshold is 20.
+        for _ in 0..19 {
+            let ctx = make_ctx_with_method_path("OPTIONS", "/api/users", "5.6.7.8");
+            assert!(checker.check(&ctx).is_none());
+        }
+        let ctx = make_ctx_with_method_path("OPTIONS", "/api/users", "5.6.7.8");
+        let det = checker.check(&ctx).expect("hit at 20");
+        assert_eq!(det.rule_id.as_deref().unwrap_or(""), "SCAN-OPT-001");
+    }
+
+    #[test]
+    fn options_window_expires() {
+        let clock = Arc::new(MockClock::new());
+        let checker = ScannerCheck::with_clock(clock.clone());
+        for _ in 0..19 {
+            let ctx = make_ctx_with_method_path("OPTIONS", "/api/users", "5.6.7.8");
+            checker.check(&ctx);
+        }
+        clock.advance(TEST_WINDOW_EXPIRED);
+        let ctx = make_ctx_with_method_path("OPTIONS", "/api/users", "5.6.7.8");
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn per_ip_isolation_does_not_leak() {
+        let clock = Arc::new(MockClock::new());
+        let checker = ScannerCheck::with_clock(clock);
+        // IP A racks up 29 distinct paths.
+        for i in 0..29 {
+            let ctx = make_ctx_with_method_path("GET", &format!("/p{i}"), "1.1.1.1");
+            checker.check(&ctx);
+        }
+        // IP B starts cold — single request, no detection.
+        let ctx_b = make_ctx_with_method_path("GET", "/p0", "2.2.2.2");
+        assert!(checker.check(&ctx_b).is_none());
+    }
+
+    #[test]
+    fn ua_scanner_short_circuits_before_state_lookup() {
+        let clock = Arc::new(MockClock::new());
+        let checker = ScannerCheck::with_clock(clock);
+        let mut ctx = make_ctx_with_method_path("OPTIONS", "/", "5.6.7.8");
+        ctx.headers.insert("user-agent".to_string(), "sqlmap/1.7".to_string());
+        let det = checker.check(&ctx).expect("hit");
+        // UA hit gives SCAN-001..SCAN-032, never the state-machine SCAN-OPT-001.
+        let id = det.rule_id.as_deref().unwrap_or("");
+        assert!(id.starts_with("SCAN-") && !id.contains("OPT") && !id.contains("ENUM"));
+    }
+
+    #[test]
+    fn skipped_when_scan_disabled_even_for_state_signals() {
+        let clock = Arc::new(MockClock::new());
+        let checker = ScannerCheck::with_clock(clock);
+        let mut ctx = make_ctx_with_method_path("OPTIONS", "/", "5.6.7.8");
+        // Disable scanner check entirely.
+        ctx.host_config = Arc::new(waf_common::HostConfig {
+            defense_config: DefenseConfig {
+                scan: false,
+                ..DefenseConfig::default()
+            },
+            ..waf_common::HostConfig::default()
+        });
+        for _ in 0..50 {
+            assert!(checker.check(&ctx).is_none());
         }
     }
 }

--- a/crates/waf-engine/src/checks/scanner_state.rs
+++ b/crates/waf-engine/src/checks/scanner_state.rs
@@ -1,0 +1,336 @@
+//! Per-IP sliding-window state for FR-019 scanner detection.
+//!
+//! Tracks two signals: distinct paths visited (endpoint enumeration) and
+//! OPTIONS requests issued (preflight abuse). Both windows share the same
+//! length, sourced from `defense_config.scanner_window_secs`.
+//!
+//! State is bounded: when the per-IP map exceeds `max_entries`, the oldest
+//! 10 percent (by last-touched timestamp) are evicted. This prevents an
+//! attacker rotating IPv6 /64 prefixes from OOM-ing the engine — Red Team
+//! Finding #6.
+//!
+//! Time is read through an injected [`Clock`] so tests can advance windows
+//! deterministically without sleeping (Validation Q7).
+
+// `duration_suboptimal_units` flags `from_secs(60)` etc. across the test
+// bodies; we keep the literals as seconds for readability against the
+// `scanner_window_secs` config name. `significant_drop_tightening` flags
+// the DashMap entry held during a Mutex lock — restructuring to drop the
+// entry RefMut early would require owning the inner `Arc<Mutex<…>>` per
+// record. `redundant_clone` fires on test fixtures.
+#![allow(
+    clippy::duration_suboptimal_units,
+    clippy::significant_drop_tightening,
+    clippy::redundant_clone
+)]
+
+use std::collections::{HashMap, VecDeque};
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+use parking_lot::Mutex;
+
+use super::Clock;
+
+/// Per-IP record: ring buffer of path hits + incremental distinct-path
+/// index + ring buffer of OPTIONS timestamps, plus the wall-clock instant
+/// of the most recent touch (used by eviction).
+struct IpRecord {
+    /// `(timestamp, path)` pairs — newest at the back. Pruned on every push
+    /// to keep the buffer bounded by the active window. Duplicate paths ARE
+    /// appended (so window-expiry is cheap) but deduped at count-time via
+    /// `paths_set`.
+    paths: VecDeque<(Instant, String)>,
+    /// `path → count` of occurrences currently in `paths`. Avoids the
+    /// per-request O(N) rebuild `HashSet<&str>::from_iter` paid on every
+    /// `distinct_paths()` call — under sustained one-IP-one-path traffic
+    /// the `VecDeque` grows to window-sized, and the rebuild was O(N) per
+    /// request = O(N²) over the window.
+    paths_set: HashMap<String, usize>,
+    /// Timestamps of OPTIONS requests within the active window.
+    options: VecDeque<Instant>,
+    last_touched: Instant,
+}
+
+impl IpRecord {
+    fn new(now: Instant) -> Self {
+        Self {
+            paths: VecDeque::new(),
+            paths_set: HashMap::new(),
+            options: VecDeque::new(),
+            last_touched: now,
+        }
+    }
+
+    /// Push a path hit and update the incremental distinct-path index.
+    fn push_path(&mut self, now: Instant, path: &str) {
+        // Bump or insert; only the first occurrence contributes to
+        // distinct-path count.
+        *self.paths_set.entry(path.to_string()).or_insert(0) += 1;
+        self.paths.push_back((now, path.to_string()));
+        // Hard cap to bound per-record memory under sustained abuse —
+        // an attacker whose request stream stays inside one window can
+        // otherwise grow `paths` by req-rate × window-len. The distinct
+        // count we care about is `paths_set.len()`, so the deque only
+        // needs enough headroom to roll old entries out of the window.
+        // (Pre-merge Finding I3.)
+        while self.paths.len() > PATHS_HARD_CAP {
+            let Some((_, old_path)) = self.paths.pop_front() else {
+                break;
+            };
+            if let Some(count) = self.paths_set.get_mut(&old_path) {
+                *count = count.saturating_sub(1);
+                if *count == 0 {
+                    self.paths_set.remove(&old_path);
+                }
+            }
+        }
+    }
+
+    /// Drop entries older than `window` ago, decrementing / removing from
+    /// the distinct-path index as entries leave the window.
+    fn prune(&mut self, now: Instant, window: Duration) {
+        let cutoff = now.checked_sub(window).unwrap_or(now);
+        while let Some((t, _)) = self.paths.front() {
+            if *t >= cutoff {
+                break;
+            }
+            let Some((_, old_path)) = self.paths.pop_front() else {
+                break;
+            };
+            if let Some(count) = self.paths_set.get_mut(&old_path) {
+                *count = count.saturating_sub(1);
+                if *count == 0 {
+                    self.paths_set.remove(&old_path);
+                }
+            }
+        }
+        while self.options.front().is_some_and(|t| *t < cutoff) {
+            self.options.pop_front();
+        }
+    }
+
+    /// O(1) — just the length of the distinct-path index.
+    fn distinct_paths(&self) -> usize {
+        self.paths_set.len()
+    }
+}
+
+/// How many `record_*` calls over `max_entries` must happen before we pay
+/// the O(N log N) eviction scan. Amortizes the cost so an attacker spamming
+/// unique IPs past the cap cannot turn eviction itself into a `DoS` amplifier.
+const EVICT_INTERVAL: usize = 1024;
+
+/// Hard cap on per-IP `IpRecord.paths` length. Caps memory cost of any
+/// single attacker IP at `O(PATHS_HARD_CAP × avg_path_len)` — distinct-path
+/// detection reads `paths_set.len()` so the deque only needs slack to roll
+/// old entries out by time-window.
+const PATHS_HARD_CAP: usize = 1024;
+
+pub struct ScannerState {
+    per_ip: Arc<DashMap<IpAddr, Mutex<IpRecord>>>,
+    max_entries: usize,
+    /// Counts calls while over capacity — only every `EVICT_INTERVAL`'th
+    /// triggers an actual eviction sweep.
+    evict_ticker: AtomicUsize,
+    clock: Arc<dyn Clock>,
+}
+
+impl ScannerState {
+    pub fn new(max_entries: usize, clock: Arc<dyn Clock>) -> Self {
+        Self {
+            per_ip: Arc::new(DashMap::new()),
+            max_entries,
+            evict_ticker: AtomicUsize::new(0),
+            clock,
+        }
+    }
+
+    /// Record one path visit and return the current distinct-path count
+    /// inside `window` for this client.
+    pub fn record_path(&self, ip: IpAddr, path: &str, window: Duration) -> usize {
+        self.evict_if_over_cap();
+        let now = self.clock.now();
+        let entry = self.per_ip.entry(ip).or_insert_with(|| Mutex::new(IpRecord::new(now)));
+        let mut rec = entry.lock();
+        rec.last_touched = now;
+        rec.push_path(now, path);
+        rec.prune(now, window);
+        rec.distinct_paths()
+    }
+
+    /// Record one OPTIONS request and return the current OPTIONS count
+    /// inside `window` for this client.
+    pub fn record_options(&self, ip: IpAddr, window: Duration) -> usize {
+        self.evict_if_over_cap();
+        let now = self.clock.now();
+        let entry = self.per_ip.entry(ip).or_insert_with(|| Mutex::new(IpRecord::new(now)));
+        let mut rec = entry.lock();
+        rec.last_touched = now;
+        rec.options.push_back(now);
+        rec.prune(now, window);
+        rec.options.len()
+    }
+
+    /// Drop the oldest 10 percent of entries (by `last_touched`) — but only
+    /// once every [`EVICT_INTERVAL`] calls while over cap. Amortizes the
+    /// O(N log N) sort so an attacker cycling IPv6 prefixes cannot turn
+    /// eviction itself into a CPU amplifier.
+    fn evict_if_over_cap(&self) {
+        if self.per_ip.len() <= self.max_entries {
+            return;
+        }
+        let tick = self.evict_ticker.fetch_add(1, Ordering::Relaxed);
+        if !tick.is_multiple_of(EVICT_INTERVAL) {
+            return;
+        }
+        let mut ages: Vec<(IpAddr, Instant)> = self
+            .per_ip
+            .iter()
+            .map(|kv| (*kv.key(), kv.value().lock().last_touched))
+            .collect();
+        // Drop enough to come back below cap, capped at 10 percent of current size.
+        let over = self.per_ip.len().saturating_sub(self.max_entries);
+        let drop_n = over.max(ages.len() / 10).min(ages.len());
+        if drop_n == 0 {
+            return;
+        }
+        // Partial-sort: we only need the `drop_n` smallest-by-timestamp
+        // entries at the front of the vec; full sort is O(N log N) and makes
+        // the eviction path its own CPU-DoS primitive under IPv6 /64
+        // rotation. `select_nth_unstable_by_key` is O(N) average.
+        if drop_n < ages.len() {
+            ages.select_nth_unstable_by_key(drop_n - 1, |(_, t)| *t);
+        }
+        for (ip, _) in ages.into_iter().take(drop_n) {
+            self.per_ip.remove(&ip);
+        }
+    }
+
+    /// Drop every entry whose `last_touched` is older than `cutoff`. Run by
+    /// a periodic prune task in production.
+    pub fn prune_older_than(&self, cutoff: Instant) {
+        self.per_ip.retain(|_, rec| rec.lock().last_touched >= cutoff);
+    }
+
+    pub fn len(&self) -> usize {
+        self.per_ip.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.per_ip.is_empty()
+    }
+}
+
+// `manual_duration_constructor` from the workspace `nursery` lints fires on
+// every `Duration::from_secs(60)` / `from_secs(120)` we use here — clippy
+// would prefer multiplying-by-60 idioms. The literals stay readable as-is.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checks::test_clock::MockClock;
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn record_path_returns_growing_distinct_count() {
+        let clock = Arc::new(MockClock::new());
+        let s = ScannerState::new(1000, clock.clone());
+        assert_eq!(s.record_path(ip("1.1.1.1"), "/a", Duration::from_secs(60)), 1);
+        assert_eq!(s.record_path(ip("1.1.1.1"), "/b", Duration::from_secs(60)), 2);
+        assert_eq!(s.record_path(ip("1.1.1.1"), "/c", Duration::from_secs(60)), 3);
+    }
+
+    #[test]
+    fn duplicate_paths_count_once() {
+        let clock = Arc::new(MockClock::new());
+        let s = ScannerState::new(1000, clock.clone());
+        for _ in 0..5 {
+            s.record_path(ip("1.1.1.1"), "/same", Duration::from_secs(60));
+        }
+        assert_eq!(s.record_path(ip("1.1.1.1"), "/same", Duration::from_secs(60)), 1);
+    }
+
+    #[test]
+    fn distinct_paths_window_expires() {
+        let clock = Arc::new(MockClock::new());
+        let s = ScannerState::new(1000, clock.clone());
+        s.record_path(ip("1.1.1.1"), "/a", Duration::from_secs(60));
+        s.record_path(ip("1.1.1.1"), "/b", Duration::from_secs(60));
+        clock.advance(Duration::from_secs(120));
+        // Both prior entries are now outside the window; new entry is
+        // alone in the buffer.
+        assert_eq!(s.record_path(ip("1.1.1.1"), "/c", Duration::from_secs(60)), 1);
+    }
+
+    #[test]
+    fn options_count_grows_then_window_expires() {
+        let clock = Arc::new(MockClock::new());
+        let s = ScannerState::new(1000, clock.clone());
+        for _ in 0..10 {
+            s.record_options(ip("1.1.1.1"), Duration::from_secs(60));
+        }
+        assert_eq!(s.record_options(ip("1.1.1.1"), Duration::from_secs(60)), 11);
+        clock.advance(Duration::from_secs(120));
+        assert_eq!(s.record_options(ip("1.1.1.1"), Duration::from_secs(60)), 1);
+    }
+
+    #[test]
+    fn per_ip_isolation() {
+        let clock = Arc::new(MockClock::new());
+        let s = ScannerState::new(1000, clock.clone());
+        for i in 0..5 {
+            s.record_path(ip("1.1.1.1"), &format!("/p{i}"), Duration::from_secs(60));
+        }
+        // Different IP starts fresh.
+        assert_eq!(s.record_path(ip("2.2.2.2"), "/x", Duration::from_secs(60)), 1);
+    }
+
+    #[test]
+    fn caps_at_max_entries_eventually() {
+        // Eviction is amortized (every EVICT_INTERVAL calls while over cap) to
+        // prevent the evict-sweep itself being a DoS vector. Test that size
+        // stays bounded by (max + EVICT_INTERVAL) — the worst-case headroom —
+        // and drops back to ~max once an eviction sweep fires.
+        let clock = Arc::new(MockClock::new());
+        let s = ScannerState::new(100, clock.clone());
+        let total = 100 + EVICT_INTERVAL + 100;
+        for i in 0..total {
+            s.record_path(
+                ip(&format!("10.{}.{}.{}", (i >> 16) & 0xff, (i >> 8) & 0xff, i & 0xff)),
+                "/a",
+                Duration::from_secs(60),
+            );
+        }
+        // At least one sweep fired — size is strictly below total inserted.
+        assert!(s.len() < total, "no sweep fired: len={}", s.len());
+        // Worst-case headroom above cap is one interval's worth.
+        assert!(s.len() <= 100 + EVICT_INTERVAL, "headroom exceeded: len={}", s.len());
+    }
+
+    #[test]
+    fn prune_older_than_drops_stale_entries() {
+        let clock = Arc::new(MockClock::new());
+        let s = ScannerState::new(1000, clock.clone());
+        s.record_path(ip("1.1.1.1"), "/old", Duration::from_secs(60));
+        clock.advance(Duration::from_secs(600));
+        s.record_path(ip("2.2.2.2"), "/new", Duration::from_secs(60));
+        let cutoff = clock.now().checked_sub(Duration::from_secs(300)).unwrap();
+        s.prune_older_than(cutoff);
+        assert_eq!(s.len(), 1);
+    }
+
+    #[test]
+    fn empty_state_starts_at_zero() {
+        let clock = Arc::new(MockClock::new());
+        let s = ScannerState::new(1000, clock);
+        assert!(s.is_empty());
+        assert_eq!(s.len(), 0);
+    }
+}

--- a/crates/waf-engine/src/checks/ssrf.rs
+++ b/crates/waf-engine/src/checks/ssrf.rs
@@ -1,0 +1,372 @@
+//! Server-Side Request Forgery detection (FR-016).
+//!
+//! Scans every `http(s)://…` URL it can find in body, query, cookie, and the
+//! SSRF-prone headers; resolves the host string via `url::Url::parse` (so the
+//! `user@host` userinfo bypass — Capital One 2019 — cannot smuggle a metadata
+//! IP past a substring filter); and flags the request when the resolved host
+//! is either a known cloud-metadata identifier or an RFC1918 / loopback /
+//! link-local IP, including obfuscated dword / hex / octal / IPv6-mapped
+//! forms.
+//!
+//! No DNS resolution in v1 — the DNS-rebinding mitigation requires an
+//! upstream resolver hook and is deferred (see plan §Out of Scope).
+
+use std::net::IpAddr;
+
+use url::{Host, Url};
+use waf_common::{DetectionResult, Phase, RequestCtx};
+
+use super::Check;
+use super::ssrf_patterns::{METADATA_HOST_DESCS, METADATA_HOST_SET};
+use super::ssrf_scanners::{extract_urls, is_private_ip, parse_obfuscated_ip};
+
+pub struct SsrfCheck;
+
+impl SsrfCheck {
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for SsrfCheck {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Check for SsrfCheck {
+    fn check(&self, ctx: &RequestCtx) -> Option<DetectionResult> {
+        if !ctx.host_config.defense_config.ssrf {
+            return None;
+        }
+
+        let allowlist = &ctx.host_config.defense_config.ssrf_outbound_host_allowlist;
+
+        for (location, candidate) in extract_urls(ctx) {
+            // Parse via `url::Url` so userinfo `user[:pass]@host` is split out
+            // and we get the real host — substring extraction would let
+            // `http://google.com@169.254.169.254/` look benign.
+            let Ok(url) = Url::parse(&candidate) else {
+                continue;
+            };
+            let Some(host) = url.host() else {
+                continue;
+            };
+
+            // Textual form for allowlist + metadata-regex matching. `url::Host`
+            // strips the IPv6 brackets so `[::1]` arrives here as `::1`, which
+            // is what we want.
+            let host_text = match &host {
+                Host::Domain(s) => (*s).to_string(),
+                Host::Ipv4(v4) => v4.to_string(),
+                Host::Ipv6(v6) => v6.to_string(),
+            };
+
+            if allowlist.iter().any(|allowed| allowed.eq_ignore_ascii_case(&host_text)) {
+                continue;
+            }
+
+            // Rule 1-3: literal metadata identifier — runs against the textual
+            // host so it catches both `metadata.google.internal` (Domain arm)
+            // and `100.100.100.200` (Ipv4 arm — not in a private CIDR).
+            if let Some(idx) = METADATA_HOST_SET.matches(&host_text).iter().next() {
+                let desc = METADATA_HOST_DESCS.get(idx).copied().unwrap_or("metadata host");
+                return Some(detection(idx + 1, desc, &location, &host_text));
+            }
+
+            // Rule 4-5: typed IPv4/IPv6 hosts go straight through the CIDR
+            // check; Domain hosts try the obfuscated-IP normaliser first.
+            let private_hit = match host {
+                Host::Ipv4(v4) => is_private_ip(IpAddr::V4(v4)),
+                Host::Ipv6(v6) => is_private_ip(IpAddr::V6(v6)),
+                Host::Domain(d) => parse_obfuscated_ip(d).is_some_and(is_private_ip),
+            };
+            if private_hit {
+                return Some(detection(
+                    METADATA_HOST_DESCS.len() + 1,
+                    "private / loopback / link-local IP",
+                    &location,
+                    &host_text,
+                ));
+            }
+        }
+        None
+    }
+}
+
+fn detection(rule_seq: usize, desc: &str, location: &str, host: &str) -> DetectionResult {
+    DetectionResult {
+        rule_id: Some(format!("SSRF-{rule_seq:03}")),
+        rule_name: "SSRF".to_string(),
+        phase: Phase::Ssrf,
+        detail: format!("{desc} ({host}) referenced from {location}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use std::collections::HashMap;
+    use std::net::IpAddr;
+    use std::sync::Arc;
+    use waf_common::{DefenseConfig, HostConfig};
+
+    fn make_ctx(query: &str, body: &str) -> RequestCtx {
+        make_ctx_with(query, body, HashMap::new(), DefenseConfig::default())
+    }
+
+    fn make_ctx_with(query: &str, body: &str, headers: HashMap<String, String>, dc: DefenseConfig) -> RequestCtx {
+        RequestCtx {
+            req_id: "test".to_string(),
+            client_ip: "127.0.0.1".parse::<IpAddr>().unwrap(),
+            client_port: 0,
+            method: "POST".to_string(),
+            host: "example.com".to_string(),
+            port: 80,
+            path: "/api/webhook".to_string(),
+            query: query.to_string(),
+            headers,
+            body_preview: Bytes::from(body.to_string()),
+            content_length: body.len() as u64,
+            is_tls: false,
+            host_config: Arc::new(HostConfig {
+                defense_config: dc,
+                ..HostConfig::default()
+            }),
+            geo: None,
+            tier: waf_common::tier::Tier::CatchAll,
+            tier_policy: waf_common::RequestCtx::default_tier_policy(),
+            cookies: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn detects_rfc1918_in_body_json() {
+        let ctx = make_ctx("", r#"{"webhook_url":"http://10.1.2.3/api"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_172_16_range_in_query() {
+        let ctx = make_ctx("target=http://172.16.0.1/", "");
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_192_168_range_in_referer() {
+        let mut h = HashMap::new();
+        h.insert("referer".to_string(), "http://192.168.1.1/admin".to_string());
+        let ctx = make_ctx_with("", "", h, DefenseConfig::default());
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_loopback() {
+        let ctx = make_ctx("", r#"{"target":"http://127.0.0.1:8080/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_localhost() {
+        // Belt-and-suspenders: `localhost` and friends resolve to 127.0.0.1
+        // on virtually every deployment, so they belong on the metadata
+        // denylist before DNS lands (Pre-merge Finding R1).
+        for host in ["localhost", "localhost.localdomain", "ip6-localhost", "ip6-loopback"] {
+            let body = format!(r#"{{"target":"http://{host}/admin"}}"#);
+            let ctx = make_ctx("", &body);
+            assert!(
+                SsrfCheck::new().check(&ctx).is_some(),
+                "expected SSRF detection for hostname {host}"
+            );
+        }
+    }
+
+    #[test]
+    fn detects_aws_metadata() {
+        let ctx = make_ctx("", r#"{"u":"http://169.254.169.254/latest/meta-data/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_gcp_metadata() {
+        let ctx = make_ctx("", r#"{"u":"http://metadata.google.internal/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_alibaba_metadata() {
+        let ctx = make_ctx("", r#"{"u":"http://100.100.100.200/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_consul_metadata() {
+        let ctx = make_ctx("", r#"{"u":"http://metadata.service.consul/v1/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_ipv6_mapped_ipv4_metadata() {
+        let ctx = make_ctx("", r#"{"u":"http://[::ffff:169.254.169.254]/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_ipv6_mapped_alibaba_metadata() {
+        // Regression: `100.100.100.200` is intentionally NOT in PRIVATE_CIDRS
+        // (that would flag the whole CGNAT range). The IPv6-mapped form
+        // `::ffff:100.100.100.200` needs an explicit re-check against the
+        // metadata regex set, otherwise it bypasses SSRF entirely even though
+        // the bare `100.100.100.200` is caught.
+        let ctx = make_ctx("", r#"{"u":"http://[::ffff:100.100.100.200]/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_ipv6_loopback() {
+        let ctx = make_ctx("", r#"{"u":"http://[::1]/admin"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_obfuscated_decimal_dword() {
+        let ctx = make_ctx("", r#"{"u":"http://2130706433/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_obfuscated_hex_dword() {
+        let ctx = make_ctx("", r#"{"u":"http://0x7f000001/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_obfuscated_octal_dword() {
+        let ctx = make_ctx("", r#"{"u":"http://017700000001/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn allows_clean_public_url() {
+        let ctx = make_ctx("", r#"{"webhook":"https://api.stripe.com/v1/charges"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn allows_clean_example_com() {
+        let ctx = make_ctx("", r#"{"webhook":"https://example.com/hooks/abc"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn skipped_when_ssrf_disabled() {
+        let dc = DefenseConfig {
+            ssrf: false,
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx_with("", r#"{"u":"http://169.254.169.254/"}"#, HashMap::new(), dc);
+        assert!(SsrfCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_url_in_nested_json_object() {
+        let ctx = make_ctx("", r#"{"outer":{"inner":{"hook":"http://10.0.0.5/"}}}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_url_in_json_array() {
+        let ctx = make_ctx("", r#"{"hooks":["https://api.public.com/", "http://10.20.30.40/"]}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn empty_body_no_detection() {
+        let ctx = make_ctx("", "");
+        assert!(SsrfCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_form_urlencoded_body_after_decode() {
+        let ctx = make_ctx("", "webhook=http%3A//10.0.0.1/&user=alice");
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_userinfo_bypass_aws_metadata() {
+        // Capital One 2019 — substring filters defeated by `user@host`.
+        // url::Url::parse treats `google.com` as userinfo and the metadata IP
+        // as host, so detection still fires.
+        let ctx = make_ctx("", r#"{"u":"http://google.com@169.254.169.254/latest/meta-data/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn allows_metadata_ip_as_userinfo_only() {
+        // Inverse: 169.254.169.254 in the userinfo position is harmless
+        // because the actual host is google.com.
+        let ctx = make_ctx("", r#"{"u":"http://169.254.169.254@google.com/"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn malformed_url_skipped_not_panicked() {
+        // Unclosed bracket — Url::parse fails, we skip rather than crash.
+        let ctx = make_ctx("", r#"{"u":"http://[::1"}"#);
+        let _ = SsrfCheck::new().check(&ctx);
+    }
+
+    #[test]
+    fn allowlist_bypasses_detection() {
+        let dc = DefenseConfig {
+            ssrf_outbound_host_allowlist: vec!["10.0.0.42".to_string()],
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx_with("", r#"{"u":"http://10.0.0.42/internal"}"#, HashMap::new(), dc);
+        assert!(SsrfCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn allowlist_match_is_case_insensitive_for_hostnames() {
+        let dc = DefenseConfig {
+            ssrf_outbound_host_allowlist: vec!["Internal.Service".to_string()],
+            ..DefenseConfig::default()
+        };
+        let ctx = make_ctx_with("", r#"{"u":"http://internal.service/api"}"#, HashMap::new(), dc);
+        // Hostname only — no IP resolution — but allowlist match should
+        // exempt regardless. (Defense in depth: even if a future rule starts
+        // flagging hostnames, allowlist still wins.)
+        assert!(SsrfCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_destination_header() {
+        let mut h = HashMap::new();
+        h.insert("destination".to_string(), "http://10.0.0.5/".to_string());
+        let ctx = make_ctx_with("", "", h, DefenseConfig::default());
+        assert!(SsrfCheck::new().check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detection_carries_correct_phase_and_rule_id() {
+        let ctx = make_ctx("", r#"{"u":"http://169.254.169.254/"}"#);
+        let det = SsrfCheck::new().check(&ctx).expect("hit");
+        assert_eq!(det.phase, Phase::Ssrf);
+        assert_eq!(det.rule_name, "SSRF");
+        assert!(det.rule_id.as_deref().unwrap_or("").starts_with("SSRF-"));
+    }
+
+    #[test]
+    fn allows_public_ip_addresses() {
+        let ctx = make_ctx("", r#"{"u":"http://8.8.8.8/dns"}"#);
+        assert!(SsrfCheck::new().check(&ctx).is_none());
+    }
+
+    #[test]
+    fn first_malicious_url_short_circuits() {
+        let ctx = make_ctx("", r#"{"a":"http://10.0.0.1/", "b":"https://api.public.com/"}"#);
+        let det = SsrfCheck::new().check(&ctx).expect("hit");
+        assert!(det.detail.contains("10.0.0.1"));
+    }
+}

--- a/crates/waf-engine/src/checks/ssrf_patterns.rs
+++ b/crates/waf-engine/src/checks/ssrf_patterns.rs
@@ -1,0 +1,64 @@
+//! SSRF pattern data — metadata hostnames and private-network CIDRs.
+//!
+//! Kept in a sibling file so `ssrf.rs` stays under the modularization limit.
+
+use std::sync::LazyLock;
+
+use ipnet::Ipv4Net;
+use regex::RegexSet;
+
+/// Cloud / orchestrator metadata hostnames that should never be reachable
+/// from a user-supplied URL. Anchored with `^` so a request body containing
+/// `metadata.google.internal.attacker.com` does not slip past as a substring.
+///
+/// `localhost` and its `/etc/hosts` variants are included as a cheap
+/// belt-and-suspenders before DNS resolution lands (Pre-merge Finding R1):
+/// virtually every host resolves these to 127.0.0.1, so a webhook URL
+/// containing `http://localhost/admin` is an SSRF risk.
+pub static METADATA_HOST_DESCS: &[&str] = &[
+    "AWS / OpenStack metadata IP (169.254.169.254)",
+    "Google Cloud metadata host",
+    "Alibaba Cloud metadata IP (100.100.100.200)",
+    "Consul metadata service",
+    "DigitalOcean / generic 'metadata' host",
+    "localhost / loopback hostname",
+];
+
+// SAFETY: Compile-time string literals; failure is a code bug.
+pub static METADATA_HOST_SET: LazyLock<RegexSet> = LazyLock::new(|| {
+    match RegexSet::new([
+        r"^169\.254\.169\.254$",
+        r"^metadata\.google\.internal$",
+        r"^100\.100\.100\.200$",
+        r"^metadata\.service\.consul$",
+        r"^metadata(\.|$)",
+        r"^(localhost|localhost\.localdomain|ip6-localhost|ip6-loopback)$",
+    ]) {
+        Ok(set) => set,
+        Err(e) => {
+            tracing::error!("BUG: SSRF metadata host regex set failed to compile: {e}");
+            RegexSet::empty()
+        }
+    }
+});
+
+/// Private / loopback / link-local IPv4 ranges. Caller should also test the
+/// IPv4 form of an IPv6-mapped address against this set.
+///
+/// 100.64.0.0/10 (RFC 6598 carrier-grade NAT) is intentionally NOT included
+/// — only the exact metadata IP `100.100.100.200` is flagged via the regex
+/// set above. Treating the whole CGNAT range as SSRF would false-flag
+/// legitimate calls into ISP-shared address space.
+pub static PRIVATE_CIDRS: LazyLock<Vec<Ipv4Net>> = LazyLock::new(|| {
+    [
+        "10.0.0.0/8",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+        "127.0.0.0/8",
+        "169.254.0.0/16",
+        "0.0.0.0/8",
+    ]
+    .iter()
+    .filter_map(|s| s.parse::<Ipv4Net>().ok())
+    .collect()
+});

--- a/crates/waf-engine/src/checks/ssrf_scanners.rs
+++ b/crates/waf-engine/src/checks/ssrf_scanners.rs
@@ -1,0 +1,257 @@
+//! SSRF helpers — URL extraction, obfuscated-IP normalisation, RFC1918 check.
+//!
+//! Kept in a sibling file so `ssrf.rs` stays under the modularization limit.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::LazyLock;
+
+use regex::Regex;
+use waf_common::RequestCtx;
+
+use super::ssrf_patterns::{METADATA_HOST_SET, PRIVATE_CIDRS};
+use super::url_decode_recursive;
+
+/// Headers that have historically been the SSRF foothold and are worth scanning
+/// even if the body is empty. Lowercase — `RequestCtx.headers` keys arrive
+/// lowercase from the gateway.
+const URL_BEARING_HEADERS: &[&str] = &[
+    "referer",
+    "location",
+    "x-original-url",
+    "x-rewrite-url",
+    "x-forwarded-host",
+    "x-forwarded-server",
+    "destination",
+    "forwarded",
+];
+
+// SAFETY: compile-time literal — failure is a code bug.
+static URL_RE: LazyLock<Regex> = LazyLock::new(|| {
+    match Regex::new(r#"(?i)https?://[^\s\x00-\x20\x7f"'<>\\]+"#) {
+        Ok(re) => re,
+        Err(e) => {
+            tracing::error!("BUG: SSRF URL extractor regex failed to compile: {e}");
+            // Returning a regex that matches nothing keeps the check from
+            // firing rather than panicking the engine.
+            #[allow(clippy::expect_used)]
+            Regex::new(r"$^").expect("trivial regex must compile")
+        }
+    }
+});
+
+/// Pull every `http(s)://…` substring from request body, query, cookie, and
+/// the SSRF-prone headers. Each candidate is recursively url-decoded before
+/// regex extraction so `webhook=http%3A//10.0.0.1/` is normalised first.
+pub fn extract_urls(ctx: &RequestCtx) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = Vec::new();
+
+    let mut push_from = |location: &str, text: &str| {
+        if text.is_empty() {
+            return;
+        }
+        let decoded = url_decode_recursive(text);
+        for m in URL_RE.find_iter(&decoded) {
+            out.push((location.to_string(), m.as_str().to_string()));
+        }
+    };
+
+    push_from("query", &ctx.query);
+    if !ctx.body_preview.is_empty() {
+        let body_str = String::from_utf8_lossy(&ctx.body_preview);
+        push_from("body", &body_str);
+    }
+    for header_name in URL_BEARING_HEADERS {
+        if let Some(value) = ctx.headers.get(*header_name) {
+            push_from(&format!("header.{header_name}"), value);
+        }
+    }
+    if let Some(cookie) = ctx.headers.get("cookie") {
+        push_from("cookie", cookie);
+    }
+    out
+}
+
+/// Parse a host string into an `IpAddr`, accepting the obfuscated forms that
+/// classic SSRF payloads use to bypass naive substring filters.
+///
+/// Recognised:
+/// - `127.0.0.1`, `::1` (canonical)
+/// - `0x7f000001` / `0X7F000001` (hex dword)
+/// - `017700000001` (leading-zero octal dword)
+/// - `2130706433` (decimal dword)
+///
+/// Mixed-radix dotted forms like `0x7F.0.0.1` are normalised by `Url::parse`
+/// before this function ever sees the `host_str`, so they reach this code as
+/// `127.0.0.1` already.
+pub fn parse_obfuscated_ip(s: &str) -> Option<IpAddr> {
+    if let Ok(addr) = s.parse::<IpAddr>() {
+        return Some(addr);
+    }
+    if let Some(rest) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X"))
+        && let Ok(n) = u32::from_str_radix(rest, 16)
+    {
+        return Some(IpAddr::V4(Ipv4Addr::from(n)));
+    }
+    if s.starts_with('0')
+        && s.len() > 1
+        && !s.starts_with("0x")
+        && !s.starts_with("0X")
+        && s.bytes().all(|b| (b'0'..=b'7').contains(&b))
+        && let Ok(n) = u32::from_str_radix(s, 8)
+    {
+        return Some(IpAddr::V4(Ipv4Addr::from(n)));
+    }
+    if s.bytes().all(|b| b.is_ascii_digit())
+        && let Ok(n) = s.parse::<u32>()
+    {
+        return Some(IpAddr::V4(Ipv4Addr::from(n)));
+    }
+    None
+}
+
+/// Return `true` if the IP belongs to a private / loopback / link-local
+/// range — i.e. should not be reachable from a user-supplied URL.
+///
+/// IPv6 addresses are first tested for loopback (`::1`) and IPv4-mapped form
+/// (`::ffff:a.b.c.d`); the mapped IPv4 is then run through the same CIDR set
+/// so `[::ffff:169.254.169.254]` is caught the same way `169.254.169.254` is.
+pub fn is_private_ip(addr: IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(v4) => PRIVATE_CIDRS.iter().any(|net| net.contains(&v4)),
+        IpAddr::V6(v6) => {
+            if v6.is_loopback() {
+                return true;
+            }
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                if PRIVATE_CIDRS.iter().any(|net| net.contains(&v4)) {
+                    return true;
+                }
+                // Metadata IPs (e.g. 100.100.100.200 Alibaba, 169.254.169.254
+                // AWS) that ride in PRIVATE_CIDRS would already have matched;
+                // the 100.100.100.200 case is deliberately excluded from
+                // PRIVATE_CIDRS to avoid flagging the whole CGNAT range, so
+                // we re-check the bare IPv4 text against the metadata regex
+                // set here to close the `[::ffff:100.100.100.200]` bypass.
+                return METADATA_HOST_SET.is_match(&v4.to_string());
+            }
+            // Reject IPv6 unique-local + link-local prefixes; everything
+            // else is treated as routable for v1.
+            let segs = v6.segments();
+            // fc00::/7 (unique-local)
+            if segs[0] & 0xfe00 == 0xfc00 {
+                return true;
+            }
+            // fe80::/10 (link-local)
+            if segs[0] & 0xffc0 == 0xfe80 {
+                return true;
+            }
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv6Addr;
+
+    #[test]
+    fn parse_obfuscated_ip_canonical_v4() {
+        let addr = parse_obfuscated_ip("127.0.0.1").expect("canonical");
+        assert!(addr.is_loopback());
+    }
+
+    #[test]
+    fn parse_obfuscated_ip_hex() {
+        let addr = parse_obfuscated_ip("0x7f000001").expect("hex");
+        assert_eq!(addr.to_string(), "127.0.0.1");
+    }
+
+    #[test]
+    fn parse_obfuscated_ip_hex_uppercase() {
+        let addr = parse_obfuscated_ip("0X7F000001").expect("HEX");
+        assert_eq!(addr.to_string(), "127.0.0.1");
+    }
+
+    #[test]
+    fn parse_obfuscated_ip_octal() {
+        let addr = parse_obfuscated_ip("017700000001").expect("octal");
+        assert_eq!(addr.to_string(), "127.0.0.1");
+    }
+
+    #[test]
+    fn parse_obfuscated_ip_dword_decimal() {
+        let addr = parse_obfuscated_ip("2130706433").expect("dword");
+        assert_eq!(addr.to_string(), "127.0.0.1");
+    }
+
+    #[test]
+    fn parse_obfuscated_ip_rejects_arbitrary_string() {
+        assert!(parse_obfuscated_ip("example.com").is_none());
+        assert!(parse_obfuscated_ip("notanip").is_none());
+    }
+
+    #[test]
+    fn parse_obfuscated_ip_v6_loopback() {
+        let addr = parse_obfuscated_ip("::1").expect("v6 loopback");
+        assert!(addr.is_loopback());
+    }
+
+    #[test]
+    fn is_private_ip_rfc1918() {
+        for s in [
+            "10.0.0.1",
+            "10.255.255.254",
+            "172.16.0.1",
+            "172.31.255.254",
+            "192.168.1.1",
+            "127.0.0.1",
+            "169.254.169.254",
+        ] {
+            let addr: IpAddr = s.parse().expect("test ip");
+            assert!(is_private_ip(addr), "{s} should be private");
+        }
+    }
+
+    #[test]
+    fn is_private_ip_public_v4_returns_false() {
+        for s in ["8.8.8.8", "1.1.1.1", "100.64.0.1", "100.100.100.1"] {
+            let addr: IpAddr = s.parse().expect("test ip");
+            assert!(!is_private_ip(addr), "{s} should not be private");
+        }
+    }
+
+    #[test]
+    fn is_private_ip_v6_mapped_v4() {
+        // ::ffff:169.254.169.254 — must catch the mapped form.
+        let v6: IpAddr = "::ffff:169.254.169.254".parse().expect("mapped");
+        assert!(is_private_ip(v6));
+    }
+
+    #[test]
+    fn is_private_ip_v6_mapped_alibaba_metadata() {
+        // Regression for C2: 100.100.100.200 is not in PRIVATE_CIDRS
+        // (excluded to avoid flagging all of 100.64.0.0/10 CGNAT), so the
+        // IPv6-mapped form must fall through to the metadata regex set.
+        let v6: IpAddr = "::ffff:100.100.100.200".parse().expect("mapped alibaba");
+        assert!(is_private_ip(v6));
+    }
+
+    #[test]
+    fn is_private_ip_v6_unique_local() {
+        let v6 = IpAddr::V6(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 1));
+        assert!(is_private_ip(v6));
+    }
+
+    #[test]
+    fn is_private_ip_v6_link_local() {
+        let v6 = IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1));
+        assert!(is_private_ip(v6));
+    }
+
+    #[test]
+    fn is_private_ip_v6_public_returns_false() {
+        let v6: IpAddr = "2606:4700:4700::1111".parse().expect("public v6");
+        assert!(!is_private_ip(v6));
+    }
+}

--- a/crates/waf-engine/src/checks/xss.rs
+++ b/crates/waf-engine/src/checks/xss.rs
@@ -3,9 +3,10 @@ use std::sync::LazyLock;
 use regex::RegexSet;
 use waf_common::{DetectionResult, Phase, RequestCtx};
 
+use super::xss_scanners::{scan_form_urlencoded, scan_json_body_xss};
 use super::{Check, request_targets};
 
-static XSS_DESCS: &[&str] = &[
+pub(crate) static XSS_DESCS: &[&str] = &[
     "<script> tag",
     "event handler attribute (on*=)",
     "javascript: URI",
@@ -26,7 +27,7 @@ static XSS_DESCS: &[&str] = &[
 
 // SAFETY: All patterns are compile-time string literals. If any pattern fails
 // to compile it is a code bug that must be caught in development, not at runtime.
-static XSS_SET: LazyLock<RegexSet> = LazyLock::new(|| {
+pub(crate) static XSS_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     match RegexSet::new([
         // <script...>
         r"(?i)<\s*/?\s*script[\s/>]",
@@ -90,20 +91,54 @@ impl Check for XssCheck {
             return None;
         }
 
+        // Content-Type-aware body inspection runs first so structured payloads
+        // (JSON / form-urlencoded) get precise location attribution before the
+        // raw-bytes fallback in `request_targets()`.
+        let content_type = ctx
+            .headers
+            .get("content-type")
+            .map_or("", String::as_str)
+            .to_ascii_lowercase();
+        let body_cap = ctx.host_config.defense_config.max_body_size;
+
+        if !ctx.body_preview.is_empty() {
+            if content_type.starts_with("application/json")
+                && let Some((path, idx)) = scan_json_body_xss(&ctx.body_preview, &XSS_SET, body_cap)
+            {
+                return Some(detection_at(idx, &path));
+            } else if content_type.starts_with("application/x-www-form-urlencoded")
+                && let Some((loc, idx)) = scan_form_urlencoded(&ctx.body_preview, &XSS_SET)
+            {
+                return Some(detection_at(idx, &loc));
+            }
+        }
+
+        // `text/markdown` legitimately contains `<script` snippets in code
+        // blocks; skip the raw-body location to suppress false positives.
+        // Non-body locations (path / query / cookie) still scan normally.
+        let skip_body = content_type.starts_with("text/markdown");
+
         for (location, value) in request_targets(ctx) {
+            if skip_body && location.starts_with("body") {
+                continue;
+            }
             let matches = XSS_SET.matches(&value);
             if matches.matched_any() {
                 let idx = matches.iter().next().unwrap_or(0);
-                let desc = XSS_DESCS.get(idx).copied().unwrap_or("XSS pattern");
-                return Some(DetectionResult {
-                    rule_id: Some(format!("XSS-{:03}", idx + 1)),
-                    rule_name: "XSS".to_string(),
-                    phase: Phase::Xss,
-                    detail: format!("{desc} detected in {location}"),
-                });
+                return Some(detection_at(idx, location));
             }
         }
         None
+    }
+}
+
+fn detection_at(idx: usize, location: &str) -> DetectionResult {
+    let desc = XSS_DESCS.get(idx).copied().unwrap_or("XSS pattern");
+    DetectionResult {
+        rule_id: Some(format!("XSS-{:03}", idx + 1)),
+        rule_name: "XSS".to_string(),
+        phase: Phase::Xss,
+        detail: format!("{desc} detected in {location}"),
     }
 }
 
@@ -117,22 +152,30 @@ mod tests {
     use waf_common::{DefenseConfig, HostConfig};
 
     fn make_ctx(query: &str, body: &str) -> RequestCtx {
+        make_ctx_with(query, body, "", true)
+    }
+
+    fn make_ctx_with(query: &str, body: &str, content_type: &str, xss_enabled: bool) -> RequestCtx {
+        let mut headers = HashMap::new();
+        if !content_type.is_empty() {
+            headers.insert("content-type".to_string(), content_type.to_string());
+        }
         RequestCtx {
             req_id: "test".to_string(),
             client_ip: "127.0.0.1".parse::<IpAddr>().unwrap(),
             client_port: 0,
-            method: "GET".to_string(),
+            method: "POST".to_string(),
             host: "example.com".to_string(),
             port: 80,
             path: "/".to_string(),
             query: query.to_string(),
-            headers: HashMap::new(),
+            headers,
             body_preview: Bytes::from(body.to_string()),
             content_length: body.len() as u64,
             is_tls: false,
             host_config: Arc::new(HostConfig {
                 defense_config: DefenseConfig {
-                    xss: true,
+                    xss: xss_enabled,
                     ..DefenseConfig::default()
                 },
                 ..HostConfig::default()
@@ -170,5 +213,112 @@ mod tests {
         let checker = XssCheck::new();
         let ctx = make_ctx("q=hello+world&page=1", "");
         assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn detects_script_tag_double_encoded_in_query() {
+        // %253Cscript%253E → %3Cscript%3E → <script> after recursive decode.
+        let checker = XssCheck::new();
+        let ctx = make_ctx("q=%253Cscript%253Ealert(1)%253C/script%253E", "");
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn detects_xss_in_json_body_with_path_attribution() {
+        let checker = XssCheck::new();
+        let ctx = make_ctx_with("", r#"{"a":{"b":"<script>"}}"#, "application/json", true);
+        let det = checker.check(&ctx).expect("hit");
+        assert!(det.detail.contains("body.json.a.b"));
+    }
+
+    #[test]
+    fn detects_xss_in_json_array() {
+        let checker = XssCheck::new();
+        let ctx = make_ctx_with("", r#"["safe","<img onerror=x>"]"#, "application/json", true);
+        let det = checker.check(&ctx).expect("hit");
+        assert!(det.detail.contains("body.json[1]"));
+    }
+
+    #[test]
+    fn detects_xss_in_form_urlencoded_body() {
+        let checker = XssCheck::new();
+        let ctx = make_ctx_with(
+            "",
+            "q=%3Cscript%3Ealert(1)%3C/script%3E",
+            "application/x-www-form-urlencoded",
+            true,
+        );
+        let det = checker.check(&ctx).expect("hit");
+        assert!(det.detail.contains("body.form.q"));
+    }
+
+    #[test]
+    fn allows_clean_json_body() {
+        let checker = XssCheck::new();
+        let ctx = make_ctx_with("", r#"{"name":"Alice"}"#, "application/json", true);
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn allows_clean_form_body() {
+        let checker = XssCheck::new();
+        let ctx = make_ctx_with("", "q=hello+world&page=1", "application/x-www-form-urlencoded", true);
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn malformed_json_falls_through_to_raw_scan() {
+        // Walker bails None on bad JSON; raw `request_targets()` then scans
+        // the bytes — `<script>` substring still gets caught.
+        let checker = XssCheck::new();
+        let ctx = make_ctx_with("", "not-json-but-<script>here", "application/json", true);
+        assert!(checker.check(&ctx).is_some());
+    }
+
+    #[test]
+    fn skipped_when_xss_disabled() {
+        let checker = XssCheck::new();
+        let ctx = make_ctx_with("", r#"{"x":"<script>"}"#, "application/json", false);
+        assert!(checker.check(&ctx).is_none());
+    }
+
+    #[test]
+    fn markdown_body_skipped_but_query_still_scanned() {
+        // `<script>` in a markdown body is allowed (false-positive mitigation).
+        let checker = XssCheck::new();
+        let ctx = make_ctx_with("", "Here is some `<script>` in a code block", "text/markdown", true);
+        assert!(checker.check(&ctx).is_none());
+
+        // Query string still scans even with markdown content type.
+        let ctx2 = make_ctx_with("q=<script>", "ignored", "text/markdown", true);
+        assert!(checker.check(&ctx2).is_some());
+    }
+
+    #[test]
+    fn detection_carries_correct_phase_and_rule_id_prefix() {
+        let checker = XssCheck::new();
+        let ctx = make_ctx("q=<script>", "");
+        let det = checker.check(&ctx).expect("hit");
+        assert_eq!(det.phase, waf_common::Phase::Xss);
+        assert_eq!(det.rule_name, "XSS");
+        assert!(det.rule_id.as_deref().unwrap_or("").starts_with("XSS-"));
+    }
+
+    #[test]
+    fn deeply_nested_json_does_not_overflow_dispatcher() {
+        // Echoes xss_scanners::tests but exercises the full dispatcher path
+        // including content-type detection + body cap.
+        let checker = XssCheck::new();
+        let mut s = String::new();
+        for _ in 0..200 {
+            s.push_str("{\"x\":");
+        }
+        s.push_str("\"<script>\"");
+        for _ in 0..200 {
+            s.push('}');
+        }
+        let ctx = make_ctx_with("", &s, "application/json", true);
+        // Should NOT panic. May or may not detect (walker bails past depth cap).
+        let _ = checker.check(&ctx);
     }
 }

--- a/crates/waf-engine/src/checks/xss_scanners.rs
+++ b/crates/waf-engine/src/checks/xss_scanners.rs
@@ -1,0 +1,182 @@
+//! XSS scanner helpers — JSON walker + form-urlencoded extractor.
+//!
+//! Both scanners produce `(location_string, pattern_index)` so the caller can
+//! attribute the hit precisely (e.g. `body.json.user.name` vs `body.form.q`).
+//! The JSON walker is **iterative** and bails on depth > [`MAX_JSON_DEPTH`] —
+//! using the recursive pattern from `sql_injection_scanners` would re-introduce
+//! the stack-overflow class FR-020 is meant to detect (Red Team Finding #4).
+
+use regex::RegexSet;
+use serde_json::Value;
+use std::fmt::Write;
+
+use super::url_decode_recursive;
+
+/// Hard recursion cap for JSON walking. Anything deeper is skipped (not flagged)
+/// so a malicious deep-nested body cannot crash the engine before FR-020
+/// (Phase 06) gets a chance to flag it.
+pub const MAX_JSON_DEPTH: usize = 64;
+
+/// Scan a JSON body for XSS patterns, returning (`json_path`, `pattern_index`)
+/// on the first hit. Bails out as `None` on parse error, oversize, or
+/// depth-exceeded — the body-abuse check (FR-020) is responsible for
+/// translating those cases into block decisions.
+pub fn scan_json_body_xss(body: &[u8], patterns: &RegexSet, json_parse_cap: usize) -> Option<(String, usize)> {
+    if body.len() > json_parse_cap {
+        return None;
+    }
+    let v: Value = serde_json::from_slice(body).ok()?;
+    walk_json_iter(&v, patterns)
+}
+
+/// Iterative depth-first walker. Each stack entry owns the full path string
+/// for its node — costs O(depth × `path_len`) memory bounded by
+/// [`MAX_JSON_DEPTH`] but avoids the truncate-on-pop bookkeeping that's
+/// brittle when interleaved with branchy iteration order.
+fn walk_json_iter(root: &Value, set: &RegexSet) -> Option<(String, usize)> {
+    let mut stack: Vec<(&Value, String, usize)> = Vec::with_capacity(MAX_JSON_DEPTH);
+    stack.push((root, String::from("body.json"), 0));
+
+    while let Some((node, path, depth)) = stack.pop() {
+        if depth > MAX_JSON_DEPTH {
+            // Skip — FR-020 will flag the depth violation separately.
+            continue;
+        }
+        match node {
+            Value::String(s) => {
+                let decoded = url_decode_recursive(s);
+                if let Some(idx) = set.matches(&decoded).iter().next() {
+                    return Some((path, idx));
+                }
+            }
+            Value::Object(map) => {
+                // Push reversed so LIFO pop yields original insertion order.
+                for (k, child) in map.iter().rev() {
+                    let mut child_path = path.clone();
+                    child_path.push('.');
+                    child_path.push_str(k);
+                    stack.push((child, child_path, depth + 1));
+                }
+            }
+            Value::Array(arr) => {
+                for (i, child) in arr.iter().enumerate().rev() {
+                    let mut child_path = path.clone();
+                    let _ = write!(child_path, "[{i}]");
+                    stack.push((child, child_path, depth + 1));
+                }
+            }
+            _ => {} // null / bool / number — skip
+        }
+    }
+    None
+}
+
+/// Scan a form-urlencoded body (`application/x-www-form-urlencoded`),
+/// returning (`body.form.<key>`, `pattern_index`) on first hit. Each value is
+/// percent-decoded recursively before regex match.
+pub fn scan_form_urlencoded(body: &[u8], patterns: &RegexSet) -> Option<(String, usize)> {
+    for (k, v) in url::form_urlencoded::parse(body) {
+        let decoded = url_decode_recursive(&v);
+        if let Some(idx) = patterns.matches(&decoded).iter().next() {
+            return Some((format!("body.form.{k}"), idx));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checks::xss::XSS_SET;
+
+    const TEST_CAP: usize = 64 * 1024;
+
+    #[test]
+    fn json_nested_object_hit() {
+        let body = br#"{"a":{"b":"<script>alert(1)</script>"}}"#;
+        let (path, _) = scan_json_body_xss(body, &XSS_SET, TEST_CAP).expect("hit");
+        assert_eq!(path, "body.json.a.b");
+    }
+
+    #[test]
+    fn json_array_hit() {
+        let body = br#"["safe","<img onerror=x>"]"#;
+        let (path, _) = scan_json_body_xss(body, &XSS_SET, TEST_CAP).expect("hit");
+        assert_eq!(path, "body.json[1]");
+    }
+
+    #[test]
+    fn json_clean() {
+        let body = br#"{"name":"Alice","age":25}"#;
+        assert!(scan_json_body_xss(body, &XSS_SET, TEST_CAP).is_none());
+    }
+
+    #[test]
+    fn json_malformed_returns_none() {
+        let body = b"not valid json";
+        assert!(scan_json_body_xss(body, &XSS_SET, TEST_CAP).is_none());
+    }
+
+    #[test]
+    fn json_oversize_returns_none() {
+        let body = vec![b'{'; TEST_CAP + 1];
+        assert!(scan_json_body_xss(&body, &XSS_SET, TEST_CAP).is_none());
+    }
+
+    #[test]
+    fn xss_url_encoded_value_in_json() {
+        // %3Cscript%3E decodes to <script>; recursive url-decode resolves.
+        let body = br#"{"q":"%3Cscript%3Ealert(1)%3C/script%3E"}"#;
+        assert!(scan_json_body_xss(body, &XSS_SET, TEST_CAP).is_some());
+    }
+
+    #[test]
+    fn xss_deeply_nested_json_does_not_overflow() {
+        // Synthesize depth = 200, well past MAX_JSON_DEPTH=64.
+        let mut s = String::new();
+        for _ in 0..200 {
+            s.push_str("{\"x\":");
+        }
+        s.push_str("\"<script>\"");
+        for _ in 0..200 {
+            s.push('}');
+        }
+        // Iterative walker must NOT panic; bails as None per Finding #4.
+        let _ = scan_json_body_xss(s.as_bytes(), &XSS_SET, TEST_CAP);
+    }
+
+    #[test]
+    fn xss_at_max_depth_still_detected() {
+        // Build object nested exactly MAX_JSON_DEPTH levels — leaf string
+        // sits at that depth and must still match.
+        let mut s = String::new();
+        for _ in 0..MAX_JSON_DEPTH {
+            s.push_str("{\"x\":");
+        }
+        s.push_str("\"<script>\"");
+        for _ in 0..MAX_JSON_DEPTH {
+            s.push('}');
+        }
+        assert!(scan_json_body_xss(s.as_bytes(), &XSS_SET, TEST_CAP).is_some());
+    }
+
+    #[test]
+    fn form_simple_hit() {
+        let body = b"q=%3Cscript%3Ealert(1)%3C/script%3E";
+        let (loc, _) = scan_form_urlencoded(body, &XSS_SET).expect("hit");
+        assert_eq!(loc, "body.form.q");
+    }
+
+    #[test]
+    fn form_clean() {
+        let body = b"q=hello+world&page=1";
+        assert!(scan_form_urlencoded(body, &XSS_SET).is_none());
+    }
+
+    #[test]
+    fn form_event_handler_value() {
+        let body = b"comment=%3Cimg+onerror%3Dalert(1)%3E";
+        let (loc, _) = scan_form_urlencoded(body, &XSS_SET).expect("hit");
+        assert_eq!(loc, "body.form.comment");
+    }
+}

--- a/crates/waf-engine/src/community/reporter.rs
+++ b/crates/waf-engine/src/community/reporter.rs
@@ -77,10 +77,10 @@ pub struct CommunityReporter {
 const fn compute_confidence(phase: Phase) -> f64 {
     match phase {
         Phase::SqlInjection | Phase::Rce => 0.95,
-        Phase::Xss => 0.90,
-        Phase::DirTraversal | Phase::Owasp => 0.85,
+        Phase::Xss | Phase::Ssrf => 0.90,
+        Phase::DirTraversal | Phase::Owasp | Phase::HeaderInjection | Phase::RequestBodyAbuse => 0.85,
         Phase::CustomRule | Phase::IpBlacklist | Phase::UrlBlacklist => 0.80,
-        Phase::Sensitive | Phase::Scanner | Phase::Bot => 0.70,
+        Phase::Sensitive | Phase::Scanner | Phase::Bot | Phase::BruteForce => 0.70,
         // DDoS detection based on observed traffic patterns — moderate confidence
         Phase::RateLimit | Phase::CrowdSec | Phase::Ddos => 0.60,
         Phase::Community => 0.50,

--- a/crates/waf-engine/src/engine.rs
+++ b/crates/waf-engine/src/engine.rs
@@ -29,8 +29,9 @@ use crate::checks::tx_velocity::{
     TxStore, TxVelocityCheck, TxVelocityConfig, TxVelocityFileConfig, TxVelocityReloader,
 };
 use crate::checks::{
-    AntiHotlinkCheck, BotCheck, Check, DirTraversalCheck, GeoCheck, OWASPCheck, RateLimitCheck, RateLimitConfig,
-    RceCheck, ScannerCheck, SensitiveCheck, SqlInjectionCheck, XssCheck,
+    AntiHotlinkCheck, BotCheck, BruteForceCheck, Check, DirTraversalCheck, GeoCheck, HeaderInjectionCheck, OWASPCheck,
+    RateLimitCheck, RateLimitConfig, RceCheck, RequestBodyAbuseCheck, ScannerCheck, SensitiveCheck, SqlInjectionCheck,
+    SsrfCheck, XssCheck,
 };
 use crate::community::{CommunityChecker, CommunityReporter, RequestInfo};
 use crate::crowdsec::{AppSecClient, AppSecResult, CrowdSecChecker, appsec_to_detection};
@@ -141,6 +142,8 @@ impl WafEngine {
         // Build the Phase 5-11 checker pipeline (SQLi handled separately for hot-reload).
         // FR-004 RateLimitCheck runs first to shed flood traffic before expensive
         // pattern checks. Inert until `start_rate_limit_watcher` loads tier config.
+        // FR-014..020 checks register here so each downstream FR PR only swaps
+        // its own check file (zero shared-edit conflicts).
         let rl_store: Arc<dyn RateLimitStore> = Arc::new(RlMemoryStore::new());
         let rate_limit_cfg = Arc::new(ArcSwap::from(Arc::new(RateLimitConfig::default())));
 
@@ -191,6 +194,10 @@ impl WafEngine {
             Box::new(XssCheck::new()),
             Box::new(RceCheck::new()),
             Box::new(DirTraversalCheck::new()),
+            Box::new(SsrfCheck::new()),
+            Box::new(HeaderInjectionCheck::new()),
+            Box::new(BruteForceCheck::new()),
+            Box::new(RequestBodyAbuseCheck::new()),
         ];
 
         Self {
@@ -741,6 +748,23 @@ impl WafEngine {
         }
 
         WafDecision::allow()
+    }
+
+    /// Dispatch an upstream response status to every registered `Check`.
+    ///
+    /// Gateway callers invoke this from Pingora's `response_filter` after
+    /// extracting the status code. Most checks inherit the no-op default and
+    /// ignore the call; FR-018 brute-force records 401/403 as login
+    /// failures and FR-019 scanner (future) will count 4xx/5xx bursts.
+    ///
+    /// Sync on purpose — there's no body or await in v1. The work inside
+    /// each `on_response` impl is a bounded state insert (`DashMap` +
+    /// `Mutex` push).
+    pub fn on_response(&self, ctx: &RequestCtx, status: u16) {
+        for check in &self.checkers {
+            check.on_response(ctx, status);
+        }
+        self.sqli_check.on_response(ctx, status);
     }
 
     // ── Logging helpers ───────────────────────────────────────────────────────

--- a/crates/waf-engine/tests/p0_detection_acceptance.rs
+++ b/crates/waf-engine/tests/p0_detection_acceptance.rs
@@ -1,0 +1,175 @@
+//! FR-014..FR-020 end-to-end acceptance suite.
+//!
+//! Exercises each of the 7 P0 detection checks through its public `Check`
+//! trait (and `on_response` for FR-018) using a realistic request context.
+//! Intentionally *does not* spin up the full `WafEngine` — that requires a
+//! live `PostgreSQL` instance. Unit + module-level tests cover per-check
+//! internals; this suite pins the contract that every FR fires the right
+//! phase + rule-id prefix for a known-bad input, and allows a clean input.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use bytes::Bytes;
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::Arc;
+
+use waf_common::{DefenseConfig, HostConfig, Phase, RequestCtx};
+use waf_engine::checks::{
+    BruteForceCheck, Check, DirTraversalCheck, HeaderInjectionCheck, RequestBodyAbuseCheck, ScannerCheck, SsrfCheck,
+    XssCheck,
+};
+
+fn ctx(path: &str, method: &str, body: &[u8], ct: &str, headers: HashMap<String, String>) -> RequestCtx {
+    let mut hdrs = headers;
+    if !ct.is_empty() {
+        hdrs.insert("content-type".to_string(), ct.to_string());
+    }
+    let content_length = body.len() as u64;
+    RequestCtx {
+        req_id: "p0-acc".to_string(),
+        client_ip: "5.5.5.5".parse::<IpAddr>().unwrap(),
+        client_port: 0,
+        method: method.to_string(),
+        host: "example.com".to_string(),
+        port: 80,
+        path: path.to_string(),
+        query: String::new(),
+        headers: hdrs,
+        body_preview: Bytes::copy_from_slice(body),
+        content_length,
+        is_tls: false,
+        host_config: Arc::new(HostConfig {
+            defense_config: DefenseConfig::default(),
+            ..HostConfig::default()
+        }),
+        geo: None,
+        tier: waf_common::tier::Tier::CatchAll,
+        tier_policy: waf_common::RequestCtx::default_tier_policy(),
+        cookies: HashMap::new(),
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Positive — each attack vector fires the expected phase + rule-id prefix
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn fr_014_xss_blocks_json_payload() {
+    let c = XssCheck::new();
+    let req = ctx(
+        "/api/comment",
+        "POST",
+        br#"{"comment":"<script>alert(1)</script>"}"#,
+        "application/json",
+        HashMap::new(),
+    );
+    let d = c.check(&req).expect("FR-014 hit");
+    assert_eq!(d.phase, Phase::Xss);
+    assert!(d.rule_id.as_deref().unwrap_or("").starts_with("XSS-"));
+}
+
+#[test]
+fn fr_015_path_traversal_blocks_double_encoded() {
+    let c = DirTraversalCheck::new();
+    let req = ctx("/files/%252e%252e%252fetc%252fpasswd", "GET", b"", "", HashMap::new());
+    let d = c.check(&req).expect("FR-015 hit");
+    assert_eq!(d.phase, Phase::DirTraversal);
+    assert!(d.rule_id.as_deref().unwrap_or("").starts_with("TRAV-"));
+}
+
+#[test]
+fn fr_016_ssrf_blocks_aws_metadata() {
+    let c = SsrfCheck::new();
+    let req = ctx(
+        "/api/webhook",
+        "POST",
+        br#"{"u":"http://169.254.169.254/latest/meta-data/"}"#,
+        "application/json",
+        HashMap::new(),
+    );
+    let d = c.check(&req).expect("FR-016 hit");
+    assert_eq!(d.phase, Phase::Ssrf);
+    assert!(d.rule_id.as_deref().unwrap_or("").starts_with("SSRF-"));
+}
+
+#[test]
+fn fr_017_header_injection_blocks_crlf_in_referer() {
+    let c = HeaderInjectionCheck::new();
+    let mut h = HashMap::new();
+    h.insert("referer".to_string(), "foo\r\nSet-Cookie: pwned=1".to_string());
+    let req = ctx("/", "GET", b"", "", h);
+    let d = c.check(&req).expect("FR-017 hit");
+    assert_eq!(d.phase, Phase::HeaderInjection);
+    assert!(d.rule_id.as_deref().unwrap_or("").starts_with("HDR-"));
+}
+
+#[test]
+fn fr_018_brute_force_blocks_after_five_failed_logins() {
+    let c = BruteForceCheck::new();
+    let body = br#"{"username":"alice","password":"wrong"}"#;
+    for _ in 0..5 {
+        let r = ctx("/login", "POST", body, "application/json", HashMap::new());
+        c.on_response(&r, 401);
+    }
+    let req = ctx("/login", "POST", body, "application/json", HashMap::new());
+    let d = c.check(&req).expect("FR-018 hit");
+    assert_eq!(d.phase, Phase::BruteForce);
+    assert!(d.rule_id.as_deref().unwrap_or("").starts_with("BF-"));
+}
+
+#[test]
+fn fr_019_scanner_blocks_options_abuse() {
+    let c = ScannerCheck::new();
+    // Default threshold is 20 OPTIONS from same client_ip inside window.
+    for _ in 0..19 {
+        let r = ctx("/api/users", "OPTIONS", b"", "", HashMap::new());
+        let _ = c.check(&r);
+    }
+    let req = ctx("/api/users", "OPTIONS", b"", "", HashMap::new());
+    let d = c.check(&req).expect("FR-019 hit");
+    assert_eq!(d.phase, Phase::Scanner);
+    assert!(d.rule_id.as_deref().unwrap_or("").starts_with("SCAN-"));
+}
+
+#[test]
+fn fr_020_body_abuse_blocks_oversized_declared_length() {
+    let c = RequestBodyAbuseCheck::new();
+    // Declared 128 KiB while preview body is small — matches production shape.
+    let mut req = ctx("/api/upload", "POST", b"{}", "application/json", HashMap::new());
+    req.content_length = 128 * 1024;
+    let d = c.check(&req).expect("FR-020 hit");
+    assert_eq!(d.phase, Phase::RequestBodyAbuse);
+    assert!(d.rule_id.as_deref().unwrap_or("").starts_with("BODY-"));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Negative — clean input sails through every check
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn fr_clean_benign_request_triggers_no_detection() {
+    let req = ctx("/api/v1/users/42", "GET", b"", "", HashMap::new());
+    assert!(XssCheck::new().check(&req).is_none());
+    assert!(DirTraversalCheck::new().check(&req).is_none());
+    assert!(SsrfCheck::new().check(&req).is_none());
+    assert!(HeaderInjectionCheck::new().check(&req).is_none());
+    assert!(BruteForceCheck::new().check(&req).is_none());
+    assert!(RequestBodyAbuseCheck::new().check(&req).is_none());
+    // ScannerCheck's stateful OPTIONS/enum-path counters fire only under
+    // threshold — a single clean GET must not trigger them.
+    assert!(ScannerCheck::new().check(&req).is_none());
+}
+
+#[test]
+fn fr_clean_json_webhook_passes_ssrf_and_body_abuse() {
+    let req = ctx(
+        "/api/webhook",
+        "POST",
+        br#"{"webhook":"https://api.stripe.com/v1/charges"}"#,
+        "application/json",
+        HashMap::new(),
+    );
+    assert!(SsrfCheck::new().check(&req).is_none());
+    assert!(RequestBodyAbuseCheck::new().check(&req).is_none());
+}


### PR DESCRIPTION
## Summary

**Consolidated PR** for the full FR-014..FR-020 P0 detection plan. Supersedes #28, #29, #30, #32, #33, #34, #36, #37 (all closed in favour of this one).

Ships 7 production P0 detection checks + the framework scaffold + coverage infra + end-to-end acceptance suite.

### Detection checks (all 7 FRs)

- **FR-014 XSS enhance** — iterative JSON walker (hard depth cap 64) + form-urlencoded scanner + Content-Type-aware dispatch. `text/markdown` body-skip mitigates false positives. 26 tests.
- **FR-015 path traversal enhance** — adopts shared `request_targets()` so recursive-decoded variants (`%252e%252e`) are covered; anchored patterns for `/etc/<sensitive>`, `/proc/<pid>/…`, `\windows\system32`, `boot.ini`/`win.ini`. 21 tests.
- **FR-016 SSRF detection (NEW)** — RFC1918 / loopback / link-local / cloud metadata (AWS, GCP, Alibaba, Consul); obfuscated IPs (hex, octal, decimal dword, IPv6-mapped). Userinfo bypass `http://google.com@169.254.169.254/` resolves via `url::Url::host()`. Allowlist via `ssrf_outbound_host_allowlist`. 43 tests.
- **FR-017 header injection (NEW)** — raw + `%0d%0a` / `%250d%250a` CRLF detection in header names and values; Host whitelist with IPv6-bracket awareness; XFF leftmost-private + max-hops. 29 tests.
- **FR-018 brute force + credential stuffing (NEW)** — consumes the new `Check::on_response` default hook. BF-001 per-user threshold, BF-002 password spray across distinct users. Status-code-only v1 (401/403). SHA-256-truncated usernames/passwords — never plaintext in state. 41 tests.
- **FR-019 scanner recon enhance** — per-IP sliding-window state with endpoint enumeration + OPTIONS preflight abuse. Bounded at `scanner_max_ips` (default 100k) with 10% eviction against IPv6-rotating OOM. 25 tests.
- **FR-020 body abuse (NEW)** — declared `Content-Length` size gate (64 KiB to match gateway `BODY_PREVIEW_LIMIT`), magic-byte CT mismatch, iterative byte-scan JSON depth pre-check (no parser allocation), key-count explosion via iterative `Value` walker. 41 tests.

### Framework (Phase 00 additions)

- `Phase` enum: 4 new variants (`Ssrf=19`, `HeaderInjection=20`, `BruteForce=21`, `RequestBodyAbuse=22`).
- `DefenseConfig`: 14 new fields, all `#[serde(default)]` — existing TOML configs deserialize unchanged.
- `Check` trait: default-impl `on_response(&self, _ctx, _status)` hook. All 11 pre-existing checks inherit the no-op.
- `WafEngine::on_response(ctx, status)` dispatcher — sync, gateway calls from Pingora `response_filter`.
- `Clock` trait + `SystemClock` + `MockClock` test fixture so stateful checks advance time deterministically.
- `Dockerfile.coverage` + `scripts/{coverage-gate.sh, create-worktrees.sh, setup-worktree-env.sh}` + CI coverage job (informational).

### E2E acceptance suite (new)

`crates/waf-engine/tests/p0_detection_acceptance.rs` — 9 tests pinning the contract that each FR fires the right `Phase` + rule-id prefix for a known-bad input, and that a benign request triggers no detection across all seven checks.

### Key Red Team fixes

- **#2** — Phase 00 owns all stub registrations in `engine.rs::new()` so FR branches only touch their own check file.
- **#3** — FR-020 uses iterative byte-scan for depth pre-check. `serde_json` has no `set_recursion_limit` API.
- **#4** — FR-014 walker uses owned-path iterative stack with hard depth=64 cap. Never recursive.
- **#5** — FR-020 reads `Content-Length` (not `body_preview.len()`); default `max_body_size` = 64 KiB to match Pingora `BODY_PREVIEW_LIMIT`.
- **#6** — FR-018 + FR-019 state maps bounded at 100k entries with oldest-10% eviction.
- **#7** — Collapsed `ResponseCheck` into `Check::on_response` default-impl. No async/sync mismatch with Pingora.
- **#8** — FR-018 is status-code-only v1. Pingora `response_filter` gives no body.
- **#9** + **#12** — FR-017 whitelist-only Host validation. `RequestCtx` has no `sni` field; `HashMap<String,String>` headers can't carry duplicates.
- **#10** — FR-016 uses `url::Url::host()` typed enum. Userinfo bypass cannot smuggle a metadata IP.
- **#11** — FR-018 body-regex not implemented. Generic failure regex is a victim-account-lockout primitive.
- **#13** — coverage-gate awk parser smoke-tested against pass/fail fixtures.
- **#14** — `spawn_pruner` pattern — no `tokio::spawn` from `Check::new`. State exposed via `state()` accessor.
- **#15** — Plan effort revised from 14d to ~7d critical path.

### Stats

| Artifact | Count |
|---|---|
| New check files | 10 (ssrf, ssrf_patterns, ssrf_scanners, header_injection, header_injection_patterns, body_abuse, body_abuse_walker, brute_force, brute_force_state, brute_force_extractors) |
| New sibling files | 3 (xss_scanners, scanner_state) |
| Modified check files | 4 (xss, dir_traversal, scanner, engine) |
| New DefenseConfig fields | 18 |
| Library tests | 307 |
| E2E acceptance tests | 9 |
| Total tests | 316 |

## Intentionally deferred (documented)

- **DNS-rebinding mitigation** (FR-016) — needs upstream resolver hook.
- **Duplicate-Host detection** (FR-017) — `RequestCtx.headers: HashMap<…>` can't carry duplicates; needs Pingora-layer normalization.
- **Distributed brute force** (FR-018) — same-IP only for v1.
- **Body > 64 KiB** (FR-020) — needs gateway PR to extend `BODY_PREVIEW_LIMIT`.
- **Body-regex login failure** (FR-018) — Pingora `response_filter` gives status only; body requires `response_body_filter` wiring.
- **Criterion bench harness** (`benches/p0_detection.rs`) — aggregate p99 assertion deferred; each check's hot path is bounded regex / DashMap op with no alloc on clean path.
- **Sample `rules/p0-detection.yaml`** + `docs/p0-detection-rulepack.md` + `docs/request-pipeline.md` diagram — operator-facing tuning material, separate docs PR.
- **Gateway `response_filter` wiring** of `engine.on_response` — cross-crate edit, separate PR.
- **Coverage baseline-raise** — `waf-engine` TOTAL is ≈77.82% against the strict 90% gate, below it due to pre-existing `community/*`, `crowdsec/*`, `plugins/manager.rs`, `geoip*`, `rules/{manager,hot_reload}` modules. CI coverage job is intentionally informational until a follow-up raises baseline.

## Verified

- `cargo fmt --all -- --check` rc=0
- `cargo clippy -p waf-engine -p waf-common --all-targets -- -D warnings` rc=0 on rust:1.95-slim-bookworm
- `cargo test -p waf-engine --test p0_detection_acceptance` 9/9
- `cargo test -p waf-engine --lib checks::` 307/307
- `bash scripts/coverage-gate.sh tests/fixtures/llvm-cov-summary-pass.txt 90` rc=0
- `bash scripts/coverage-gate.sh tests/fixtures/llvm-cov-summary-fail.txt 90` rc=1 (correct rejection)

## Test plan

- [ ] CI lint + test + build green
- [ ] Coverage gate informational (TOTAL ≈77.82% — follow-up raises baseline modules)
- [ ] Manual: `bash scripts/create-worktrees.sh` creates 7 worktrees without error
- [ ] Manual: `docker build -f Dockerfile.coverage -t prx-waf:cov .` succeeds