### PR TITLE
Add valkey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +730,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie-factory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +926,12 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc16"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
 name = "crc32fast"
@@ -1417,6 +1439,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,6 +1504,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "fred"
+version = "9.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cdd5378252ea124b712e0ac55147d26ae3af575883b34b8423091a4c719606b"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "bytes-utils",
+ "crossbeam-queue",
+ "float-cmp",
+ "fred-macros",
+ "futures",
+ "log",
+ "parking_lot",
+ "rand 0.8.5",
+ "redis-protocol",
+ "rustls-native-certs 0.7.3",
+ "semver",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+ "urlencoding",
+]
+
+[[package]]
+name = "fred-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1458c6e22d36d61507034d5afecc64f105c1d39712b7ac6ec3b352c423f715cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1603,10 +1673,13 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
+ "base64",
  "bytes",
  "chrono",
  "criterion",
  "dashmap",
+ "fred",
+ "futures-util",
  "h3",
  "h3-quinn",
  "hex",
@@ -2015,7 +2088,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2472,10 +2545,10 @@ dependencies = [
  "httpdate",
  "idna",
  "mime",
- "nom",
+ "nom 8.0.0",
  "percent-encoding",
  "quoted_printable",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "url",
 ]
@@ -2693,6 +2766,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2807,6 +2886,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 dependencies = [
  "spin 0.5.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3170,7 +3259,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sfv",
- "socket2",
+ "socket2 0.6.3",
  "strum",
  "strum_macros",
  "tokio",
@@ -3549,7 +3638,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3589,7 +3678,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3750,6 +3839,20 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "url",
+]
+
+[[package]]
+name = "redis-protocol"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65deb7c9501fbb2b6f812a30d59c0253779480853545153a51d8e9e444ddc99f"
+dependencies = [
+ "bytes",
+ "bytes-utils",
+ "cookie-factory",
+ "crc16",
+ "log",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -4499,6 +4602,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -5022,7 +5135,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5394,6 +5507,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5589,6 +5589,7 @@ dependencies = [
  "serde_yaml_ng",
  "sha2",
  "sqlx",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,9 @@ parking_lot = "0.12"
 ed25519-dalek = { version = "2", default-features = false, features = ["std", "rand_core"] }
 zstd = "0.13"
 
+# Valkey/Redis async client (used by gateway `valkey` feature)
+fred = { version = "9", features = ["i-keys", "i-sets", "i-server", "i-cluster", "rustls-native-certs", "unix-sockets"] }
+
 [workspace.lints.rust]
 unsafe_code = "deny"
 unused_must_use = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,10 @@ parking_lot = "0.12"
 ed25519-dalek = { version = "2", default-features = false, features = ["std", "rand_core"] }
 zstd = "0.13"
 
-# Valkey/Redis async client (used by gateway `valkey` feature)
+# Valkey/Redis async client (used by gateway `valkey` feature). Cargo forbids
+# `optional = true` on workspace dependencies; the optional bit is added in the
+# crate that owns the feature flag (`crates/gateway/Cargo.toml` →
+# `fred = { workspace = true, optional = true }`).
 fred = { version = "9", features = ["i-keys", "i-sets", "i-server", "i-cluster", "rustls-native-certs", "unix-sockets"] }
 
 [workspace.lints.rust]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
-# ─── Stage 0: Frontend Builder ───────────────────────────────────────────────
-# Builds the React/Refine/AntD admin panel (web/admin-panel).
+# ─── Stage 0: Valkey binary source ───────────────────────────────────────────
+# Pull the official Valkey image just to extract the server binary.
+# Used in the runtime stage for `backend = "embedded"` mode.
+# Using the same tag as docker-compose.valkey-cluster.yml for consistency.
+FROM docker.io/valkey/valkey:8-alpine AS valkey-source
+
+# ─── Stage 1: Frontend Builder ───────────────────────────────────────────────
+# Builds the Vue 3 admin panel (web/admin-ui).
 # Output dist/ is embedded into the Rust binary via `rust_embed` in
 # crates/waf-api/src/static_files.rs and served at /ui/* by prx-waf itself.
 FROM node:22-slim AS frontend-builder
@@ -12,7 +18,7 @@ RUN npm ci --ignore-scripts
 COPY web/admin-panel/ ./
 RUN npm run build
 
-# ─── Stage 1: Rust Builder ────────────────────────────────────────────────────
+# ─── Stage 2: Rust Builder ────────────────────────────────────────────────────
 FROM rust:1.91-slim-bookworm AS builder
 
 WORKDIR /build
@@ -42,8 +48,8 @@ RUN mkdir -p crates/prx-waf/src && echo 'fn main(){}' > crates/prx-waf/src/main.
     mkdir -p crates/waf-api/src   && echo 'pub fn dummy(){}' > crates/waf-api/src/lib.rs && \
     mkdir -p crates/waf-common/src && echo 'pub fn dummy(){}' > crates/waf-common/src/lib.rs
 
-# Pre-build all dependencies (layer-cache friendly)
-RUN cargo build --release 2>/dev/null || true
+# Pre-build all dependencies (layer-cache friendly) — with valkey feature enabled
+RUN cargo build --release --features gateway/valkey 2>/dev/null || true
 
 # Now copy the real source tree
 COPY . .
@@ -52,9 +58,9 @@ COPY . .
 COPY --from=frontend-builder /ui/dist ./web/admin-panel/dist/
 
 # Rebuild with real source (only changed crates will be recompiled)
-RUN cargo build --release -p prx-waf
+RUN cargo build --release --features gateway/valkey -p prx-waf
 
-# ─── Stage 2: Runtime ────────────────────────────────────────────────────────
+# ─── Stage 3: Runtime ────────────────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
 
 WORKDIR /app
@@ -70,8 +76,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tar \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy binary
+# Copy WAF binary
 COPY --from=builder /build/target/release/prx-waf /usr/local/bin/prx-waf
+
+# Copy the Valkey server binary for embedded mode (backend = "embedded").
+# EmbeddedValkey finds it at /usr/local/bin/valkey-server via PATH when
+# binary_path is empty in [cache.embedded].
+# If you only use [cache] backend = "memory" or external Valkey and never
+# "embedded", you may omit the valkey-source stage and this COPY to shrink the image.
+COPY --from=valkey-source /usr/local/bin/valkey-server /usr/local/bin/valkey-server
 
 # Copy default config, OWASP rules, and frontend dist
 COPY configs/   /app/configs/

--- a/configs/default.toml
+++ b/configs/default.toml
@@ -12,13 +12,17 @@ max_connections = 20
 # ── FR-009: Response Caching ──────────────────────────────────────────────────
 #
 # backend choices:
-#   "memory"     — in-process Moka LRU (no extra process; use for local run without Valkey)
+#   "memory"     — in-process Moka LRU (no extra process; default for local dev)
 #   "embedded"   — spawn valkey-server as a child process via UNIX socket
 #   "standalone" — connect to an external Valkey/Redis instance
 #   "cluster"    — connect to a Valkey cluster (topology auto-discovered)
 #
 # For "embedded" / "standalone" / "cluster" the binary must be built with
 # the `valkey` feature flag:  cargo build --features gateway/valkey
+#
+# The `CACHE_BACKEND` env var overrides this field at startup (see docker-compose.yml
+# and docs/valkey-cache-guide.md §3.1) so a single shared config file works for
+# both bare-metal local runs and Compose deployments.
 #
 [cache]
 enabled = true
@@ -28,11 +32,10 @@ max_ttl_secs = 3600
 # FR-009 Phase 3: per-route TTL rules. Hot-reloaded on file change.
 # Missing file is non-fatal at boot (logs warn, runs with no per-route rules).
 rules_path = "rules/cache.yaml"
-# Cache backend. Docker Compose default stack uses standalone Valkey (service
-# "valkey"); for local dev without Compose, set "memory" or "embedded".
-backend = "standalone"
-# If Valkey is not reachable at boot (e.g. Compose still starting), either wait for
-# `depends_on: service_healthy` or temporarily set backend = "memory".
+# Default to in-process moka so a fresh `cargo run` works without an external
+# Valkey/Redis. docker-compose.yml sets CACHE_BACKEND=standalone to switch the
+# stack to the bundled `valkey` service automatically.
+backend = "memory"
 
 # ── Embedded Valkey (backend = "embedded") ────────────────────────────────────
 # Spawns a valkey-server child process using a UNIX socket.

--- a/configs/default.toml
+++ b/configs/default.toml
@@ -9,7 +9,17 @@ listen_addr = "0.0.0.0:9527"
 database_url = "postgresql://prx_waf:prx_waf@postgres:5432/prx_waf"
 max_connections = 20
 
-# ── Phase 5: Response Caching ─────────────────────────────────────────────────
+# ── FR-009: Response Caching ──────────────────────────────────────────────────
+#
+# backend choices:
+#   "memory"     — in-process Moka LRU (no extra process; use for local run without Valkey)
+#   "embedded"   — spawn valkey-server as a child process via UNIX socket
+#   "standalone" — connect to an external Valkey/Redis instance
+#   "cluster"    — connect to a Valkey cluster (topology auto-discovered)
+#
+# For "embedded" / "standalone" / "cluster" the binary must be built with
+# the `valkey` feature flag:  cargo build --features gateway/valkey
+#
 [cache]
 enabled = true
 max_size_mb = 256
@@ -18,6 +28,49 @@ max_ttl_secs = 3600
 # FR-009 Phase 3: per-route TTL rules. Hot-reloaded on file change.
 # Missing file is non-fatal at boot (logs warn, runs with no per-route rules).
 rules_path = "rules/cache.yaml"
+# Cache backend. Docker Compose default stack uses standalone Valkey (service
+# "valkey"); for local dev without Compose, set "memory" or "embedded".
+backend = "standalone"
+# If Valkey is not reachable at boot (e.g. Compose still starting), either wait for
+# `depends_on: service_healthy` or temporarily set backend = "memory".
+
+# ── Embedded Valkey (backend = "embedded") ────────────────────────────────────
+# Spawns a valkey-server child process using a UNIX socket.
+# No separate container or service is needed.
+#
+# [cache.embedded]
+# binary_path = ""              # auto-detect from $PATH or /usr/local/bin/valkey-server
+# data_dir    = "/tmp/prx-valkey"
+# extra_args  = []              # additional valkey-server flags
+
+# ── Standalone Valkey (backend = "standalone") ────────────────────────────────
+# Hostname `valkey` matches the docker-compose.yml service name.
+#
+[cache.valkey]
+seeds                    = ["valkey:6379"]
+password                 = ""
+db                       = 0
+tls                      = false
+pool_size                = 4
+connect_timeout_ms       = 2000
+command_timeout_ms       = 500
+circuit_breaker_threshold  = 5
+circuit_breaker_reset_secs = 30
+fallback_to_memory       = true
+
+# ── Valkey Cluster (backend = "cluster") ─────────────────────────────────────
+#
+# [cache.valkey]
+# seeds                    = ["10.0.1.1:6379", "10.0.1.2:6379", "10.0.1.3:6379"]
+# password                 = ""
+# tls                      = true
+# tls_ca_cert              = "/etc/prx-waf/tls/valkey-ca.pem"
+# pool_size                = 4
+# connect_timeout_ms       = 2000
+# command_timeout_ms       = 500
+# circuit_breaker_threshold  = 5
+# circuit_breaker_reset_secs = 30
+# fallback_to_memory       = true
 
 # ── Phase 5: HTTP/3 (QUIC) ────────────────────────────────────────────────────
 [http3]

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -43,6 +43,26 @@ arc-swap = "1"
 notify = { workspace = true }
 toml = { workspace = true }
 serde_yaml = { workspace = true }
+serde_json = { workspace = true }
+base64 = { workspace = true }
+futures-util = { workspace = true }
+
+# Valkey/Redis async client — only compiled when the `valkey` feature is enabled.
+# Feature flags reference: https://docs.rs/fred/latest/fred/#features
+fred = { version = "9", features = [
+    "i-keys",       # GET, SET, DEL, SCAN, EXPIRE, TTL
+    "i-sets",       # SADD, SREM, SMEMBERS (tag index operations)
+    "i-server",     # INFO, DBSIZE, PING, CONFIG
+    "i-cluster",    # Cluster topology discovery + MOVED/ASK handling
+    "rustls-native-certs",  # TLS using rustls + OS trust store
+    "unix-sockets", # UNIX domain socket support (embedded mode)
+], optional = true }
+
+[features]
+# Enable Valkey/Redis cache backends (ValkeyStore + EmbeddedValkey supervisor).
+# Disabled by default so CI pure-memory builds stay lean.
+# Enable in production Dockerfiles with: --features valkey
+valkey = ["dep:fred"]
 
 [dev-dependencies]
 axum = { workspace = true }

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -48,15 +48,9 @@ base64 = { workspace = true }
 futures-util = { workspace = true }
 
 # Valkey/Redis async client — only compiled when the `valkey` feature is enabled.
-# Feature flags reference: https://docs.rs/fred/latest/fred/#features
-fred = { version = "9", features = [
-    "i-keys",       # GET, SET, DEL, SCAN, EXPIRE, TTL
-    "i-sets",       # SADD, SREM, SMEMBERS (tag index operations)
-    "i-server",     # INFO, DBSIZE, PING, CONFIG
-    "i-cluster",    # Cluster topology discovery + MOVED/ASK handling
-    "rustls-native-certs",  # TLS using rustls + OS trust store
-    "unix-sockets", # UNIX domain socket support (embedded mode)
-], optional = true }
+# Feature set + version are pinned in the workspace root Cargo.toml; we only
+# inherit + re-declare optionality so the `dep:fred` feature gate below works.
+fred = { workspace = true, optional = true }
 
 [features]
 # Enable Valkey/Redis cache backends (ValkeyStore + EmbeddedValkey supervisor).

--- a/crates/gateway/src/cache/backend.rs
+++ b/crates/gateway/src/cache/backend.rs
@@ -1,0 +1,205 @@
+//! `CacheBackend` — unified async interface over every cache storage implementation.
+//!
+//! Implementors: `MokaStore` (in-process LRU), `ValkeyStore` (external Valkey/Redis),
+//! `CircuitBreakerStore` (wraps Valkey with moka fallback).
+//!
+//! All methods are **infallible** by design: each implementor must absorb errors
+//! internally, degrade gracefully (log + return `None` / `0`), and never panic.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+
+// ── Serializable response type ────────────────────────────────────────────────
+
+/// A cached HTTP response. Used by all backend implementations as the value
+/// stored under each cache key.
+///
+/// `body` is serialized as base64 when going through Valkey (JSON wire format).
+#[derive(Debug, Clone)]
+pub struct CachedResponse {
+    pub status: u16,
+    /// Response headers as (name, value) pairs.
+    pub headers: Vec<(String, String)>,
+    pub body: Bytes,
+    /// Seconds until expiry (from insertion time; set by the resolver).
+    pub max_age: u64,
+}
+
+/// Wire representation used for JSON serialization to/from Valkey.
+#[derive(Serialize, Deserialize)]
+pub(crate) struct WireCachedResponse {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    #[serde(with = "base64_field")]
+    pub body: Vec<u8>,
+    pub max_age: u64,
+}
+
+impl From<&CachedResponse> for WireCachedResponse {
+    fn from(r: &CachedResponse) -> Self {
+        Self {
+            status: r.status,
+            headers: r.headers.clone(),
+            body: r.body.to_vec(),
+            max_age: r.max_age,
+        }
+    }
+}
+
+impl From<WireCachedResponse> for CachedResponse {
+    fn from(w: WireCachedResponse) -> Self {
+        Self {
+            status: w.status,
+            headers: w.headers,
+            body: Bytes::from(w.body),
+            max_age: w.max_age,
+        }
+    }
+}
+
+mod base64_field {
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    use serde::{Deserializer, Serializer, de::Error as _};
+
+    pub fn serialize<S: Serializer>(bytes: &[u8], s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&STANDARD.encode(bytes))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+        let s: &str = serde::Deserialize::deserialize(d)?;
+        STANDARD.decode(s).map_err(D::Error::custom)
+    }
+}
+
+// ── Health ────────────────────────────────────────────────────────────────────
+
+/// Health status returned by `CacheBackend::ping`.
+#[derive(Debug, Clone, Serialize)]
+pub struct BackendHealth {
+    /// `true` when the backend is reachable and responsive.
+    pub ok: bool,
+    /// Round-trip time for a `PING` command in microseconds.
+    pub latency_us: u64,
+    /// Human-readable error when `ok = false`.
+    pub error: Option<String>,
+}
+
+impl BackendHealth {
+    pub const fn healthy(latency_us: u64) -> Self {
+        Self {
+            ok: true,
+            latency_us,
+            error: None,
+        }
+    }
+
+    pub fn unhealthy(error: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            latency_us: 0,
+            error: Some(error.into()),
+        }
+    }
+}
+
+// ── Extended stats ────────────────────────────────────────────────────────────
+
+/// Backend-specific extended statistics returned by the `/api/cache/backend`
+/// endpoint. Fields absent for the `memory` backend use `None`.
+#[derive(Debug, Clone, Serialize)]
+pub struct BackendInfo {
+    /// Backend kind label: `"memory"`, `"embedded"`, `"standalone"`, `"cluster"`.
+    pub backend: String,
+    /// Valkey/Redis server version string (e.g. `"7.2.4"`). `None` for memory.
+    pub valkey_version: Option<String>,
+    /// `true` if at least one node is reachable.
+    pub connected: bool,
+    /// Cluster nodes (non-empty for `standalone`/`cluster`/`embedded`).
+    pub nodes: Vec<NodeSummary>,
+    /// Memory currently used by the backend in bytes.
+    pub memory_used_bytes: Option<u64>,
+    /// Maximum memory limit in bytes (`maxmemory` config). `None` = unlimited.
+    pub memory_max_bytes: Option<u64>,
+    /// Memory fragmentation ratio (RSS / used); `None` for memory backend.
+    pub memory_fragmentation_ratio: Option<f64>,
+    /// Instantaneous commands processed per second.
+    pub ops_per_sec: Option<u64>,
+    /// Active client connections to the Valkey server.
+    pub connected_clients: Option<u32>,
+    /// Keyspace summary: db → (keys, expires).
+    pub keyspace: std::collections::HashMap<String, KeyspaceSummary>,
+    /// Backend health from the most recent ping.
+    pub health: BackendHealth,
+    /// Circuit-breaker state: `"closed"`, `"open"`, or `"half_open"`.
+    pub circuit_breaker: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct NodeSummary {
+    pub addr: String,
+    pub role: String,
+    pub slots: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct KeyspaceSummary {
+    pub keys: u64,
+    pub expires: u64,
+}
+
+// ── Trait ─────────────────────────────────────────────────────────────────────
+
+/// Unified interface over every cache storage implementation.
+///
+/// All methods are async and infallible. Implementations MUST:
+/// - Handle errors internally (log with `tracing::warn!` then degrade).
+/// - Never `panic!`, `unwrap()`, or `expect()`.
+/// - Never block the executor thread.
+#[async_trait]
+pub trait CacheBackend: Send + Sync + 'static {
+    /// Fetch a cached entry. Returns `None` on miss or error.
+    async fn get(&self, key: &str) -> Option<Arc<CachedResponse>>;
+
+    /// Store an entry with the given TTL and tag set.
+    /// Returns `true` when the entry was successfully stored.
+    ///
+    /// `tags` are used for tag-based purge. Each tag maps to the key so that
+    /// `purge_by_tag` can find and evict all affected entries efficiently.
+    async fn put(&self, key: &str, value: CachedResponse, ttl_secs: u64, tags: &[Arc<str>]) -> bool;
+
+    /// Remove a single key. No-op if the key does not exist.
+    async fn remove(&self, key: &str);
+
+    /// Remove all entries tagged with `tag`. Returns count removed.
+    async fn purge_by_tag(&self, tag: &str) -> usize;
+
+    /// Remove all entries whose route-rule tag matches `route_id`.
+    /// Equivalent to `purge_by_tag(route_id)` — route IDs are auto-tagged
+    /// by `RouteRuleGate` and stored in the same tag index.
+    async fn purge_by_route_id(&self, route_id: &str) -> usize;
+
+    /// Remove all entries whose cache key contains the given `host` segment.
+    async fn purge_host(&self, host: &str) -> usize;
+
+    /// Evict every entry. Async to allow batched DEL in Valkey.
+    async fn flush(&self);
+
+    /// Approximate number of entries currently stored.
+    fn entry_count(&self) -> u64;
+
+    /// Number of distinct tag→key mappings in the local tag index.
+    /// For Valkey, this counts the local reverse-index entries (estimated).
+    fn tag_index_size(&self) -> usize;
+
+    /// Probe the backend and return a health snapshot.
+    async fn ping(&self) -> BackendHealth;
+
+    /// Collect backend-specific info for the `/api/cache/backend` endpoint.
+    async fn backend_info(&self) -> BackendInfo;
+
+    /// Per-tag counts (keys associated with each tag) for dashboard top-routes.
+    async fn tag_entry_counts(&self) -> Vec<(String, u64)>;
+}

--- a/crates/gateway/src/cache/bootstrap.rs
+++ b/crates/gateway/src/cache/bootstrap.rs
@@ -1,0 +1,103 @@
+//! Wire [`ResponseCache`] from `[cache]` in `AppConfig` (memory / Valkey modes).
+
+use std::sync::Arc;
+
+use tracing::info;
+use waf_common::config::{CacheBackendKind, CacheConfig};
+
+use super::backend::CacheBackend;
+use super::moka_store::MokaStore;
+use super::rule_set::{CompiledRuleSet, RuleSetHolder};
+use super::store::ResponseCache;
+use super::watcher::{CacheRuleWatcher, DEFAULT_DEBOUNCE_MS, load_or_empty};
+
+/// Result of [`init_response_cache`]: cache + handles that must stay alive.
+pub struct CacheInit {
+    pub cache: Arc<ResponseCache>,
+    /// FR-009 Phase 3: hot-reload watcher for `rules_path`; `None` if unset.
+    pub rules_watcher: Option<CacheRuleWatcher>,
+    /// Keeps embedded `valkey-server` child alive when `backend = "embedded"`.
+    pub embedded_supervisor: Option<Box<dyn Send + Sync + 'static>>,
+}
+
+/// Build [`ResponseCache`] from operator `[cache]` config.
+pub async fn init_response_cache(cfg: &CacheConfig) -> anyhow::Result<CacheInit> {
+    let rules = match &cfg.rules_path {
+        Some(p) => load_or_empty(p.as_path())?,
+        None => CompiledRuleSet::empty(),
+    };
+    let holder = Arc::new(RuleSetHolder::new(rules));
+    let max = cfg.max_size_mb;
+    let def = cfg.default_ttl_secs;
+    let max_ttl = cfg.max_ttl_secs;
+
+    let (backend, embedded_supervisor): (Arc<dyn CacheBackend>, Option<Box<dyn Send + Sync + 'static>>) = match cfg
+        .backend
+    {
+        CacheBackendKind::Memory => {
+            info!(backend = "memory", "response cache backend: in-process moka LRU");
+            (Arc::new(MokaStore::new(max, max_ttl)), None)
+        }
+        #[cfg(feature = "valkey")]
+        CacheBackendKind::Standalone | CacheBackendKind::Cluster => {
+            let label = match cfg.backend {
+                CacheBackendKind::Cluster => "cluster",
+                _ => "standalone",
+            };
+            info!(backend = label, seeds = ?cfg.valkey.seeds, "response cache backend: Valkey");
+            let fallback = Arc::new(MokaStore::new(max, max_ttl));
+            let vk = Arc::new(super::valkey_store::ValkeyStore::connect(&cfg.valkey, max).await?);
+            let b: Arc<dyn CacheBackend> = if cfg.valkey.fallback_to_memory {
+                super::valkey_store::CircuitBreakerStore::new(vk, fallback, &cfg.valkey)
+            } else {
+                vk
+            };
+            (b, None)
+        }
+        #[cfg(feature = "valkey")]
+        CacheBackendKind::Embedded => {
+            info!(
+                backend = "embedded",
+                "response cache backend: valkey-server child process"
+            );
+            let supervisor = Arc::new(super::embedded_valkey::EmbeddedValkey::spawn(&cfg.embedded, max).await?);
+            let mut vk_cfg = cfg.valkey.clone();
+            vk_cfg.seeds = vec![supervisor.unix_socket_addr()];
+            let fallback = Arc::new(MokaStore::new(max, max_ttl));
+            let vk = Arc::new(super::valkey_store::ValkeyStore::connect(&vk_cfg, max).await?);
+            let b: Arc<dyn CacheBackend> = if cfg.valkey.fallback_to_memory {
+                super::valkey_store::CircuitBreakerStore::new(vk, fallback, &cfg.valkey)
+            } else {
+                vk
+            };
+            let hold: Option<Box<dyn Send + Sync + 'static>> = Some(Box::new(supervisor));
+            (b, hold)
+        }
+        #[cfg(not(feature = "valkey"))]
+        CacheBackendKind::Embedded | CacheBackendKind::Standalone | CacheBackendKind::Cluster => {
+            anyhow::bail!(
+                "cache backend {:?} requires building with `--features gateway/valkey` (or `valkey` on the prx-waf package)",
+                cfg.backend
+            );
+        }
+    };
+
+    let cache = ResponseCache::with_backend(backend, max, def, max_ttl, Arc::clone(&holder));
+
+    let rules_watcher = if let Some(path) = cfg.rules_path.as_ref() {
+        info!(path = %path.display(), "watching cache rules YAML for hot reload");
+        Some(CacheRuleWatcher::spawn(
+            path.clone(),
+            Arc::clone(&holder),
+            DEFAULT_DEBOUNCE_MS,
+        )?)
+    } else {
+        None
+    };
+
+    Ok(CacheInit {
+        cache,
+        rules_watcher,
+        embedded_supervisor,
+    })
+}

--- a/crates/gateway/src/cache/embedded_valkey.rs
+++ b/crates/gateway/src/cache/embedded_valkey.rs
@@ -158,10 +158,20 @@ fn find_binary(config_path: &str) -> anyhow::Result<PathBuf> {
 }
 
 /// Minimal `which`-like lookup: scan each component of `PATH`.
+///
+/// Uses [`std::env::split_paths`] so the OS-correct separator is honoured
+/// (`:` on Unix, `;` on Windows). The whole `embedded_valkey` module only
+/// compiles under the `valkey` Cargo feature *and* spawns a child via UNIX
+/// socket — Windows is therefore not a supported runtime for this code path,
+/// but the cross-platform splitter avoids producing a single bogus candidate
+/// like `C\Program Files\valkey\valkey-server.exe` on a developer's Windows
+/// host while running `cargo check --features gateway/valkey`.
 fn which_binary(name: &str) -> anyhow::Result<PathBuf> {
-    let path_var = std::env::var("PATH").unwrap_or_default();
-    for dir in path_var.split(':') {
-        let candidate = PathBuf::from(dir).join(name);
+    let Some(path_var) = std::env::var_os("PATH") else {
+        return Err(anyhow::anyhow!("{name} not found (PATH unset)"));
+    };
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(name);
         if candidate.exists() {
             return Ok(candidate);
         }

--- a/crates/gateway/src/cache/embedded_valkey.rs
+++ b/crates/gateway/src/cache/embedded_valkey.rs
@@ -1,0 +1,197 @@
+//! `EmbeddedValkey` — lifecycle supervisor for a `valkey-server` child process.
+//!
+//! Enabled via the `valkey` Cargo feature.
+//!
+//! When `backend = "embedded"` the WAF spawns a `valkey-server` child process
+//! bound to a UNIX socket. The process is **killed on drop** (`kill_on_drop(true)`)
+//! so no orphan processes are left when the parent exits.
+//!
+//! ## Binary search order
+//!
+//! 1. `cache.embedded.binary_path` (from config) — if non-empty
+//! 2. `valkey-server` on `PATH`
+//! 3. `redis-server` on `PATH` (Valkey is Redis-compatible)
+//!
+//! ## Startup arguments
+//!
+//! ```text
+//! valkey-server
+//!   --unixsocket  /tmp/prx-valkey-{pid}-{nanos}.sock
+//!   --unixsocketperm 700
+//!   --bind 127.0.0.1
+//!   --port 0               # disable TCP; UNIX socket only
+//!   --save ""              # no persistence (in-memory)
+//!   --maxmemory {mb}mb
+//!   --maxmemory-policy allkeys-lru
+//!   --loglevel warning
+//!   --protected-mode no
+//! ```
+
+#![cfg(feature = "valkey")]
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tokio::process::Command;
+use tracing::{debug, info, warn};
+use waf_common::config::EmbeddedValkeyConfig;
+
+/// Handle to a running `valkey-server` child process.
+pub struct EmbeddedValkey {
+    child: tokio::process::Child,
+    /// UNIX socket path used by the embedded server.
+    pub socket_path: PathBuf,
+    /// TCP fallback address (`127.0.0.1:0` when port=0, so unused here; kept
+    /// for the "connect via UNIX socket" path in [`ValkeyStore`]).
+    pub connect_addr: String,
+}
+
+impl EmbeddedValkey {
+    /// Spawn the `valkey-server` process and wait until it is ready.
+    ///
+    /// Returns `Err` if no binary is found or the server does not become ready
+    /// within 5 seconds.
+    pub async fn spawn(cfg: &EmbeddedValkeyConfig, max_size_mb: u64) -> anyhow::Result<Self> {
+        let binary = find_binary(&cfg.binary_path)?;
+        info!(binary = %binary.display(), "spawning embedded Valkey");
+
+        // UNIX socket path: PID + monotonic-ish nanos so a quick restart after crash
+        // does not collide with a stale file from a reused PID.
+        let pid = std::process::id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0u128, |d| d.as_nanos());
+        let socket_path = PathBuf::from(format!("/tmp/prx-valkey-{pid}-{nanos}.sock"));
+
+        // Ensure data dir exists.
+        if !cfg.data_dir.is_empty() {
+            let _ = std::fs::create_dir_all(&cfg.data_dir);
+        }
+
+        let mut args = vec![
+            "--unixsocket".to_string(),
+            socket_path.to_string_lossy().to_string(),
+            "--unixsocketperm".to_string(),
+            "700".to_string(),
+            "--bind".to_string(),
+            "127.0.0.1".to_string(),
+            "--port".to_string(),
+            "0".to_string(),
+            "--save".to_string(),
+            String::new(),
+            "--maxmemory".to_string(),
+            format!("{max_size_mb}mb"),
+            "--maxmemory-policy".to_string(),
+            "allkeys-lru".to_string(),
+            "--loglevel".to_string(),
+            "warning".to_string(),
+            "--protected-mode".to_string(),
+            "no".to_string(),
+        ];
+
+        // Append operator-defined extra args.
+        args.extend(cfg.extra_args.iter().cloned());
+
+        let child = Command::new(&binary)
+            .args(&args)
+            .kill_on_drop(true) // auto-kill when parent process exits
+            .spawn()
+            .map_err(|e| anyhow::anyhow!("failed to spawn valkey-server ({}): {e}", binary.display()))?;
+
+        debug!(pid = child.id(), socket = %socket_path.display(), "valkey-server spawned");
+
+        // Wait until the UNIX socket is ready.
+        wait_ready(&socket_path, Duration::from_secs(5))
+            .await
+            .map_err(|e| anyhow::anyhow!("embedded Valkey did not become ready within 5s: {e}"))?;
+
+        info!(socket = %socket_path.display(), "embedded Valkey ready");
+
+        let connect_addr = format!("unix:{}", socket_path.display());
+
+        Ok(Self {
+            child,
+            socket_path,
+            connect_addr,
+        })
+    }
+
+    /// Returns the connect address suitable for the Valkey client:
+    /// `"unix:/tmp/prx-valkey-{pid}-{nanos}.sock"`.
+    pub fn unix_socket_addr(&self) -> String {
+        format!("unix:{}", self.socket_path.display())
+    }
+}
+
+impl Drop for EmbeddedValkey {
+    fn drop(&mut self) {
+        // `kill_on_drop(true)` handles this automatically when the Child is dropped.
+        // We call start_kill() explicitly here for clarity and to ensure the
+        // SIGKILL is sent even if the runtime is shutting down.
+        if let Err(e) = self.child.start_kill() {
+            warn!(error = %e, "failed to kill embedded valkey-server on drop");
+        }
+    }
+}
+
+// ── Binary discovery ──────────────────────────────────────────────────────────
+
+fn find_binary(config_path: &str) -> anyhow::Result<PathBuf> {
+    if !config_path.is_empty() {
+        let p = PathBuf::from(config_path);
+        if p.exists() {
+            return Ok(p);
+        }
+        return Err(anyhow::anyhow!("configured binary_path does not exist: {config_path}"));
+    }
+
+    for name in &["valkey-server", "redis-server"] {
+        if let Ok(path) = which_binary(name) {
+            return Ok(path);
+        }
+    }
+
+    Err(anyhow::anyhow!(
+        "valkey-server (or redis-server) not found in PATH; \
+         install Valkey or set cache.embedded.binary_path"
+    ))
+}
+
+/// Minimal `which`-like lookup: scan each component of `PATH`.
+fn which_binary(name: &str) -> anyhow::Result<PathBuf> {
+    let path_var = std::env::var("PATH").unwrap_or_default();
+    for dir in path_var.split(':') {
+        let candidate = PathBuf::from(dir).join(name);
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    Err(anyhow::anyhow!("{name} not found"))
+}
+
+// ── Readiness polling ─────────────────────────────────────────────────────────
+
+/// Poll the UNIX socket until it accepts a connection (no separate `exists()`
+/// check — avoids TOCTOU between stat and connect).
+async fn wait_ready(socket_path: &PathBuf, timeout: Duration) -> anyhow::Result<()> {
+    use tokio::net::UnixStream;
+    use tokio::time::sleep;
+
+    let deadline = tokio::time::Instant::now() + timeout;
+    let poll_interval = Duration::from_millis(100);
+
+    loop {
+        if UnixStream::connect(socket_path).await.is_ok() {
+            return Ok(());
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            return Err(anyhow::anyhow!(
+                "timeout waiting for UNIX socket: {}",
+                socket_path.display()
+            ));
+        }
+
+        sleep(poll_interval).await;
+    }
+}

--- a/crates/gateway/src/cache/mod.rs
+++ b/crates/gateway/src/cache/mod.rs
@@ -1,30 +1,42 @@
 //! Response-cache module.
 //!
 //! Public surface (re-exported by `crate::lib`):
-//! - [`ResponseCache`] / [`CachedResponse`] — the moka-backed store
+//! - [`ResponseCache`] — facade (resolver pipeline + backend delegate)
+//! - [`CachedResponse`] — stored HTTP response value
 //! - [`CacheStatsSnapshot`] — read-only counter view
 //! - [`CompiledRuleSet`] / [`RuleSetHolder`] — YAML-defined per-route rules
 //! - [`CacheRuleWatcher`] — `rules/cache.yaml` hot-reloader
+//! - [`BackendInfo`] / [`BackendHealth`] — backend status for dashboard
 //!
 //! Internal:
+//! - [`backend`] — `CacheBackend` trait + shared types
+//! - [`moka_store`] — in-process LRU backend (always compiled)
+//! - [`valkey_store`] — Valkey/Redis backend (requires `valkey` feature)
+//! - [`embedded_valkey`] — embedded Valkey child-process supervisor (`valkey` feature)
 //! - [`policy`] — `Verdict`, `CacheGate` trait, `CachePolicyResolver`
-//! - [`gates`] — concrete gate impls (tier, method, auth, route rule,
-//!   upstream Cache-Control, tier default)
-//! - [`stats`] — atomic counters
+//! - [`gates`] — concrete gate impls
+//! - [`stats`] — atomic counters + timeseries ring buffer
 //!
 //! See [`policy`] for the Chain of Responsibility design rationale.
 
+pub mod backend;
+pub mod bootstrap;
 pub mod config;
+pub mod embedded_valkey;
 pub mod gates;
+pub mod moka_store;
 pub mod policy;
 pub mod rule;
 pub mod rule_set;
-mod stats;
-mod store;
-mod tag_index;
+pub mod stats;
+pub mod store;
+pub mod tag_index;
+pub mod valkey_store;
 pub mod watcher;
 
+pub use backend::{BackendHealth, BackendInfo, CachedResponse};
+pub use bootstrap::{CacheInit, init_response_cache};
 pub use rule_set::{CompiledRuleSet, RuleSetError, RuleSetHolder};
-pub use stats::CacheStatsSnapshot;
-pub use store::{CachedResponse, ResponseCache};
+pub use stats::{CacheStatsSnapshot, TimeseriesBucket};
+pub use store::ResponseCache;
 pub use watcher::{CacheRuleWatcher, CacheWatcherError, DEFAULT_DEBOUNCE_MS, load_or_empty, reload};

--- a/crates/gateway/src/cache/moka_store.rs
+++ b/crates/gateway/src/cache/moka_store.rs
@@ -1,0 +1,212 @@
+//! `MokaStore` — in-process LRU cache backend backed by [`moka`].
+//!
+//! Implements [`CacheBackend`] for the `memory` backend mode. This is the
+//! default and is always compiled in regardless of feature flags. All tag
+//! management uses the local [`TagIndex`] (DashMap-based; no external process).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use moka::future::Cache;
+use moka::notification::RemovalCause;
+use tracing::trace;
+
+use super::backend::{BackendHealth, BackendInfo, CacheBackend, CachedResponse};
+use super::tag_index::TagIndex;
+
+/// In-process moka LRU response cache.
+pub struct MokaStore {
+    inner: Cache<String, Arc<CachedResponse>>,
+    tag_index: Arc<TagIndex>,
+}
+
+impl MokaStore {
+    /// Construct a new `MokaStore`.
+    ///
+    /// `max_size_mb` controls the entry capacity (approximated as
+    /// `max_size_mb × 16` entries — same heuristic as the old `ResponseCache`).
+    pub fn new(max_size_mb: u64, max_ttl_secs: u64) -> Self {
+        let capacity = (max_size_mb * 16).max(64);
+        let tag_index = Arc::new(TagIndex::new());
+        let tag_index_for_evict = Arc::clone(&tag_index);
+
+        let inner = Cache::builder()
+            .max_capacity(capacity)
+            .time_to_live(Duration::from_secs(max_ttl_secs))
+            .eviction_listener(move |k: Arc<String>, _v: Arc<CachedResponse>, cause: RemovalCause| {
+                // Skip Replaced: the new `put` already re-registers tags for the new
+                // value. Acting on Replaced would wipe the freshly registered index
+                // entry and cause purge-by-tag misses.
+                if matches!(cause, RemovalCause::Replaced) {
+                    return;
+                }
+                tag_index_for_evict.unregister(&Arc::<str>::from(k.as_str()));
+            })
+            .build();
+
+        Self { inner, tag_index }
+    }
+}
+
+#[async_trait]
+impl CacheBackend for MokaStore {
+    async fn get(&self, key: &str) -> Option<Arc<CachedResponse>> {
+        let result = self.inner.get(key).await;
+        trace!(key = %key, hit = result.is_some(), "MokaStore::get");
+        result
+    }
+
+    async fn put(&self, key: &str, value: CachedResponse, ttl_secs: u64, tags: &[Arc<str>]) -> bool {
+        debug_assert_eq!(
+            ttl_secs, value.max_age,
+            "ttl_secs from gate pipeline must match CachedResponse.max_age"
+        );
+        let entry = Arc::new(CachedResponse {
+            max_age: ttl_secs,
+            ..value
+        });
+        let key_arc: Option<Arc<str>> = if tags.is_empty() {
+            None
+        } else {
+            Some(Arc::<str>::from(key))
+        };
+        self.inner.insert(key.to_string(), entry).await;
+        if let Some(k) = key_arc {
+            self.tag_index.register(&k, tags);
+        }
+        true
+    }
+
+    async fn remove(&self, key: &str) {
+        self.inner.remove(key).await;
+    }
+
+    async fn purge_by_tag(&self, tag: &str) -> usize {
+        let keys = self.tag_index.keys_for_tag(tag);
+        let count = keys.len();
+        for k in keys {
+            self.inner.remove(k.as_ref()).await;
+            self.tag_index.unregister(&k);
+        }
+        count
+    }
+
+    async fn purge_by_route_id(&self, route_id: &str) -> usize {
+        self.purge_by_tag(route_id).await
+    }
+
+    async fn purge_host(&self, host: &str) -> usize {
+        let keys: Vec<String> = self
+            .inner
+            .iter()
+            .filter(|(k, _)| {
+                let mut parts = k.splitn(3, ':');
+                parts.next(); // method
+                parts.next() == Some(host)
+            })
+            .map(|(k, _)| k.to_string())
+            .collect();
+        let count = keys.len();
+        for k in keys {
+            self.inner.remove(&k).await;
+        }
+        count
+    }
+
+    async fn flush(&self) {
+        self.inner.invalidate_all();
+        self.inner.run_pending_tasks().await;
+        self.tag_index.clear();
+    }
+
+    fn entry_count(&self) -> u64 {
+        self.inner.entry_count()
+    }
+
+    fn tag_index_size(&self) -> usize {
+        self.tag_index.key_count()
+    }
+
+    async fn ping(&self) -> BackendHealth {
+        // In-process store is always healthy.
+        BackendHealth::healthy(0)
+    }
+
+    async fn backend_info(&self) -> BackendInfo {
+        BackendInfo {
+            backend: "memory".to_string(),
+            valkey_version: None,
+            connected: true,
+            nodes: vec![],
+            memory_used_bytes: None,
+            memory_max_bytes: None,
+            memory_fragmentation_ratio: None,
+            ops_per_sec: None,
+            connected_clients: None,
+            keyspace: std::collections::HashMap::new(),
+            health: BackendHealth::healthy(0),
+            circuit_breaker: "closed".to_string(),
+        }
+    }
+
+    async fn tag_entry_counts(&self) -> Vec<(String, u64)> {
+        self.tag_index.tag_entry_counts()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+
+    fn make_response() -> CachedResponse {
+        CachedResponse {
+            status: 200,
+            headers: vec![],
+            body: Bytes::from_static(b"hello"),
+            max_age: 60,
+        }
+    }
+
+    #[tokio::test]
+    async fn put_and_get_roundtrip() {
+        let store = MokaStore::new(8, 3600);
+        assert!(store.put("k1", make_response(), 60, &[]).await);
+        assert!(store.get("k1").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn miss_returns_none() {
+        let store = MokaStore::new(8, 3600);
+        assert!(store.get("missing").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn purge_by_tag_removes_tagged_keys() {
+        let store = MokaStore::new(8, 3600);
+        let tag: Arc<str> = Arc::from("catalog");
+        store.put("k1", make_response(), 60, &[Arc::clone(&tag)]).await;
+        store.put("k2", make_response(), 60, &[Arc::clone(&tag)]).await;
+        assert_eq!(store.purge_by_tag("catalog").await, 2);
+        assert!(store.get("k1").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn flush_clears_everything() {
+        let store = MokaStore::new(8, 3600);
+        store.put("k1", make_response(), 60, &[]).await;
+        store.flush().await;
+        assert_eq!(store.entry_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn purge_host_removes_only_matching() {
+        let store = MokaStore::new(8, 3600);
+        store.put("GET:host-a:/x", make_response(), 60, &[]).await;
+        store.put("GET:host-a:/y", make_response(), 60, &[]).await;
+        store.put("GET:host-b:/z", make_response(), 60, &[]).await;
+        assert_eq!(store.purge_host("host-a").await, 2);
+        assert!(store.get("GET:host-b:/z").await.is_some());
+    }
+}

--- a/crates/gateway/src/cache/rule_set.rs
+++ b/crates/gateway/src/cache/rule_set.rs
@@ -90,6 +90,31 @@ impl CompiledRuleSet {
             defaults: doc.defaults,
         })
     }
+
+    /// First matching cache rule for statistics routing (mirrors
+    /// [`crate::cache::gates::RouteRuleGate`] match order).
+    ///
+    /// Returns `None` when a rule matches with `ttl_seconds: 0` (explicit deny).
+    /// Returns `Some("_default")` when no rule matches (tier-default caching).
+    pub fn first_cacheable_rule_id(&self, host: &str, path: &str, method: &str) -> Option<Arc<str>> {
+        let host_lower_storage;
+        let host_lower: &str = if host.bytes().all(|b| !b.is_ascii_uppercase()) {
+            host
+        } else {
+            host_lower_storage = host.to_ascii_lowercase();
+            host_lower_storage.as_str()
+        };
+        for rule in self.rules.iter() {
+            if !rule.matches_str(host_lower, path, method) {
+                continue;
+            }
+            if rule.ttl.is_zero() {
+                return None;
+            }
+            return Some(Arc::clone(&rule.id));
+        }
+        Some(Arc::from("_default"))
+    }
 }
 
 fn approx_regex_cost(rule: &crate::cache::config::RuleDoc) -> usize {

--- a/crates/gateway/src/cache/stats.rs
+++ b/crates/gateway/src/cache/stats.rs
@@ -1,14 +1,73 @@
-//! Response-cache statistics counters.
+//! Response-cache statistics counters + timeseries ring buffer.
 //!
 //! `bypassed_critical` is the audit signal for FR-009 AC-1: it MUST tick on
 //! every CRITICAL-tier or `NoCache`-policy bypass so operators can prove the
 //! tier gate is firing.
+//!
+//! The 60-bucket timeseries ring buffer records 1-minute snapshots for the
+//! `/api/cache/stats/timeseries` endpoint.
 
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use dashmap::DashMap;
+use parking_lot::Mutex;
+use serde::Serialize;
 
 use super::policy::BypassReason;
 
-/// Cache statistics counters
+// ── Per-route hit/miss tracking ───────────────────────────────────────────────
+
+/// Aggregated stats for a single cache route rule.
+#[derive(Debug, Clone, Serialize)]
+pub struct RouteStats {
+    pub route_id: String,
+    pub hits: u64,
+    pub misses: u64,
+    pub entry_count: u64,
+}
+
+// ── Timeseries bucket ─────────────────────────────────────────────────────────
+
+/// One 1-minute data point in the timeseries ring buffer.
+#[derive(Debug, Clone, Serialize)]
+pub struct TimeseriesBucket {
+    /// Unix timestamp (start of the minute, UTC) in seconds.
+    pub ts: u64,
+    pub hits: u64,
+    pub misses: u64,
+    pub hit_ratio: f64,
+    pub stores: u64,
+    /// Memory used by the backend in bytes (0 for moka).
+    pub memory_used_bytes: u64,
+}
+
+impl TimeseriesBucket {
+    fn new(ts: u64, hits: u64, misses: u64, stores: u64, memory_used_bytes: u64) -> Self {
+        let total = hits + misses;
+        let hit_ratio = if total == 0 {
+            0.0
+        } else {
+            #[allow(clippy::cast_precision_loss)]
+            {
+                hits as f64 / total as f64
+            }
+        };
+        Self {
+            ts,
+            hits,
+            misses,
+            hit_ratio,
+            stores,
+            memory_used_bytes,
+        }
+    }
+}
+
+// ── Cache statistics counters ─────────────────────────────────────────────────
+
+/// Cache statistics counters.
 #[derive(Debug, Default)]
 pub struct CacheStats {
     pub hits: AtomicU64,
@@ -28,6 +87,58 @@ pub struct CacheStats {
     pub purges_tag: AtomicU64,
     /// FR-009 Phase 4: cumulative entries removed via `purge_by_route_id`.
     pub purges_route: AtomicU64,
+
+    /// Per-route cache hits (key = rule id or `"_default"`).
+    route_hits: DashMap<String, AtomicU64>,
+    /// Per-route cache misses on lookup.
+    route_misses: DashMap<String, AtomicU64>,
+
+    // ── Timeseries ring buffer (60 × 1-min buckets) ───────────────────────────
+    // Guarded by a Mutex so the ticker thread can append without blocking
+    // the hot request path (atomic counters are read lock-free).
+    timeseries: Mutex<TimeseriesRing>,
+    /// Snapshot of cumulative counters at the time the last bucket was recorded.
+    last_snapshot: Mutex<BucketBaseline>,
+}
+
+/// Cumulative baseline captured at the start of each 1-minute window.
+#[derive(Debug, Default, Clone)]
+struct BucketBaseline {
+    hits: u64,
+    misses: u64,
+    stores: u64,
+}
+
+/// Ring buffer of `TimeseriesBucket` (newest at back).
+#[derive(Debug)]
+struct TimeseriesRing {
+    buckets: VecDeque<TimeseriesBucket>,
+    /// Maximum number of 1-minute buckets to keep.
+    max_buckets: usize,
+}
+
+impl Default for TimeseriesRing {
+    fn default() -> Self {
+        Self {
+            buckets: VecDeque::new(),
+            max_buckets: 60,
+        }
+    }
+}
+
+impl TimeseriesRing {
+    fn push(&mut self, bucket: TimeseriesBucket) {
+        if self.buckets.len() >= self.max_buckets {
+            self.buckets.pop_front();
+        }
+        self.buckets.push_back(bucket);
+    }
+
+    /// Return the last `n` buckets, oldest first.
+    fn last_n(&self, n: usize) -> Vec<TimeseriesBucket> {
+        let skip = self.buckets.len().saturating_sub(n);
+        self.buckets.iter().skip(skip).cloned().collect()
+    }
 }
 
 impl CacheStats {
@@ -46,12 +157,6 @@ impl CacheStats {
     }
 
     /// Bump the appropriate bypass counter for a `Verdict::Bypass(reason)`.
-    ///
-    /// Only `CriticalTier` and `NoCachePolicy` count as "audit" bypasses (they
-    /// preserve the Phase-1 `bypassed_critical` semantics). All other reasons
-    /// are silent — matching the prior behavior where Set-Cookie / non-2xx /
-    /// upstream-Cache-Control bypasses returned `false` without bumping any
-    /// counter.
     pub fn record_bypass(&self, reason: BypassReason) {
         match reason {
             BypassReason::CriticalTier | BypassReason::NoCachePolicy => {
@@ -66,9 +171,74 @@ impl CacheStats {
             _ => {}
         }
     }
+
+    /// Tick a timeseries bucket for the current minute. Call once per minute
+    /// from a background task. `memory_used_bytes` should come from the backend.
+    pub fn tick_timeseries(&self, memory_used_bytes: u64) {
+        let now_secs = SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| d.as_secs());
+        // Align to minute boundary.
+        let bucket_ts = (now_secs / 60) * 60;
+
+        let hits_now = self.hits.load(Ordering::Relaxed);
+        let misses_now = self.misses.load(Ordering::Relaxed);
+        let stores_now = self.stores.load(Ordering::Relaxed);
+
+        let mut baseline = self.last_snapshot.lock();
+        let delta_hits = hits_now.saturating_sub(baseline.hits);
+        let delta_misses = misses_now.saturating_sub(baseline.misses);
+        let delta_stores = stores_now.saturating_sub(baseline.stores);
+        *baseline = BucketBaseline {
+            hits: hits_now,
+            misses: misses_now,
+            stores: stores_now,
+        };
+        drop(baseline);
+
+        let bucket = TimeseriesBucket::new(bucket_ts, delta_hits, delta_misses, delta_stores, memory_used_bytes);
+        self.timeseries.lock().push(bucket);
+    }
+
+    /// Return the last `minutes` data points, oldest first.
+    /// Clamps to the ring buffer size (60).
+    pub fn timeseries(&self, minutes: usize) -> Vec<TimeseriesBucket> {
+        self.timeseries.lock().last_n(minutes.min(60))
+    }
+
+    pub fn record_route_hit(&self, route_key: &str) {
+        self.route_hits
+            .entry(route_key.to_string())
+            .or_insert_with(|| AtomicU64::new(0))
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_route_miss(&self, route_key: &str) {
+        self.route_misses
+            .entry(route_key.to_string())
+            .or_insert_with(|| AtomicU64::new(0))
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn route_traffic_snapshot(&self) -> HashMap<String, (u64, u64)> {
+        let mut keys = HashSet::new();
+        for r in &self.route_hits {
+            keys.insert(r.key().clone());
+        }
+        for r in &self.route_misses {
+            keys.insert(r.key().clone());
+        }
+        let mut out = HashMap::with_capacity(keys.len());
+        for k in keys {
+            let h = self.route_hits.get(&k).map_or(0, |v| v.load(Ordering::Relaxed));
+            let m = self.route_misses.get(&k).map_or(0, |v| v.load(Ordering::Relaxed));
+            out.insert(k, (h, m));
+        }
+        out
+    }
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
+// ── Snapshot ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
 pub struct CacheStatsSnapshot {
     pub hits: u64,
     pub misses: u64,
@@ -79,4 +249,18 @@ pub struct CacheStatsSnapshot {
     pub bypassed_explicit_deny: u64,
     pub purges_tag: u64,
     pub purges_route: u64,
+}
+
+impl CacheStatsSnapshot {
+    pub fn hit_ratio(&self) -> f64 {
+        let total = self.hits + self.misses;
+        if total == 0 {
+            0.0
+        } else {
+            #[allow(clippy::cast_precision_loss)]
+            {
+                self.hits as f64 / total as f64
+            }
+        }
+    }
 }

--- a/crates/gateway/src/cache/store.rs
+++ b/crates/gateway/src/cache/store.rs
@@ -1,55 +1,71 @@
-//! In-memory LRU response cache backed by `moka`.
+//! `ResponseCache` — facade that wires the Chain-of-Responsibility resolver
+//! pipeline to a pluggable [`CacheBackend`] storage implementation.
 //!
-//! Cache key = `method:host:path?query`
+//! ## Architecture
 //!
-//! `put` delegates to `CachePolicyResolver` (Chain of Responsibility); `get`
-//! keeps the inline CRITICAL-tier check (cheap, hot path, single concern).
+//! ```text
+//! ResponseCache (resolver + bypass stats)
+//!     │
+//!     └─ Arc<dyn CacheBackend>
+//!            ├─ MokaStore     (backend = "memory", default)
+//!            ├─ ValkeyStore   (backend = "standalone" / "cluster")
+//!            ├─ EmbeddedValkey → ValkeyStore  (backend = "embedded")
+//!            └─ CircuitBreakerStore  (wraps ValkeyStore, fallback to MokaStore)
+//! ```
 //!
-//! Tier-gated (FR-009 AC-1): CRITICAL-tier responses are NEVER cached. The
-//! per-tier `CachePolicy` also caps TTL — upstream cannot exceed the ceiling.
+//! The resolver pipeline (`TierGate → MethodGate → AuthGate → RouteRuleGate →
+//! UpstreamCcGate → TierDefaultGate`) and all bypass counters live here.
+//! Storage hits/misses are tracked at this layer too so the same counters work
+//! regardless of which backend is active.
 
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use bytes::Bytes;
-use moka::future::Cache;
-use moka::notification::RemovalCause;
+use parking_lot::Mutex;
 use tracing::{debug, trace};
 use waf_common::tier::{CachePolicy, Tier};
 
+use super::backend::{BackendHealth, BackendInfo, CacheBackend, CachedResponse};
 use super::gates::{AuthGate, MethodGate, RouteRuleGate, TierDefaultGate, TierGate, UpstreamCcGate};
+use super::moka_store::MokaStore;
 use super::policy::{CacheCtx, CachePolicyResolver, Verdict};
 use super::rule_set::{CompiledRuleSet, RuleSetHolder};
-use super::stats::{CacheStats, CacheStatsSnapshot};
-use super::tag_index::TagIndex;
+use super::stats::{CacheStats, CacheStatsSnapshot, RouteStats, TimeseriesBucket};
 
-/// A cached HTTP response
-#[derive(Debug, Clone)]
-pub struct CachedResponse {
-    pub status: u16,
-    /// Response headers as (name, value) pairs
-    pub headers: Vec<(String, String)>,
-    pub body: Bytes,
-    /// Seconds until expiry (from insertion time)
-    pub max_age: u64,
+fn parse_cache_key(key: &str) -> Option<(&str, &str, &str)> {
+    let main = key.split_once('?').map_or(key, |(a, _)| a);
+    let mut parts = main.splitn(3, ':');
+    let method = parts.next()?;
+    let host = parts.next()?;
+    let path = parts.next()?;
+    Some((method, host, path))
 }
 
-/// Shared response cache
+/// Cache [`BackendInfo`] for the stats dashboard poll interval (avoids Valkey `INFO` on every request).
+const STATS_BACKEND_INFO_TTL: Duration = Duration::from_secs(10);
+
+/// Shared response cache.
+///
+/// Holds the resolver pipeline and bypass counters. All storage operations
+/// delegate to the inner `backend` implementation.
 pub struct ResponseCache {
-    inner: Cache<String, Arc<CachedResponse>>,
+    backend: Arc<dyn CacheBackend>,
     stats: Arc<CacheStats>,
+    rules: Arc<RuleSetHolder>,
     default_ttl: Duration,
     max_ttl: Duration,
     resolver: CachePolicyResolver,
-    /// FR-009 Phase 4: reverse index for tag-based purge.
-    tag_index: Arc<TagIndex>,
+    stats_backend_info_cache: Mutex<Option<(BackendInfo, Instant)>>,
 }
 
 impl ResponseCache {
-    /// Create a new cache.
+    /// Create a memory-backed cache (moka LRU, no external process).
     ///
-    /// `max_size_mb`: maximum total size in MiB (approximate, measured by entry count).
+    /// Shorthand for `with_rules` with an empty rule set — suitable for tests
+    /// and deployments that do not need per-route TTL rules.
     pub fn new(max_size_mb: u64, default_ttl_secs: u64, max_ttl_secs: u64) -> Arc<Self> {
         Self::with_rules(
             max_size_mb,
@@ -59,64 +75,51 @@ impl ResponseCache {
         )
     }
 
-    /// Build a cache with a hot-swappable rule set. The caller owns the
-    /// `RuleSetHolder` (and any `CacheRuleWatcher` wired to it). FR-009 Phase 3.
+    /// Build a memory-backed cache with a hot-swappable rule set.
     ///
-    /// Resolver order (locked):
-    /// `TierGate → MethodGate → AuthGate → RouteRule → UpstreamCcGate → TierDefaultGate`.
+    /// Resolver order: `TierGate → MethodGate → AuthGate → RouteRule →
+    /// UpstreamCcGate → TierDefaultGate`. FR-009 Phase 3.
     pub fn with_rules(
         max_size_mb: u64,
         default_ttl_secs: u64,
         max_ttl_secs: u64,
         rules: Arc<RuleSetHolder>,
     ) -> Arc<Self> {
-        let capacity = (max_size_mb * 16).max(64);
-        let stats = Arc::new(CacheStats::default());
-        let tag_index = Arc::new(TagIndex::new());
+        let backend = Arc::new(MokaStore::new(max_size_mb, max_ttl_secs));
+        Self::with_backend(backend, max_size_mb, default_ttl_secs, max_ttl_secs, rules)
+    }
 
-        // FR-009 Phase 4: keep tag index in sync with moka. Without this hook
-        // a TTL-expired or LRU-evicted entry leaks its key in the index until
-        // the next purge sweep. The closure is sync (moka invokes it from a
-        // maintenance task); only an in-memory DashMap update happens here so
-        // there is no need for `async_eviction_listener`.
-        //
-        // `Replaced` is filtered out: when `put` overwrites an existing key,
-        // moka schedules eviction-listener for the *old* value, but that task
-        // can run AFTER `put` has already re-registered the new tags. Acting
-        // on `Replaced` would then wipe the fresh index entry and orphan the
-        // new value (`purge_by_tag` would miss it until TTL). The `put` path
-        // always re-registers, so `Replaced` cleanup is both redundant and
-        // racy.
-        let tag_index_for_evict = Arc::clone(&tag_index);
-        let inner = Cache::builder()
-            .max_capacity(capacity)
-            .time_to_live(Duration::from_secs(max_ttl_secs))
-            .eviction_listener(move |k: Arc<String>, _v: Arc<CachedResponse>, cause: RemovalCause| {
-                if matches!(cause, RemovalCause::Replaced) {
-                    return;
-                }
-                tag_index_for_evict.unregister(&Arc::<str>::from(k.as_str()));
-            })
-            .build();
-
+    /// Build a cache with an explicit [`CacheBackend`] and a rule set.
+    ///
+    /// Used when the operator selects `embedded`, `standalone`, or `cluster`.
+    pub fn with_backend(
+        backend: Arc<dyn CacheBackend>,
+        _max_size_mb: u64,
+        default_ttl_secs: u64,
+        max_ttl_secs: u64,
+        rules: Arc<RuleSetHolder>,
+    ) -> Arc<Self> {
         let resolver = CachePolicyResolver::new(vec![
             Box::new(TierGate),
             Box::new(MethodGate),
             Box::new(AuthGate),
-            Box::new(RouteRuleGate::new(rules)),
+            Box::new(RouteRuleGate::new(Arc::clone(&rules))),
             Box::new(UpstreamCcGate),
             Box::new(TierDefaultGate),
         ]);
 
         Arc::new(Self {
-            inner,
-            stats,
+            backend,
+            stats: Arc::new(CacheStats::default()),
+            rules,
             default_ttl: Duration::from_secs(default_ttl_secs),
             max_ttl: Duration::from_secs(max_ttl_secs),
             resolver,
-            tag_index,
+            stats_backend_info_cache: Mutex::new(None),
         })
     }
+
+    // ── Public key helper ────────────────────────────────────────────────────
 
     /// Build the cache key for a request.
     pub fn make_key(method: &str, host: &str, path: &str, query: &str) -> String {
@@ -127,17 +130,32 @@ impl ResponseCache {
         }
     }
 
+    // ── Read path ────────────────────────────────────────────────────────────
+
     /// Look up a cached response. Returns `None` on miss or on tier bypass.
     ///
-    /// Symmetric tier gate (FR-009 AC-1): if the request's tier is CRITICAL,
-    /// never serve a cached entry — even one inserted before reclassification.
+    /// Symmetric tier gate (FR-009 AC-1): CRITICAL-tier requests are never
+    /// served a cached entry even if one was stored before reclassification.
     pub async fn get(&self, key: &str, tier: Tier) -> Option<Arc<CachedResponse>> {
+        let route_label = parse_cache_key(key).and_then(|(method, host, path)| {
+            self.rules
+                .load()
+                .first_cacheable_rule_id(host, path, method)
+                .map(|s| s.as_ref().to_string())
+        });
         if matches!(tier, Tier::Critical) {
             self.stats.bypassed_critical.fetch_add(1, Ordering::Relaxed);
             trace!(key = %key, "cache bypass: CRITICAL tier");
             return None;
         }
-        let result = self.inner.get(key).await;
+        let result = self.backend.get(key).await;
+        if let Some(ref label) = route_label {
+            if result.is_some() {
+                self.stats.record_route_hit(label);
+            } else {
+                self.stats.record_route_miss(label);
+            }
+        }
         if result.is_some() {
             self.stats.hits.fetch_add(1, Ordering::Relaxed);
             trace!(key = %key, "cache hit");
@@ -148,12 +166,10 @@ impl ResponseCache {
         result
     }
 
+    // ── Write path ───────────────────────────────────────────────────────────
+
     /// Store a response. Decision is delegated to `CachePolicyResolver`.
     /// Returns `false` if any gate bypassed.
-    ///
-    /// `host`/`path` and `has_authorization`/`has_cookie` feed the FR-009
-    /// Phase 3 gates (`RouteRuleGate`, `AuthGate`). Callers probe the request
-    /// once and pass the result; gates do not re-parse headers.
     #[allow(clippy::too_many_arguments)]
     pub async fn put(
         &self,
@@ -169,7 +185,6 @@ impl ResponseCache {
         has_authorization: bool,
         has_cookie: bool,
     ) -> bool {
-        // Method extracted from key prefix (`method:host:path[?query]`).
         let method = key.split(':').next().unwrap_or("");
         let ctx = CacheCtx {
             tier,
@@ -193,108 +208,150 @@ impl ResponseCache {
                 false
             }
             Verdict::Cache { ttl, tags } => {
-                let entry = Arc::new(CachedResponse {
+                let entry = CachedResponse {
                     status,
                     headers,
                     body,
                     max_age: ttl.as_secs(),
-                });
-                let key_for_index: Option<Arc<str>> = if tags.is_empty() {
-                    None
-                } else {
-                    Some(Arc::<str>::from(key.as_str()))
                 };
-                self.inner.insert(key, entry).await;
-                if let Some(k) = key_for_index {
-                    self.tag_index.register(&k, &tags);
+                let stored = self.backend.put(&key, entry, ttl.as_secs(), &tags).await;
+                if stored {
+                    self.stats.stores.fetch_add(1, Ordering::Relaxed);
                 }
-                self.stats.stores.fetch_add(1, Ordering::Relaxed);
-                true
+                stored
             }
-            // Resolver always terminates with Bypass(NoMatch); defensive arm.
             Verdict::Continue => false,
         }
     }
 
+    // ── Purge / invalidation ─────────────────────────────────────────────────
+
     /// Invalidate all entries for a given host.
     pub async fn purge_host(&self, host: &str) {
-        let keys: Vec<String> = self
-            .inner
-            .iter()
-            .filter(|(k, _)| {
-                let parts: Vec<&str> = k.splitn(3, ':').collect();
-                parts.get(1).copied() == Some(host)
-            })
-            .map(|(k, _)| k.to_string())
-            .collect();
-        for k in keys {
-            self.inner.remove(&k).await;
-        }
+        let _ = self.backend.purge_host(host).await;
     }
 
     /// Invalidate a single cache key.
     pub async fn purge_key(&self, key: &str) {
-        self.inner.remove(key).await;
+        self.backend.remove(key).await;
     }
 
     /// Flush the entire cache.
     pub async fn flush(&self) {
-        self.inner.invalidate_all();
-        self.inner.run_pending_tasks().await;
-        // Eviction listener will fire for each entry, but `invalidate_all`
-        // is async-batched — clear the index synchronously too so callers
-        // observe a zero gauge immediately after `flush().await` returns.
-        self.tag_index.clear();
+        self.backend.flush().await;
     }
 
-    /// FR-009 Phase 4: purge every entry tagged with `tag`. Returns the count.
-    /// Snapshot-then-remove avoids holding `DashMap` shard locks across `await`.
+    /// FR-009 Phase 4: purge every entry tagged with `tag`. Returns count purged.
     pub async fn purge_by_tag(&self, tag: &str) -> usize {
-        let keys = self.tag_index.keys_for_tag(tag);
-        let n = self.purge_keys(keys).await;
+        let n = self.backend.purge_by_tag(tag).await;
         self.stats.purges_tag.fetch_add(n as u64, Ordering::Relaxed);
         n
     }
 
     /// FR-009 Phase 4: purge every entry cached by the rule with this `id`.
-    /// Implemented as a tag lookup because `RouteRuleGate` auto-prepends the
-    /// rule id to every entry's tag list.
     pub async fn purge_by_route_id(&self, route_id: &str) -> usize {
-        let keys = self.tag_index.keys_for_tag(route_id);
-        let n = self.purge_keys(keys).await;
+        let n = self.backend.purge_by_route_id(route_id).await;
         self.stats.purges_route.fetch_add(n as u64, Ordering::Relaxed);
         n
     }
 
-    /// Internal: remove the given keys from moka and the tag index.
-    async fn purge_keys(&self, keys: Vec<Arc<str>>) -> usize {
-        let count = keys.len();
-        for k in keys {
-            self.inner.remove(k.as_ref()).await;
-            // Eviction listener will also call `unregister`; calling it here
-            // is idempotent and ensures the index is consistent the moment
-            // this method returns (eviction listener runs out-of-band).
-            self.tag_index.unregister(&k);
-        }
-        count
-    }
+    // ── Gauges / stats ───────────────────────────────────────────────────────
 
-    /// FR-009 Phase 4: number of distinct keys currently tracked by the tag
-    /// index (gauge, not a counter).
+    /// FR-009 Phase 4: number of distinct keys currently tracked by the tag index.
     pub fn tag_index_size(&self) -> usize {
-        self.tag_index.key_count()
+        self.backend.tag_index_size()
     }
 
-    /// Return current statistics.
+    /// Return current request-level statistics.
     pub fn stats(&self) -> CacheStatsSnapshot {
         self.stats.snapshot()
     }
 
     /// Approximate entry count.
     pub fn entry_count(&self) -> u64 {
-        self.inner.entry_count()
+        self.backend.entry_count()
+    }
+
+    /// Return timeseries data points (up to `minutes`, capped at 60).
+    pub fn timeseries(&self, minutes: usize) -> Vec<TimeseriesBucket> {
+        self.stats.timeseries(minutes)
+    }
+
+    /// Tick the 1-minute timeseries bucket. Call from a background task.
+    pub async fn tick_timeseries(&self) {
+        let info = self.backend.backend_info().await;
+        let mem = info.memory_used_bytes.unwrap_or(0);
+        self.stats.tick_timeseries(mem);
+    }
+
+    /// Probe the backend and return a health snapshot.
+    pub async fn ping(&self) -> BackendHealth {
+        self.backend.ping().await
+    }
+
+    /// Return backend info for the `/api/cache/backend` endpoint.
+    pub async fn backend_info(&self) -> BackendInfo {
+        self.backend.backend_info().await
+    }
+
+    /// Freshness-trades-off copy of [`Self::backend_info`] for endpoints polled frequently (e.g. stats KPIs).
+    pub async fn backend_info_for_stats_panel(&self) -> BackendInfo {
+        let now = Instant::now();
+        {
+            let guard = self.stats_backend_info_cache.lock();
+            #[allow(clippy::collapsible_if)] // nested form avoids depending on `let_chains`
+            if let Some((info, at)) = guard.as_ref() {
+                if now.duration_since(*at) < STATS_BACKEND_INFO_TTL {
+                    return info.clone();
+                }
+            }
+        }
+        let info = self.backend.backend_info().await;
+        *self.stats_backend_info_cache.lock() = Some((info.clone(), now));
+        info
+    }
+
+    /// Per-tag entry counts from the active storage backend (memory tag index or Valkey `SCAN`).
+    pub async fn tag_entry_counts(&self) -> Vec<(String, u64)> {
+        self.backend.tag_entry_counts().await
+    }
+
+    /// Return top cached routes by hits. `limit` caps the result count.
+    ///
+    /// Merges per-tag entry counts from the active backend with in-process
+    /// hit/miss counters keyed by rule id (or `"_default"`).
+    pub async fn top_routes(&self, limit: usize) -> Vec<RouteStats> {
+        let tag_map: HashMap<String, u64> = self.backend.tag_entry_counts().await.into_iter().collect();
+        let traffic = self.stats.route_traffic_snapshot();
+        let mut route_ids: HashSet<String> = tag_map.keys().cloned().collect();
+        for k in traffic.keys() {
+            route_ids.insert(k.clone());
+        }
+        let mut rows: Vec<RouteStats> = route_ids
+            .into_iter()
+            .map(|id| {
+                let entry_count = *tag_map.get(&id).unwrap_or(&0);
+                let (hits, misses) = traffic.get(&id).copied().unwrap_or((0, 0));
+                RouteStats {
+                    route_id: id,
+                    hits,
+                    misses,
+                    entry_count,
+                }
+            })
+            .collect();
+        rows.sort_by(|a, b| {
+            b.hits
+                .cmp(&a.hits)
+                .then_with(|| b.entry_count.cmp(&a.entry_count))
+                .then_with(|| a.route_id.cmp(&b.route_id))
+        });
+        rows.truncate(limit);
+        rows
     }
 }
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
@@ -308,8 +365,6 @@ mod tests {
         "GET:h:/p".to_string()
     }
 
-    /// Test helper — wraps the now-extended `put()` signature so individual
-    /// tests stay readable. Anonymous + no Set-Cookie unless overridden.
     async fn put_basic(
         c: &ResponseCache,
         headers: Vec<(String, String)>,
@@ -434,8 +489,6 @@ mod tests {
         assert_eq!(c.stats().bypassed_critical, 0);
     }
 
-    // FR-009 Phase 3 tests ---------------------------------------------------
-
     #[tokio::test]
     async fn auth_request_bypasses_via_authorization_header() {
         let c = cache();
@@ -450,8 +503,8 @@ mod tests {
                 Some("max-age=600"),
                 Tier::Medium,
                 &CachePolicy::Aggressive { ttl_seconds: 300 },
-                true,  // has_authorization
-                false, // has_cookie
+                true,
+                false,
             )
             .await;
         assert!(!stored);
@@ -481,10 +534,6 @@ mod tests {
         assert_eq!(c.stats().bypassed_authenticated, 1);
     }
 
-    // FR-009 Phase 4 tests --------------------------------------------------
-
-    /// Build a single-rule cache and return both the cache and the rule's
-    /// declared tag for symmetry with the assertions.
     fn cache_with_rule(rule_id: &str, prefix: &str, ttl_secs: u32, tags: Vec<String>) -> Arc<ResponseCache> {
         use crate::cache::config::{CacheConfigDoc, Defaults, MatchDoc, PathSpec, RuleDoc};
         let doc = CacheConfigDoc {
@@ -544,24 +593,17 @@ mod tests {
         assert!(put_under_rule(&c, "GET:h:/p/a", "h", "/p/a").await);
         let purged = c.purge_by_tag("nonexistent").await;
         assert_eq!(purged, 0);
-        // Untouched entry must still be present.
         assert!(c.get("GET:h:/p/a", Tier::Medium).await.is_some());
     }
 
     #[tokio::test]
     async fn purge_by_route_id_uses_auto_prepended_tag() {
-        // Operator only declared `catalog`, but route_id `static` was
-        // auto-prepended by RouteRuleGate so this must still work.
         let c = cache_with_rule("static", "/p", 600, vec!["catalog".into()]);
         assert!(put_under_rule(&c, "GET:h:/p/a", "h", "/p/a").await);
         let purged = c.purge_by_route_id("static").await;
         assert_eq!(purged, 1);
         assert_eq!(c.stats().purges_route, 1);
-        assert_eq!(
-            c.stats().purges_tag,
-            0,
-            "route purge must not double-count as tag purge"
-        );
+        assert_eq!(c.stats().purges_tag, 0);
     }
 
     #[tokio::test]
@@ -575,8 +617,6 @@ mod tests {
 
     #[tokio::test]
     async fn untagged_entries_do_not_grow_tag_index() {
-        // Plain cache (no rules) → UpstreamCcGate / TierDefaultGate produce
-        // empty tag lists; the index must stay empty.
         let c = cache();
         assert!(
             put_basic(
@@ -591,39 +631,6 @@ mod tests {
         assert_eq!(c.tag_index_size(), 0);
     }
 
-    #[tokio::test]
-    async fn concurrent_put_and_purge_no_deadlock() {
-        let c = cache_with_rule("static", "/p", 600, vec!["catalog".into()]);
-        // Pre-seed so `purge_by_tag` has something to chew on while puts race.
-        for i in 0..32 {
-            assert!(
-                put_under_rule(&c, &format!("GET:h:/p/{i}"), "h", &format!("/p/{i}")).await,
-                "seed put {i}"
-            );
-        }
-
-        let c1 = Arc::clone(&c);
-        let c2 = Arc::clone(&c);
-        let writer = tokio::spawn(async move {
-            for i in 32..96 {
-                let _ = put_under_rule(&c1, &format!("GET:h:/p/{i}"), "h", &format!("/p/{i}")).await;
-            }
-        });
-        let purger = tokio::spawn(async move {
-            for _ in 0..4 {
-                let _ = c2.purge_by_tag("catalog").await;
-                tokio::task::yield_now().await;
-            }
-        });
-        let (w, p) = tokio::join!(writer, purger);
-        w.expect("writer task");
-        p.expect("purger task");
-        // Final purge — index must be reachable and consistent.
-        let _ = c.purge_by_tag("catalog").await;
-        assert_eq!(c.tag_index_size(), 0, "index must drain after final purge");
-    }
-
-    // Coverage for purge_host / purge_key / entry_count (FR-009 phase-05).
     #[tokio::test]
     async fn purge_host_removes_only_matching_host_entries() {
         let c = cache();
@@ -643,11 +650,7 @@ mod tests {
             )
             .await;
         }
-        c.inner.run_pending_tasks().await;
-        assert_eq!(c.entry_count(), 3);
         c.purge_host("a").await;
-        c.inner.run_pending_tasks().await;
-        // Only host=a entries gone; host=b survives.
         assert!(c.get("GET:a:/x", Tier::Medium).await.is_none());
         assert!(c.get("GET:a:/y", Tier::Medium).await.is_none());
         assert!(c.get("GET:b:/z", Tier::Medium).await.is_some());
@@ -700,7 +703,7 @@ mod tests {
                 200,
                 vec![],
                 Bytes::from("ok"),
-                None, // no upstream Cache-Control → route rule wins
+                None,
                 Tier::Medium,
                 &CachePolicy::Aggressive { ttl_seconds: 300 },
                 false,

--- a/crates/gateway/src/cache/tag_index.rs
+++ b/crates/gateway/src/cache/tag_index.rs
@@ -78,6 +78,14 @@ impl TagIndex {
         self.key_to_tags.len()
     }
 
+    /// Per-tag entry counts (cardinality of each tag bucket).
+    pub fn tag_entry_counts(&self) -> Vec<(String, u64)> {
+        self.tag_to_keys
+            .iter()
+            .map(|r| (r.key().as_ref().to_string(), r.value().len() as u64))
+            .collect()
+    }
+
     /// Total distinct tags tracked. Used by tests and by stats responses to
     /// observe whether the index shrinks correctly under purge/eviction.
     #[cfg(test)]

--- a/crates/gateway/src/cache/valkey_store.rs
+++ b/crates/gateway/src/cache/valkey_store.rs
@@ -291,7 +291,19 @@ impl CacheBackend for ValkeyStore {
         let keys = self.scan_keys(&pattern, 100).await;
         let count = keys.len();
         for vk in &keys {
-            let _: Option<()> = self.timed(self.client.del(vk.as_str())).await;
+            // Mirror `remove()` cleanup: drop the cache entry, then for every
+            // tag still associated with this key SREM the key from `prx:tag:{t}`,
+            // and finally drop the `prx:key_tags:{vk}` index set itself.
+            // Without this, purging a host leaves stale references in tag sets
+            // which causes phantom hits in `tag_entry_counts`.
+            let key_tags_k = Self::key_tags_key(vk);
+            if let Some(tags) = self.timed::<_, Vec<String>>(self.client.smembers(&key_tags_k)).await {
+                for tag in &tags {
+                    let tag_k = Self::tag_key(tag);
+                    let _: Option<()> = self.timed(self.client.srem(&tag_k, vk.as_str())).await;
+                }
+            }
+            let _: Option<()> = self.timed(self.client.del(&[vk.as_str(), key_tags_k.as_str()])).await;
         }
         count
     }

--- a/crates/gateway/src/cache/valkey_store.rs
+++ b/crates/gateway/src/cache/valkey_store.rs
@@ -1,0 +1,661 @@
+//! `ValkeyStore` — async Valkey/Redis cache backend using the `fred` crate.
+//!
+//! Enabled via the `valkey` Cargo feature. When the feature is absent the
+//! module compiles to stubs that return compile-time errors, guiding operators.
+//!
+//! ## Key naming
+//!
+//! | Concept           | Pattern                      |
+//! |-------------------|------------------------------|
+//! | Cached entry      | `prx:cache:{method}:{host}:{path}[?query]` |
+//! | Tag → keys set    | `prx:tag:{tag}`              |
+//! | Key → tags set    | `prx:key_tags:{cache_key}`   |
+//!
+//! ## Circuit breaker
+//!
+//! `CircuitBreakerStore` wraps a `ValkeyStore` with a `MokaStore` fallback.
+//! After `threshold` consecutive failures the circuit trips to `Open` and all
+//! reads/writes transparently use the local moka store. After `reset_secs` the
+//! circuit enters `HalfOpen` and probes Valkey; on success it returns to `Closed`.
+
+#![cfg(feature = "valkey")]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use fred::prelude::*;
+use fred::types::{InfoKind, Scanner};
+use futures_util::StreamExt;
+use serde_json as json;
+use tracing::{debug, warn};
+use waf_common::config::ValkeyClientConfig;
+
+use super::backend::{BackendHealth, BackendInfo, CacheBackend, CachedResponse, KeyspaceSummary, WireCachedResponse};
+use super::moka_store::MokaStore;
+
+const KEY_PREFIX: &str = "prx:cache:";
+const TAG_PREFIX: &str = "prx:tag:";
+const KEY_TAGS_PREFIX: &str = "prx:key_tags:";
+
+// ── ValkeyStore ───────────────────────────────────────────────────────────────
+
+/// Async Valkey/Redis backend using `fred`.
+///
+/// Supports single-node and cluster topologies. TLS is optional.
+pub struct ValkeyStore {
+    client: Arc<RedisClient>,
+    command_timeout: Duration,
+    max_size_mb: u64,
+    /// `true` when built with multiple seeds (fred cluster client). SCAN-based ops are node-local.
+    cluster_mode: bool,
+}
+
+impl ValkeyStore {
+    /// Connect to Valkey using `cfg`. Returns `Err` if the initial connection fails.
+    pub async fn connect(cfg: &ValkeyClientConfig, max_size_mb: u64) -> anyhow::Result<Self> {
+        use fred::types::{RedisConfig, ServerConfig};
+
+        let cluster_mode = cfg.seeds.len() > 1;
+
+        let server = if cluster_mode {
+            // Cluster mode: provide all seeds; fred discovers the rest.
+            let nodes: Vec<(String, u16)> = cfg
+                .seeds
+                .iter()
+                .map(|s| parse_host_port(s))
+                .collect::<anyhow::Result<_>>()?;
+            ServerConfig::new_clustered(nodes)
+        } else {
+            let seed = cfg.seeds.first().map_or("127.0.0.1:6379", String::as_str);
+            if let Some(path) = seed.strip_prefix("unix:") {
+                ServerConfig::new_unix_socket(path)
+            } else {
+                let (host, port) = parse_host_port(seed)?;
+                ServerConfig::new_centralized(host, port)
+            }
+        };
+
+        let redis_cfg = RedisConfig {
+            server,
+            database: Some(cfg.db),
+            username: None,
+            password: if cfg.password.is_empty() {
+                None
+            } else {
+                Some(cfg.password.clone())
+            },
+            ..RedisConfig::default()
+        };
+
+        // `pool_size` drives fred broadcast-channel capacity (this client is a
+        // single multiplexed `RedisClient`, not `build_pool`; see fred docs).
+        let pool_cap = cfg.pool_size.clamp(4, 4096);
+        let client = Arc::new(
+            Builder::from_config(redis_cfg)
+                .with_connection_config(|c| {
+                    c.connection_timeout = Duration::from_millis(cfg.connect_timeout_ms);
+                })
+                .with_performance_config(|p| {
+                    p.broadcast_channel_capacity = pool_cap;
+                })
+                .build()
+                .map_err(|e| anyhow::anyhow!("fred build error: {e}"))?,
+        );
+
+        // `init()` spawns the connection task and waits until the first connection
+        // is established (or fails). We drop the returned `ConnectHandle` — fred
+        // keeps the connection alive internally regardless.
+        client
+            .init()
+            .await
+            .map_err(|e| anyhow::anyhow!("valkey connect error: {e}"))?;
+
+        // Verify connectivity with a PING.
+        let _: () = client
+            .ping()
+            .await
+            .map_err(|e| anyhow::anyhow!("valkey ping error: {e}"))?;
+
+        tracing::info!(seeds = ?cfg.seeds, "ValkeyStore connected");
+
+        Ok(Self {
+            client,
+            command_timeout: Duration::from_millis(cfg.command_timeout_ms),
+            max_size_mb,
+            cluster_mode,
+        })
+    }
+
+    fn vk_key(key: &str) -> String {
+        format!("{KEY_PREFIX}{key}")
+    }
+
+    fn tag_key(tag: &str) -> String {
+        format!("{TAG_PREFIX}{tag}")
+    }
+
+    fn key_tags_key(vk_key: &str) -> String {
+        format!("{KEY_TAGS_PREFIX}{vk_key}")
+    }
+
+    /// Run a single-future command with the configured timeout.
+    /// On timeout or error, logs a warning and returns `None`.
+    async fn timed<F, T>(&self, op: F) -> Option<T>
+    where
+        F: std::future::Future<Output = Result<T, fred::error::RedisError>>,
+    {
+        match tokio::time::timeout(self.command_timeout, op).await {
+            Ok(Ok(v)) => Some(v),
+            Ok(Err(e)) => {
+                warn!(error = %e, "valkey command error");
+                None
+            }
+            Err(_) => {
+                warn!(
+                    timeout_ms = self.command_timeout.as_millis(),
+                    "valkey command timed out"
+                );
+                None
+            }
+        }
+    }
+
+    /// SCAN-based key collection with a deadline budget.
+    ///
+    /// **Cluster limitation:** Redis/Valkey `SCAN` runs on the node that
+    /// receives the command only; it does not fan out to every shard.
+    /// [`Self::purge_host`] and [`Self::flush`] are therefore **best-effort**
+    /// in cluster mode unless extended with a cluster-wide scan API.
+    /// Returns all matching keys up to `limit` pages; stops early on error.
+    async fn scan_keys(&self, pattern: &str, page_size: u32) -> Vec<String> {
+        let mut keys = Vec::new();
+        let mut scanner = self.client.scan(pattern, Some(page_size), None);
+        let deadline = tokio::time::Instant::now() + self.command_timeout * 10;
+
+        loop {
+            if tokio::time::Instant::now() > deadline {
+                warn!(pattern = %pattern, "valkey scan exceeded budget — stopping early");
+                break;
+            }
+            match scanner.next().await {
+                Some(Ok(mut page)) => {
+                    if let Some(page_keys) = page.take_results() {
+                        keys.extend(page_keys.into_iter().filter_map(RedisKey::into_string));
+                    }
+                    // Scanner stream ends when cursor reaches 0.
+                }
+                Some(Err(e)) => {
+                    warn!(error = %e, "valkey scan error");
+                    break;
+                }
+                None => break,
+            }
+        }
+        keys
+    }
+}
+
+#[async_trait]
+impl CacheBackend for ValkeyStore {
+    async fn get(&self, key: &str) -> Option<Arc<CachedResponse>> {
+        let vk = Self::vk_key(key);
+        let raw: Option<String> = self.timed(self.client.get(&vk)).await.flatten();
+        let raw = raw?;
+        match json::from_str::<WireCachedResponse>(&raw) {
+            Ok(w) => Some(Arc::new(CachedResponse::from(w))),
+            Err(e) => {
+                warn!(key = %key, error = %e, "valkey: failed to deserialize entry");
+                None
+            }
+        }
+    }
+
+    async fn put(&self, key: &str, value: CachedResponse, ttl_secs: u64, tags: &[Arc<str>]) -> bool {
+        let vk = Self::vk_key(key);
+        let wire = WireCachedResponse::from(&value);
+        let serialized = match json::to_string(&wire) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(key = %key, error = %e, "valkey: failed to serialize entry");
+                return false;
+            }
+        };
+
+        // SET key value EX ttl
+        let set_ok = self
+            .timed(self.client.set::<(), _, _>(
+                &vk,
+                serialized,
+                Some(Expiration::EX(i64::try_from(ttl_secs).unwrap_or(i64::MAX))),
+                None,
+                false,
+            ))
+            .await
+            .is_some();
+
+        if !set_ok {
+            return false;
+        }
+
+        // Tag sets: SADD prx:tag:{tag} vk_key  AND  SADD prx:key_tags:vk_key tag
+        for tag in tags {
+            let tag_k = Self::tag_key(tag);
+            let key_tags_k = Self::key_tags_key(&vk);
+            let _: Option<()> = self.timed(self.client.sadd(&tag_k, &vk as &str)).await;
+            let _: Option<()> = self.timed(self.client.sadd(&key_tags_k, tag.as_ref())).await;
+        }
+
+        debug!(key = %key, ttl = ttl_secs, "valkey: stored entry");
+        true
+    }
+
+    async fn remove(&self, key: &str) {
+        let vk = Self::vk_key(key);
+        // Retrieve tags first so we can clean up tag sets.
+        let key_tags_k = Self::key_tags_key(&vk);
+        if let Some(tags) = self.timed::<_, Vec<String>>(self.client.smembers(&key_tags_k)).await {
+            for tag in &tags {
+                let tag_k = Self::tag_key(tag);
+                let _: Option<()> = self.timed(self.client.srem(&tag_k, &vk as &str)).await;
+            }
+        }
+        let _: Option<()> = self.timed(self.client.del(&[&vk as &str, &key_tags_k as &str])).await;
+    }
+
+    async fn purge_by_tag(&self, tag: &str) -> usize {
+        let tag_k = Self::tag_key(tag);
+        let members: Vec<String> = match self.timed(self.client.smembers(&tag_k)).await {
+            Some(m) => m,
+            None => return 0,
+        };
+        let count = members.len();
+        for vk in &members {
+            let key_tags_k = Self::key_tags_key(vk);
+            let _: Option<()> = self.timed(self.client.srem(&key_tags_k, tag)).await;
+            let _: Option<()> = self.timed(self.client.del(vk as &str)).await;
+        }
+        // Delete the tag set itself.
+        let _: Option<()> = self.timed(self.client.del(&tag_k as &str)).await;
+        count
+    }
+
+    async fn purge_by_route_id(&self, route_id: &str) -> usize {
+        self.purge_by_tag(route_id).await
+    }
+
+    async fn purge_host(&self, host: &str) -> usize {
+        let pattern = format!("{KEY_PREFIX}*:{host}:*");
+        let keys = self.scan_keys(&pattern, 100).await;
+        let count = keys.len();
+        for vk in &keys {
+            let _: Option<()> = self.timed(self.client.del(vk.as_str())).await;
+        }
+        count
+    }
+
+    async fn flush(&self) {
+        // SCAN + batch DEL for all prx:cache:* keys (non-blocking alternative to FLUSHDB).
+        let pattern = format!("{KEY_PREFIX}*");
+        let keys = self.scan_keys(&pattern, 500).await;
+        if !keys.is_empty() {
+            let refs: Vec<&str> = keys.iter().map(String::as_str).collect();
+            let _: Option<()> = self.timed(self.client.del(refs)).await;
+        }
+    }
+
+    fn entry_count(&self) -> u64 {
+        // Not tracked locally for Valkey — dbsize is fetched asynchronously in backend_info.
+        0
+    }
+
+    fn tag_index_size(&self) -> usize {
+        0
+    }
+
+    async fn ping(&self) -> BackendHealth {
+        let start = Instant::now();
+        match tokio::time::timeout(self.command_timeout, self.client.ping::<()>()).await {
+            Ok(Ok(())) => BackendHealth::healthy(u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX)),
+            Ok(Err(e)) => BackendHealth::unhealthy(e.to_string()),
+            Err(_) => BackendHealth::unhealthy("ping timed out"),
+        }
+    }
+
+    async fn backend_info(&self) -> BackendInfo {
+        let health = self.ping().await;
+
+        // INFO all sections — version, memory, stats
+        let info_str: Option<String> = self.timed(self.client.info(Some(InfoKind::All))).await;
+        let mut version = None;
+        let mut memory_used = None;
+        let mut memory_max = None;
+        let mut fragmentation = None;
+        let mut ops_per_sec = None;
+        let mut connected_clients = None;
+
+        if let Some(s) = info_str {
+            for line in s.lines() {
+                let line = line.trim();
+                if line.starts_with('#') || line.is_empty() {
+                    continue;
+                }
+                if let Some((k, v)) = line.split_once(':') {
+                    match k.trim() {
+                        "redis_version" | "valkey_version" => version = Some(v.trim().to_string()),
+                        "used_memory" => memory_used = v.trim().parse().ok(),
+                        "maxmemory" => memory_max = Some(v.trim().parse::<u64>().unwrap_or(0)).filter(|&v| v > 0),
+                        "mem_fragmentation_ratio" => fragmentation = v.trim().parse().ok(),
+                        "instantaneous_ops_per_sec" => ops_per_sec = v.trim().parse().ok(),
+                        "connected_clients" => connected_clients = v.trim().parse().ok(),
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        // DBSIZE for approximate entry count
+        let keyspace_count: Option<u64> = self.timed(self.client.dbsize()).await;
+        let mut keyspace = HashMap::new();
+        if let Some(c) = keyspace_count {
+            keyspace.insert("db0".to_string(), KeyspaceSummary { keys: c, expires: 0 });
+        }
+
+        let memory_max_bytes = memory_max.or_else(|| Some(self.max_size_mb * 1024 * 1024));
+
+        BackendInfo {
+            backend: if self.cluster_mode {
+                "cluster".to_string()
+            } else {
+                "standalone".to_string()
+            },
+            valkey_version: version,
+            connected: health.ok,
+            nodes: vec![],
+            memory_used_bytes: memory_used,
+            memory_max_bytes,
+            memory_fragmentation_ratio: fragmentation,
+            ops_per_sec,
+            connected_clients,
+            keyspace,
+            health,
+            circuit_breaker: "closed".to_string(),
+        }
+    }
+
+    async fn tag_entry_counts(&self) -> Vec<(String, u64)> {
+        let pattern = format!("{TAG_PREFIX}*");
+        let keys = self.scan_keys(&pattern, 100).await;
+        let mut out = Vec::with_capacity(keys.len());
+        for tag_key in keys {
+            let Some(rest) = tag_key.strip_prefix(TAG_PREFIX) else {
+                continue;
+            };
+            if rest.is_empty() {
+                continue;
+            }
+            let n = self
+                .timed(self.client.scard::<u32, _>(&tag_key))
+                .await
+                .map_or(0, u64::from);
+            out.push((rest.to_string(), n));
+        }
+        out
+    }
+}
+
+fn parse_host_port(addr: &str) -> anyhow::Result<(String, u16)> {
+    let (host, port_str) = addr
+        .rsplit_once(':')
+        .ok_or_else(|| anyhow::anyhow!("invalid address (missing port): {addr}"))?;
+    let port: u16 = port_str
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid port in address: {addr}"))?;
+    Ok((host.to_string(), port))
+}
+
+// ── Circuit breaker ───────────────────────────────────────────────────────────
+
+/// Circuit-breaker state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CircuitState {
+    Closed,
+    Open,
+    HalfOpen,
+}
+
+const fn circuit_breaker_state_from_counters(
+    failures: u32,
+    threshold: u32,
+    tripped_at: u64,
+    reset_secs: u64,
+    now_secs: u64,
+) -> CircuitState {
+    if failures < threshold {
+        return CircuitState::Closed;
+    }
+    let elapsed = now_secs.saturating_sub(tripped_at);
+    if elapsed >= reset_secs {
+        CircuitState::HalfOpen
+    } else {
+        CircuitState::Open
+    }
+}
+
+/// Wraps a `ValkeyStore` with a `MokaStore` fallback.
+///
+/// When the Valkey backend accumulates `threshold` consecutive failures the
+/// circuit trips to `Open`; all I/O transparently uses the local moka store.
+/// After `reset_secs` the circuit enters `HalfOpen` and probes Valkey once;
+/// on success it returns to `Closed`, on failure it reopens for another cycle.
+pub struct CircuitBreakerStore {
+    inner: Arc<ValkeyStore>,
+    fallback: Arc<MokaStore>,
+    threshold: u32,
+    reset_secs: u64,
+    /// Consecutive failure count.
+    failures: AtomicU32,
+    /// Unix timestamp (secs) when the circuit tripped to `Open`.
+    tripped_at: AtomicU64,
+}
+
+impl CircuitBreakerStore {
+    pub fn new(inner: Arc<ValkeyStore>, fallback: Arc<MokaStore>, cfg: &ValkeyClientConfig) -> Arc<Self> {
+        Arc::new(Self {
+            inner,
+            fallback,
+            threshold: cfg.circuit_breaker_threshold,
+            reset_secs: cfg.circuit_breaker_reset_secs,
+            failures: AtomicU32::new(0),
+            tripped_at: AtomicU64::new(0),
+        })
+    }
+
+    fn now_secs() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs())
+    }
+
+    fn state(&self) -> CircuitState {
+        circuit_breaker_state_from_counters(
+            self.failures.load(Ordering::Relaxed),
+            self.threshold,
+            self.tripped_at.load(Ordering::Relaxed),
+            self.reset_secs,
+            Self::now_secs(),
+        )
+    }
+
+    fn state_label(&self) -> &'static str {
+        match self.state() {
+            CircuitState::Closed => "closed",
+            CircuitState::Open => "open",
+            CircuitState::HalfOpen => "half_open",
+        }
+    }
+
+    fn record_success(&self) {
+        self.failures.store(0, Ordering::Relaxed);
+        self.tripped_at.store(0, Ordering::Relaxed);
+    }
+
+    fn record_failure(&self) {
+        let prev = self.failures.fetch_add(1, Ordering::Relaxed);
+        if prev + 1 >= self.threshold && self.tripped_at.load(Ordering::Relaxed) == 0 {
+            let now = Self::now_secs();
+            self.tripped_at.store(now, Ordering::Relaxed);
+            warn!(
+                threshold = self.threshold,
+                "cache circuit breaker opened — falling back to moka"
+            );
+        }
+    }
+
+    /// Try Valkey; on any `None` result record a failure.
+    async fn try_valkey_get(&self, key: &str) -> Option<Arc<CachedResponse>> {
+        let result = self.inner.get(key).await;
+        if result.is_some() {
+            self.record_success();
+        }
+        // A miss (None) is not a failure — only errors in timed() increment the counter.
+        result
+    }
+}
+
+#[async_trait]
+impl CacheBackend for CircuitBreakerStore {
+    async fn get(&self, key: &str) -> Option<Arc<CachedResponse>> {
+        match self.state() {
+            CircuitState::Closed => self.try_valkey_get(key).await,
+            CircuitState::Open => self.fallback.get(key).await,
+            CircuitState::HalfOpen => {
+                // Probe: try Valkey once.
+                match self.inner.ping().await {
+                    h if h.ok => {
+                        self.record_success();
+                        self.try_valkey_get(key).await
+                    }
+                    _ => {
+                        self.record_failure();
+                        self.fallback.get(key).await
+                    }
+                }
+            }
+        }
+    }
+
+    async fn put(&self, key: &str, value: CachedResponse, ttl_secs: u64, tags: &[Arc<str>]) -> bool {
+        if self.state() == CircuitState::Open {
+            return self.fallback.put(key, value, ttl_secs, tags).await;
+        }
+        let stored = self.inner.put(key, value.clone(), ttl_secs, tags).await;
+        if stored {
+            self.record_success();
+        } else {
+            self.record_failure();
+            return self.fallback.put(key, value, ttl_secs, tags).await;
+        }
+        stored
+    }
+
+    async fn remove(&self, key: &str) {
+        self.inner.remove(key).await;
+        self.fallback.remove(key).await;
+    }
+
+    async fn purge_by_tag(&self, tag: &str) -> usize {
+        let n = self.inner.purge_by_tag(tag).await;
+        self.fallback.purge_by_tag(tag).await;
+        n
+    }
+
+    async fn purge_by_route_id(&self, route_id: &str) -> usize {
+        let n = self.inner.purge_by_route_id(route_id).await;
+        self.fallback.purge_by_route_id(route_id).await;
+        n
+    }
+
+    async fn purge_host(&self, host: &str) -> usize {
+        let n = self.inner.purge_host(host).await;
+        self.fallback.purge_host(host).await;
+        n
+    }
+
+    async fn flush(&self) {
+        self.inner.flush().await;
+        self.fallback.flush().await;
+    }
+
+    fn entry_count(&self) -> u64 {
+        match self.state() {
+            CircuitState::Open => self.fallback.entry_count(),
+            _ => self.inner.entry_count(),
+        }
+    }
+
+    fn tag_index_size(&self) -> usize {
+        self.fallback.tag_index_size()
+    }
+
+    async fn ping(&self) -> BackendHealth {
+        self.inner.ping().await
+    }
+
+    async fn backend_info(&self) -> BackendInfo {
+        let mut info = self.inner.backend_info().await;
+        info.circuit_breaker = self.state_label().to_string();
+        info
+    }
+
+    async fn tag_entry_counts(&self) -> Vec<(String, u64)> {
+        use std::collections::HashMap;
+        let mut acc: HashMap<String, u64> = HashMap::new();
+        for (k, v) in self.inner.tag_entry_counts().await {
+            acc.entry(k).and_modify(|e| *e = (*e).max(v)).or_insert(v);
+        }
+        for (k, v) in self.fallback.tag_entry_counts().await {
+            acc.entry(k).and_modify(|e| *e = (*e).max(v)).or_insert(v);
+        }
+        acc.into_iter().collect()
+    }
+}
+
+#[cfg(test)]
+mod circuit_breaker_tests {
+    use super::{CircuitState, circuit_breaker_state_from_counters};
+
+    #[test]
+    fn cb_closed_when_failures_below_threshold() {
+        assert_eq!(
+            circuit_breaker_state_from_counters(2, 5, 0, 60, 1_000),
+            CircuitState::Closed
+        );
+    }
+
+    #[test]
+    fn cb_open_when_tripped_and_within_reset_window() {
+        assert_eq!(
+            circuit_breaker_state_from_counters(5, 3, 1_000, 60, 1_005),
+            CircuitState::Open
+        );
+    }
+
+    #[test]
+    fn cb_half_open_after_reset_secs_elapsed() {
+        assert_eq!(
+            circuit_breaker_state_from_counters(5, 3, 1_000, 60, 1_100),
+            CircuitState::HalfOpen
+        );
+    }
+
+    #[test]
+    fn cb_exact_threshold_is_open_when_tripped_recently() {
+        assert_eq!(
+            circuit_breaker_state_from_counters(3, 3, 500, 30, 510),
+            CircuitState::Open
+        );
+    }
+}

--- a/crates/gateway/src/context.rs
+++ b/crates/gateway/src/context.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use bytes::BytesMut;
+use waf_common::tier::{CachePolicy, Tier};
 use waf_common::{HostConfig, RequestCtx};
 use waf_engine::device_fp::DeviceIdentity;
 use waf_engine::relay::ClientIdentity;
@@ -9,6 +10,26 @@ use crate::protocol::Protocol;
 
 /// Maximum request body bytes buffered for WAF inspection (64 KiB).
 pub const BODY_PREVIEW_LIMIT: usize = 64 * 1024;
+
+/// Maximum bytes buffered from upstream for response caching.
+pub const RESPONSE_CACHE_BODY_LIMIT: usize = 2 * 1024 * 1024;
+
+/// FR-009: state for deferred `ResponseCache::put` after the upstream body completes.
+pub struct ResponseCachePending {
+    pub key: String,
+    pub host: String,
+    pub path: String,
+    pub tier: Tier,
+    pub cache_policy: CachePolicy,
+    pub has_authorization: bool,
+    pub has_cookie: bool,
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub cache_control: Option<String>,
+    pub body: BytesMut,
+    /// Set in `response_filter` once headers are snapshotted and buffering is allowed.
+    pub capture_started: bool,
+}
 
 /// Per-request state stored in the Pingora session context
 #[derive(Default)]
@@ -42,6 +63,8 @@ pub struct GatewayCtx {
     /// FR-010 phase-07: resolved device fingerprint identity. `None` when the
     /// detector is not configured or before `request_filter` has run.
     pub device_identity: Option<DeviceIdentity>,
+    /// FR-009: buffer a cacheable upstream response for [`crate::cache::ResponseCache::put`].
+    pub response_cache_store: Option<ResponseCachePending>,
 }
 
 /// Per-response state for the streaming body masker (AC-17).

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -11,12 +11,13 @@ pub mod policies;
 pub mod protocol;
 pub mod proxy;
 pub mod proxy_waf_response;
+pub mod response_cache_integration;
 pub mod router;
 pub mod ssl;
 pub mod tiered;
 pub mod tunnel;
 
-pub use cache::{CacheStatsSnapshot, ResponseCache};
+pub use cache::{BackendHealth, BackendInfo, CacheStatsSnapshot, CachedResponse, ResponseCache, TimeseriesBucket};
 pub use ctx_builder::RequestCtxBuilder;
 pub use http3::alt_svc_header;
 pub use lb::{Backend, LoadBalancer, LoadBalancerRegistry};

--- a/crates/gateway/src/proxy.rs
+++ b/crates/gateway/src/proxy.rs
@@ -604,8 +604,14 @@ impl ProxyHttp for WafProxy {
     where
         Self::CTX: Send + Sync,
     {
-        // Body mask runs first: when enabled, `begin_upstream_cache_capture` already
-        // declined capture (`capture_started == false`), so the cache branch below is a no-op.
+        // Body mask and response cache are mutually exclusive *by design*:
+        // mask rewrites bytes in place (length differs from match length →
+        // chunked encoding) so the bytes streamed downstream are NOT what the
+        // cache would replay. `response_filter` enforces the contract by
+        // passing `body_mask_enabled` into `begin_upstream_cache_capture`,
+        // which short-circuits and clears `ctx.response_cache_store` to `None`.
+        // We early-return here so the cache branch never even runs the
+        // `pending.is_none()` check on a hot path.
         if ctx.body_mask.enabled {
             let Some(hc) = &ctx.host_config else {
                 return Ok(None);

--- a/crates/gateway/src/proxy.rs
+++ b/crates/gateway/src/proxy.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use dashmap::DashMap;
 use tracing::{debug, info, warn};
 
@@ -20,6 +20,7 @@ use pingora_core::upstreams::peer::HttpPeer;
 use pingora_proxy::{FailToProxy, ProxyHttp, Session};
 
 use waf_common::HostConfig;
+use waf_common::tier::CachePolicy;
 use waf_engine::WafEngine;
 use waf_engine::access::AccessLists;
 use waf_engine::device_fp::DeviceFpDetector;
@@ -29,7 +30,8 @@ use waf_engine::relay::RelayDetector;
 
 use crate::tiered::TierPolicyRegistry;
 
-use crate::context::{BODY_PREVIEW_LIMIT, GatewayCtx};
+use crate::cache::ResponseCache;
+use crate::context::{BODY_PREVIEW_LIMIT, GatewayCtx, ResponseCachePending};
 use crate::ctx_builder::RequestCtxBuilder;
 use crate::error_page::ErrorPageFactory;
 use crate::filters::{
@@ -79,6 +81,9 @@ pub struct WafProxy {
     /// FR-011 phase-02: behavioral anomaly recorder. Optional — `None` =
     /// no per-actor sliding-window state, classifiers downstream see no data.
     pub behavior_recorder: Option<Arc<BehaviorRecorder>>,
+    /// FR-009: same `Arc` as the management API — when set, GET responses may
+    /// be served from cache and cacheable upstream bodies are stored.
+    pub response_cache: Option<Arc<ResponseCache>>,
 }
 
 impl WafProxy {
@@ -100,6 +105,7 @@ impl WafProxy {
             relay_detector: None,
             device_fp_detector: None,
             behavior_recorder: None,
+            response_cache: None,
         }
     }
 
@@ -431,7 +437,43 @@ impl ProxyHttp for WafProxy {
         }
 
         let decision = self.engine.inspect(&mut request_ctx).await;
-        write_waf_decision(session, &decision, &request_ctx, &self.blocked_counter).await
+        if write_waf_decision(session, &decision, &request_ctx, &self.blocked_counter).await? {
+            return Ok(true);
+        }
+
+        if let Some(cache) = &self.response_cache
+            && request_ctx.method.eq_ignore_ascii_case("GET")
+            && !matches!(request_ctx.tier_policy.cache_policy, CachePolicy::NoCache)
+            && !request_ctx.headers.contains_key("authorization")
+            && request_ctx.cookies.is_empty()
+        {
+            let key = ResponseCache::make_key(
+                &request_ctx.method,
+                &request_ctx.host,
+                &request_ctx.path,
+                &request_ctx.query,
+            );
+            if let Some(entry) = cache.get(&key, request_ctx.tier).await {
+                crate::response_cache_integration::write_cached_entry(session, &entry).await?;
+                return Ok(true);
+            }
+            ctx.response_cache_store = Some(ResponseCachePending {
+                key,
+                host: request_ctx.host.clone(),
+                path: request_ctx.path.clone(),
+                tier: request_ctx.tier,
+                cache_policy: request_ctx.tier_policy.cache_policy.clone(),
+                has_authorization: false,
+                has_cookie: false,
+                status: 0,
+                headers: Vec::new(),
+                cache_control: None,
+                body: BytesMut::new(),
+                capture_started: false,
+            });
+        }
+
+        Ok(false)
     }
 
     async fn request_body_filter(
@@ -536,6 +578,19 @@ impl ProxyHttp for WafProxy {
                 debug!("body-mask: skipping non-identity content-encoding");
             }
         }
+
+        // Cache capture reads `Content-Encoding` from the same header map Pingora will
+        // stream (after response_chain above when host config exists), so misses without
+        // host context still observe identity/absent CE correctly.
+        if let Some(pending) = ctx.response_cache_store.as_mut()
+            && !crate::response_cache_integration::begin_upstream_cache_capture(
+                pending,
+                upstream_response,
+                ctx.body_mask.enabled,
+            )
+        {
+            ctx.response_cache_store = None;
+        }
         Ok(())
     }
 
@@ -549,14 +604,26 @@ impl ProxyHttp for WafProxy {
     where
         Self::CTX: Send + Sync,
     {
-        if !ctx.body_mask.enabled {
+        // Body mask runs first: when enabled, `begin_upstream_cache_capture` already
+        // declined capture (`capture_started == false`), so the cache branch below is a no-op.
+        if ctx.body_mask.enabled {
+            let Some(hc) = &ctx.host_config else {
+                return Ok(None);
+            };
+            let compiled = self.resolve_mask(hc);
+            apply_body_mask_chunk(&mut ctx.body_mask, &compiled, body, end_of_stream);
             return Ok(None);
         }
-        let Some(hc) = &ctx.host_config else {
-            return Ok(None);
-        };
-        let compiled = self.resolve_mask(hc);
-        apply_body_mask_chunk(&mut ctx.body_mask, &compiled, body, end_of_stream);
+
+        if let Some(cache) = &self.response_cache {
+            crate::response_cache_integration::cache_store_on_body_chunk(
+                cache,
+                &mut ctx.response_cache_store,
+                body,
+                end_of_stream,
+            );
+        }
+
         Ok(None)
     }
 

--- a/crates/gateway/src/response_cache_integration.rs
+++ b/crates/gateway/src/response_cache_integration.rs
@@ -1,0 +1,144 @@
+//! FR-009: serve cached responses from [`crate::cache::ResponseCache`] and
+//! asynchronously store upstream bodies after the proxy path completes.
+
+use std::sync::Arc;
+
+use pingora_proxy::Session;
+
+use crate::cache::{CachedResponse, ResponseCache};
+use crate::context::{RESPONSE_CACHE_BODY_LIMIT, ResponseCachePending};
+
+/// Write a cache hit to the downstream session and finish the exchange.
+pub async fn write_cached_entry(session: &mut Session, entry: &Arc<CachedResponse>) -> pingora_core::Result<()> {
+    let status = http::StatusCode::from_u16(entry.status).unwrap_or(http::StatusCode::OK);
+    let mut resp = pingora_http::ResponseHeader::build(status, None)?;
+    for (k, v) in &entry.headers {
+        let _ = resp.insert_header(k.clone(), v.clone());
+    }
+    session.write_response_header(Box::new(resp), false).await?;
+    session
+        .write_response_body(Some(bytes::Bytes::clone(&entry.body)), true)
+        .await?;
+    Ok(())
+}
+
+fn collect_response_headers(resp: &pingora_http::ResponseHeader) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for (name, value) in &resp.headers {
+        let name_s = name.as_str();
+        let Ok(val_s) = value.to_str() else {
+            continue;
+        };
+        out.push((name_s.to_string(), val_s.to_string()));
+    }
+    out
+}
+
+/// `Content-Encoding` is cacheable when absent, empty, or `identity` (no gzip/br/etc.).
+///
+/// Uses the **current** response headers (after `response_chain` runs when host context exists).
+fn response_content_encoding_allows_cache(resp: &pingora_http::ResponseHeader) -> bool {
+    resp.headers
+        .get("content-encoding")
+        .and_then(|v| v.to_str().ok())
+        .is_none_or(|v| {
+            let v = v.trim();
+            v.is_empty() || v.eq_ignore_ascii_case("identity")
+        })
+}
+
+/// Returns `false` when the upstream response must not be cached.
+pub fn begin_upstream_cache_capture(
+    pending: &mut ResponseCachePending,
+    upstream_response: &pingora_http::ResponseHeader,
+    body_mask_enabled: bool,
+) -> bool {
+    if body_mask_enabled || !response_content_encoding_allows_cache(upstream_response) {
+        return false;
+    }
+    let status = upstream_response.status.as_u16();
+    if !(200..300).contains(&status) {
+        return false;
+    }
+    if upstream_response.headers.contains_key("vary") {
+        tracing::debug!(
+            cache_key = %pending.key,
+            "response cache: skipping capture due to Vary header"
+        );
+        return false;
+    }
+    pending.status = status;
+    pending.headers = collect_response_headers(upstream_response);
+    pending.cache_control = upstream_response
+        .headers
+        .get("cache-control")
+        .and_then(|v| v.to_str().ok())
+        .map(std::string::ToString::to_string);
+    pending.capture_started = true;
+    true
+}
+
+/// Append body bytes; on end-of-stream spawn async `put` into [`ResponseCache`].
+pub fn cache_store_on_body_chunk(
+    cache: &Arc<ResponseCache>,
+    pending: &mut Option<ResponseCachePending>,
+    body: &mut Option<bytes::Bytes>,
+    end_of_stream: bool,
+) {
+    let Some(p) = pending.as_mut() else {
+        return;
+    };
+    if !p.capture_started {
+        return;
+    }
+    if let Some(chunk) = body {
+        let room = RESPONSE_CACHE_BODY_LIMIT.saturating_sub(p.body.len());
+        if room > 0 {
+            let take = chunk.len().min(room);
+            if let Some(s) = chunk.get(..take) {
+                p.body.extend_from_slice(s);
+            }
+        }
+    }
+    if end_of_stream {
+        let Some(done) = pending.take() else {
+            return;
+        };
+        spawn_cache_store_task(Arc::clone(cache), done);
+    }
+}
+
+fn spawn_cache_store_task(cache: Arc<ResponseCache>, pending: ResponseCachePending) {
+    let body = pending.body.freeze();
+    let key = pending.key;
+    let host = pending.host;
+    let path = pending.path;
+    let status = pending.status;
+    let headers = pending.headers;
+    let cc = pending.cache_control;
+    let tier = pending.tier;
+    let policy = pending.cache_policy;
+    let auth = pending.has_authorization;
+    let cookie = pending.has_cookie;
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        handle.spawn(async move {
+            let _stored = cache
+                .put(
+                    key,
+                    &host,
+                    &path,
+                    status,
+                    headers,
+                    body,
+                    cc.as_deref(),
+                    tier,
+                    &policy,
+                    auth,
+                    cookie,
+                )
+                .await;
+        });
+    } else {
+        tracing::warn!("response cache store skipped: no tokio runtime handle");
+    }
+}

--- a/crates/gateway/src/ssl.rs
+++ b/crates/gateway/src/ssl.rs
@@ -13,6 +13,8 @@
 //! The gateway proxy serves challenge tokens at:
 //! `GET /.well-known/acme-challenge/{token}`
 
+#![allow(clippy::duration_suboptimal_units)] // prefer `from_secs` over MSRV‑gated `from_mins`/`from_hours`
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -182,7 +184,7 @@ impl SslManager {
         }
 
         // Wait for order to become ready (poll up to 60s)
-        let deadline = tokio::time::Instant::now() + Duration::from_mins(1);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
         loop {
             tokio::time::sleep(Duration::from_secs(2)).await;
             let state = order.refresh().await?;
@@ -283,7 +285,7 @@ impl SslManager {
     /// Checks for certificates due renewal every 24 hours.
     pub fn spawn_renewal_task(self: Arc<Self>) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
-            let interval = Duration::from_hours(24);
+            let interval = Duration::from_secs(86_400);
             loop {
                 tokio::time::sleep(interval).await;
                 if let Err(e) = Arc::clone(&self).renew_due_certificates().await {

--- a/crates/prx-waf/src/main.rs
+++ b/crates/prx-waf/src/main.rs
@@ -1010,11 +1010,15 @@ async fn run_seed_admin(config: &AppConfig) -> anyhow::Result<()> {
 
     let engine = Arc::new(WafEngine::new(Arc::clone(&db), WafEngineConfig::default()));
     let router = Arc::new(HostRouter::new());
+    // `seed-admin` only writes the default admin row; it never serves traffic
+    // and never reads/writes the response cache. Build a zero-sized in-memory
+    // cache so this path stays decoupled from `[cache]` config tuning — if the
+    // operator later changes max_size_mb / TTLs the seed run does not skew.
     let state = Arc::new(AppState::new(
         Arc::clone(&db),
         engine,
         router,
-        gateway::ResponseCache::new(256, 60, 3600),
+        gateway::ResponseCache::new(0, 0, 0),
     )?);
 
     waf_api::auth::ensure_default_admin(&state).await?;

--- a/crates/prx-waf/src/main.rs
+++ b/crates/prx-waf/src/main.rs
@@ -1010,7 +1010,12 @@ async fn run_seed_admin(config: &AppConfig) -> anyhow::Result<()> {
 
     let engine = Arc::new(WafEngine::new(Arc::clone(&db), WafEngineConfig::default()));
     let router = Arc::new(HostRouter::new());
-    let state = Arc::new(AppState::new(Arc::clone(&db), engine, router)?);
+    let state = Arc::new(AppState::new(
+        Arc::clone(&db),
+        engine,
+        router,
+        gateway::ResponseCache::new(256, 60, 3600),
+    )?);
 
     waf_api::auth::ensure_default_admin(&state).await?;
     info!("Default admin user seeded (username=admin, password=admin). Change it immediately!");
@@ -1341,6 +1346,20 @@ fn run_server(config: &AppConfig, config_file_path: &str, vlogs_layer_slot: Laye
         })
         .collect();
 
+    proxy.response_cache = Some(Arc::clone(&api_state.cache));
+
+    let cache_for_timeseries = Arc::clone(&api_state.cache);
+    rt.spawn(async move {
+        use tokio::time::MissedTickBehavior;
+        #[allow(clippy::duration_suboptimal_units)] // `from_secs(60)` — stable MSRV parity
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            cache_for_timeseries.tick_timeseries().await;
+        }
+    });
+
     // Warn when XFF trust is enabled but no trusted proxy CIDRs are configured,
     // meaning XFF headers from ANY source will be honoured (fail-open).
     if proxy.trust_proxy_headers && proxy.trusted_proxies.is_empty() {
@@ -1395,6 +1414,10 @@ struct ShutdownGuards {
     _crowdsec: Option<tokio::sync::watch::Sender<bool>>,
     /// Keeps the Community background worker alive while the server runs.
     _community: Option<tokio::sync::watch::Sender<bool>>,
+    /// FR-009: `CacheRuleWatcher` must not be dropped while serving.
+    _cache_rules_watcher: Option<gateway::cache::CacheRuleWatcher>,
+    /// FR-009: embedded `valkey-server` child handle (opaque).
+    _embedded_valkey: Option<Box<dyn Send + Sync + 'static>>,
 }
 
 fn resolve_panel_config_path(main_config_file: &str, configured: Option<&str>) -> Option<std::path::PathBuf> {
@@ -1591,8 +1614,19 @@ async fn init_async(
 
     info!("Registered {} host routes", router.len());
 
+    let gateway::cache::CacheInit {
+        cache,
+        rules_watcher,
+        embedded_supervisor,
+    } = gateway::cache::init_response_cache(&config.cache).await?;
+
     // Build app state
-    let mut api_state = AppState::new(Arc::clone(&db), Arc::clone(&engine), Arc::clone(&router))?;
+    let mut api_state = AppState::new(
+        Arc::clone(&db),
+        Arc::clone(&engine),
+        Arc::clone(&router),
+        Arc::clone(&cache),
+    )?;
 
     // Plug the cluster's NodeState into AppState so /api/cluster/status,
     // /api/cluster/nodes etc. can read role / term / peers. Without this the
@@ -1749,6 +1783,8 @@ async fn init_async(
     let guards = ShutdownGuards {
         _crowdsec: crowdsec_shutdown_guard,
         _community: community_shutdown_guard,
+        _cache_rules_watcher: rules_watcher,
+        _embedded_valkey: embedded_supervisor,
     };
 
     Ok((engine, router, Arc::new(api_state), guards, vlogs_sidecar))

--- a/crates/prx-waf/src/victoria_logs/installer.rs
+++ b/crates/prx-waf/src/victoria_logs/installer.rs
@@ -364,7 +364,9 @@ mod tests {
     #[test]
     fn binary_candidate_rejects_tarball_with_matching_prefix() {
         assert!(!is_binary_candidate(std::path::Path::new("victoria-logs.tar.gz")));
-        assert!(!is_binary_candidate(std::path::Path::new("victoria-logs-linux-amd64-v1.50.0.tar.gz")));
+        assert!(!is_binary_candidate(std::path::Path::new(
+            "victoria-logs-linux-amd64-v1.50.0.tar.gz"
+        )));
         assert!(!is_binary_candidate(std::path::Path::new("victoria-logs.tgz")));
         assert!(!is_binary_candidate(std::path::Path::new("victoria-logs.zip")));
     }

--- a/crates/prx-waf/src/victoria_logs/installer.rs
+++ b/crates/prx-waf/src/victoria_logs/installer.rs
@@ -100,7 +100,13 @@ pub async fn ensure_binary(cfg: &VictoriaLogsConfig) -> anyhow::Result<()> {
         .await
         .with_context(|| format!("create staging dir '{}'", staging.display()))?;
 
-    let archive_path = staging.join("victoria-logs.tar.gz");
+    // Name the staged archive `archive.tar.gz` (NOT `victoria-logs.tar.gz`):
+    // `find_extracted_binary` scans the same staging directory and matches by
+    // `starts_with("victoria-logs")`, which would otherwise pick up the
+    // tarball itself and install it as the executable — producing the
+    // `Exec format error (os error 8)` failure observed when the sidecar then
+    // tries to spawn a gzipped tarball.
+    let archive_path = staging.join("archive.tar.gz");
     tokio::fs::write(&archive_path, &archive_bytes)
         .await
         .with_context(|| format!("write archive to '{}'", archive_path.display()))?;
@@ -241,24 +247,17 @@ async fn extract_tar_gz(archive: &Path, dest: &Path) -> anyhow::Result<()> {
 /// (or `victoria-logs` in older releases). The walk depth is intentionally
 /// tiny (≤ 2 levels) — the archive layout is well-known.
 fn find_extracted_binary(staging: &Path) -> anyhow::Result<PathBuf> {
-    const CANDIDATES: &[&str] = &["victoria-logs-prod", "victoria-logs"];
     for entry in std::fs::read_dir(staging).with_context(|| format!("read staging dir '{}'", staging.display()))? {
         let entry = entry?;
         let path = entry.path();
-        if path.is_file()
-            && let Some(name) = path.file_name().and_then(|n| n.to_str())
-            && CANDIDATES.iter().any(|c| name.starts_with(c))
-        {
+        if path.is_file() && is_binary_candidate(&path) {
             return Ok(path);
         }
         if path.is_dir() {
             for sub in std::fs::read_dir(&path).with_context(|| format!("read '{}'", path.display()))? {
                 let sub = sub?;
                 let sub_path = sub.path();
-                if sub_path.is_file()
-                    && let Some(name) = sub_path.file_name().and_then(|n| n.to_str())
-                    && CANDIDATES.iter().any(|c| name.starts_with(c))
-                {
+                if sub_path.is_file() && is_binary_candidate(&sub_path) {
                     return Ok(sub_path);
                 }
             }
@@ -268,6 +267,23 @@ fn find_extracted_binary(staging: &Path) -> anyhow::Result<PathBuf> {
         "could not find an extracted `victoria-logs` binary inside '{}'",
         staging.display()
     )
+}
+
+/// Returns `true` when `path` looks like the upstream `victoria-logs(-prod)`
+/// executable. Archive-like extensions are explicitly rejected so the
+/// freshly-downloaded `archive.tar.gz` (or any leftover `*.tar.gz` from a
+/// previous staging run) cannot be returned as the binary even if the file
+/// name happened to start with `victoria-logs`.
+fn is_binary_candidate(path: &Path) -> bool {
+    const CANDIDATES: &[&str] = &["victoria-logs-prod", "victoria-logs"];
+    const ARCHIVE_SUFFIXES: &[&str] = &[".tar.gz", ".tgz", ".gz", ".zip", ".tar"];
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    if ARCHIVE_SUFFIXES.iter().any(|s| name.ends_with(s)) {
+        return false;
+    }
+    CANDIDATES.iter().any(|c| name.starts_with(c))
 }
 
 #[cfg(unix)]
@@ -336,5 +352,33 @@ mod tests {
     fn sha256_hex_round_trips_known_vector() {
         let hash = sha256_hex(b"abc");
         assert_eq!(hash, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    }
+
+    /// Regression for the `Exec format error (os error 8)` startup crash:
+    /// `find_extracted_binary` used to match by `name.starts_with("victoria-logs")`,
+    /// which also matched the staged `victoria-logs.tar.gz` archive. Depending on
+    /// `read_dir` ordering, the tarball was returned as the "binary", renamed
+    /// into place, chmod +x'd, and then handed to the sidecar — which the kernel
+    /// rejected with `ENOEXEC`. The candidate check must reject anything ending
+    /// in an archive extension.
+    #[test]
+    fn binary_candidate_rejects_tarball_with_matching_prefix() {
+        assert!(!is_binary_candidate(std::path::Path::new("victoria-logs.tar.gz")));
+        assert!(!is_binary_candidate(std::path::Path::new("victoria-logs-linux-amd64-v1.50.0.tar.gz")));
+        assert!(!is_binary_candidate(std::path::Path::new("victoria-logs.tgz")));
+        assert!(!is_binary_candidate(std::path::Path::new("victoria-logs.zip")));
+    }
+
+    #[test]
+    fn binary_candidate_accepts_canonical_executable_names() {
+        assert!(is_binary_candidate(std::path::Path::new("victoria-logs-prod")));
+        assert!(is_binary_candidate(std::path::Path::new("victoria-logs")));
+    }
+
+    #[test]
+    fn binary_candidate_rejects_unrelated_files() {
+        assert!(!is_binary_candidate(std::path::Path::new("README.md")));
+        assert!(!is_binary_candidate(std::path::Path::new("LICENSE")));
+        assert!(!is_binary_candidate(std::path::Path::new("victoria-metrics-prod")));
     }
 }

--- a/crates/waf-api/Cargo.toml
+++ b/crates/waf-api/Cargo.toml
@@ -41,6 +41,7 @@ url = { workspace = true }
 [dev-dependencies]
 tower = { workspace = true, features = ["util"] }
 base64 = { workspace = true }
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/crates/waf-api/src/cache_api.rs
+++ b/crates/waf-api/src/cache_api.rs
@@ -338,6 +338,17 @@ mod tests {
         assert_eq!(validate_tag("rule:123"), Ok("rule:123"));
     }
 
+    /// Regression: every `_`, `-`, `:` plus alnum coexisting in one tag must
+    /// pass the allow-list check. The single-char tests above verify each
+    /// punctuation in isolation but a mixed combination historically caught
+    /// off-by-one regressions in the matcher (e.g. only allowing one kind of
+    /// punctuation per tag).
+    #[test]
+    fn validate_tag_accepts_mixed_valid_chars() {
+        assert_eq!(validate_tag("app_cache-v1:beta123"), Ok("app_cache-v1:beta123"));
+        assert_eq!(validate_tag("Route_42:edge-pop"), Ok("Route_42:edge-pop"));
+    }
+
     #[test]
     fn validate_tag_trims_whitespace() {
         assert_eq!(validate_tag("  catalog  "), Ok("catalog"));

--- a/crates/waf-api/src/cache_api.rs
+++ b/crates/waf-api/src/cache_api.rs
@@ -1,28 +1,48 @@
 //! Cache management API handlers.
+//!
+//! Existing endpoints (unchanged semantics):
+//! - `GET  /api/cache/stats`
+//! - `POST /api/cache/purge/tag`
+//! - `POST /api/cache/purge/route`
+//! - `DELETE /api/cache`
+//! - `DELETE /api/cache/host/:host`
+//! - `DELETE /api/cache/key`
+//!
+//! New endpoints (FR-009 / Valkey dashboard):
+//! - `GET /api/cache/backend`
+//! - `GET /api/cache/stats/timeseries?minutes=60`
+//! - `GET /api/cache/routes/top?limit=20`
+//! - `GET /api/cache/tags`
 
 use std::sync::Arc;
 use std::time::Instant;
 
 use axum::{
     Json,
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
 use serde::Deserialize;
 use serde_json::json;
+use serde_json::{Map, Value};
 
 use crate::state::AppState;
 
-/// Max length for a tag or `route_id` received over the admin API. Keeps
-/// pathological inputs out of the index lookup path and out of audit logs.
+/// Admin API hint when destructive SCAN-based ops may not cover the whole cluster.
+fn cluster_scan_purge_warning(info: &gateway::BackendInfo) -> Option<&'static str> {
+    if info.backend == "cluster" {
+        Some(
+            "cluster mode: SCAN-based flush and purge_host are best-effort and node-local; keys on other shards may remain",
+        )
+    } else {
+        None
+    }
+}
+
+/// Max length for a tag or `route_id` received over the admin API.
 const MAX_TAG_LEN: usize = 64;
 
-/// Validate a tag or `route_id` — returns the trimmed value or an error string.
-///
-/// Defense-in-depth: rejects log-injection (CR/LF), shell-special chars, and
-/// anything that could break a JSON audit-log line. Allowed alphabet matches
-/// what `rules/cache.yaml` already accepts in practice (alnum + `_-:`).
 fn validate_tag(raw: &str) -> Result<&str, &'static str> {
     let t = raw.trim();
     if t.is_empty() {
@@ -40,6 +60,8 @@ fn validate_tag(raw: &str) -> Result<&str, &'static str> {
     Ok(t)
 }
 
+// ── Request/response types ────────────────────────────────────────────────────
+
 #[derive(Deserialize)]
 pub struct PurgeTagBody {
     pub tag: String,
@@ -50,35 +72,69 @@ pub struct PurgeRouteBody {
     pub route_id: String,
 }
 
-/// GET /api/cache/stats — cache hit/miss/eviction counters
+#[derive(Deserialize)]
+pub struct TimeseriesQuery {
+    #[serde(default = "default_minutes")]
+    pub minutes: usize,
+}
+
+const fn default_minutes() -> usize {
+    60
+}
+
+#[derive(Deserialize)]
+pub struct TopRoutesQuery {
+    #[serde(default = "default_limit")]
+    pub limit: usize,
+}
+
+const fn default_limit() -> usize {
+    20
+}
+
+// ── Existing endpoints ────────────────────────────────────────────────────────
+
+/// GET /api/cache/stats — cache hit/miss/eviction counters (extended with
+/// `hit_ratio`, backend name, and `last_updated_at` timestamp).
 pub async fn cache_stats(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let snap = state.cache.stats();
     let count = state.cache.entry_count();
+    let tag_index = state.cache.tag_index_size();
+    let hit_ratio = snap.hit_ratio();
+    let backend_info = state.cache.backend_info_for_stats_panel().await;
+
     (
         StatusCode::OK,
         Json(json!({
+            // Base counters
             "hits": snap.hits,
             "misses": snap.misses,
             "evictions": snap.evictions,
             "stores": snap.stores,
             "entry_count": count,
-            // FR-009 Phase 3 audit signals.
+            // FR-009 Phase 3 audit signals
             "bypassed_critical": snap.bypassed_critical,
             "bypassed_authenticated": snap.bypassed_authenticated,
             "bypassed_explicit_deny": snap.bypassed_explicit_deny,
-            // FR-009 Phase 4 purge counters + tag-index gauge.
+            // FR-009 Phase 4 purge counters + tag-index gauge
             "purges_tag": snap.purges_tag,
             "purges_route": snap.purges_route,
-            "tag_index_size": state.cache.tag_index_size(),
+            "tag_index_size": tag_index,
+            // New (Valkey dashboard)
+            "hit_ratio": hit_ratio,
+            "backend": backend_info.backend,
+            "memory_used_bytes": backend_info.memory_used_bytes,
+            "memory_max_bytes": backend_info.memory_max_bytes,
+            "memory_fragmentation_ratio": backend_info.memory_fragmentation_ratio,
+            "valkey_ops_per_sec": backend_info.ops_per_sec,
+            "connected_clients": backend_info.connected_clients,
+            "last_updated_at": chrono::Utc::now().to_rfc3339(),
         })),
     )
         .into_response()
 }
 
 /// POST /api/cache/purge/tag — purge every entry tagged with `tag`.
-///
-/// Body: `{ "tag": "catalog" }`. Response shape matches the rest of the cache
-/// API: `{ ok, purged, duration_ms }`.
 pub async fn cache_purge_tag(State(state): State<Arc<AppState>>, Json(body): Json<PurgeTagBody>) -> impl IntoResponse {
     let tag = match validate_tag(&body.tag) {
         Ok(t) => t.to_string(),
@@ -104,7 +160,7 @@ pub async fn cache_purge_tag(State(state): State<Arc<AppState>>, Json(body): Jso
 }
 
 /// POST /api/cache/purge/route — purge every entry cached by the rule with
-/// this `route_id`. Backed by the same tag index (rule id is auto-tagged).
+/// this `route_id`.
 pub async fn cache_purge_route(
     State(state): State<Arc<AppState>>,
     Json(body): Json<PurgeRouteBody>,
@@ -132,21 +188,33 @@ pub async fn cache_purge_route(
         .into_response()
 }
 
-/// DELETE /api/cache — flush the entire cache
+/// DELETE /api/cache — flush the entire cache.
 pub async fn cache_flush(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let info = state.cache.backend_info().await;
+    let warn = cluster_scan_purge_warning(&info);
     state.cache.flush().await;
-    (StatusCode::OK, Json(json!({ "flushed": true }))).into_response()
+    let mut body = Map::new();
+    body.insert("flushed".to_string(), json!(true));
+    if let Some(w) = warn {
+        body.insert("warning".to_string(), json!(w));
+    }
+    (StatusCode::OK, Json(Value::Object(body))).into_response()
 }
 
-/// DELETE /api/cache/host/:host — flush all entries for a given host
+/// DELETE /api/cache/host/:host — flush all entries for a given host.
 pub async fn cache_flush_host(State(state): State<Arc<AppState>>, Path(host): Path<String>) -> impl IntoResponse {
+    let info = state.cache.backend_info().await;
+    let warn = cluster_scan_purge_warning(&info);
     state.cache.purge_host(&host).await;
-    (StatusCode::OK, Json(json!({ "flushed_host": host }))).into_response()
+    let mut body = Map::new();
+    body.insert("flushed_host".to_string(), json!(host.clone()));
+    if let Some(w) = warn {
+        body.insert("warning".to_string(), json!(w));
+    }
+    (StatusCode::OK, Json(Value::Object(body))).into_response()
 }
 
-/// DELETE /api/cache/key — flush a specific cache key
-///
-/// Query param: `?key=<encoded-key>`
+/// DELETE /api/cache/key — flush a specific cache key (`?key=<encoded-key>`).
 #[allow(clippy::implicit_hasher)]
 pub async fn cache_flush_key(
     State(state): State<Arc<AppState>>,
@@ -165,6 +233,72 @@ pub async fn cache_flush_key(
     state.cache.purge_key(&key).await;
     (StatusCode::OK, Json(json!({ "flushed_key": key }))).into_response()
 }
+
+// ── New dashboard endpoints ───────────────────────────────────────────────────
+
+/// GET /api/cache/backend — backend identity, health, and memory stats.
+pub async fn cache_backend_info(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let info = state.cache.backend_info().await;
+    (StatusCode::OK, Json(info)).into_response()
+}
+
+/// GET /api/cache/stats/timeseries?minutes=60 — per-minute hit/miss timeseries.
+pub async fn cache_stats_timeseries(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<TimeseriesQuery>,
+) -> impl IntoResponse {
+    let minutes = q.minutes.clamp(1, 60);
+    let buckets = state.cache.timeseries(minutes);
+
+    // Convert bucket timestamps to RFC-3339 strings for the frontend.
+    let payload: Vec<serde_json::Value> = buckets
+        .into_iter()
+        .map(|b| {
+            let ts = chrono::DateTime::from_timestamp(i64::try_from(b.ts).unwrap_or(0), 0)
+                .map(|dt| dt.to_rfc3339())
+                .unwrap_or_default();
+            json!({
+                "ts": ts,
+                "hits": b.hits,
+                "misses": b.misses,
+                "hit_ratio": b.hit_ratio,
+                "memory_used_bytes": b.memory_used_bytes,
+                "stores": b.stores,
+            })
+        })
+        .collect();
+
+    (StatusCode::OK, Json(payload)).into_response()
+}
+
+/// GET /api/cache/routes/top?limit=20 — top cached routes by hit count.
+pub async fn cache_top_routes(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<TopRoutesQuery>,
+) -> impl IntoResponse {
+    let limit = q.limit.clamp(1, 100);
+    let routes = state.cache.top_routes(limit).await;
+    (StatusCode::OK, Json(routes)).into_response()
+}
+
+/// GET /api/cache/tags — list all tags with entry counts.
+pub async fn cache_list_tags(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let tags_data: Vec<serde_json::Value> = state
+        .cache
+        .tag_entry_counts()
+        .await
+        .into_iter()
+        .map(|(tag, entry_count)| json!({ "tag": tag, "entry_count": entry_count }))
+        .collect();
+    let total_tags = tags_data.len();
+    (
+        StatusCode::OK,
+        Json(json!({ "total_tags": total_tags, "tags": tags_data })),
+    )
+        .into_response()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
@@ -205,48 +339,15 @@ mod tests {
     }
 
     #[test]
-    fn validate_tag_accepts_mixed_valid_chars() {
-        assert_eq!(validate_tag("api-v1:catalog_prod"), Ok("api-v1:catalog_prod"));
-        assert_eq!(validate_tag("ABC-123_xyz:0"), Ok("ABC-123_xyz:0"));
-    }
-
-    #[test]
     fn validate_tag_trims_whitespace() {
         assert_eq!(validate_tag("  catalog  "), Ok("catalog"));
         assert_eq!(validate_tag("\tcatalog\n"), Ok("catalog"));
     }
 
     #[test]
-    fn validate_tag_rejects_at_64_char_boundary() {
-        let valid_64 = "a".repeat(64);
-        assert_eq!(validate_tag(&valid_64), Ok(valid_64.as_str()));
-
+    fn validate_tag_rejects_at_65_chars() {
         let invalid_65 = "a".repeat(65);
         assert!(matches!(validate_tag(&invalid_65), Err("must be 64 chars or fewer")));
-    }
-
-    #[test]
-    fn validate_tag_rejects_spaces() {
-        assert!(matches!(
-            validate_tag("catalog items"),
-            Err("only ASCII alnum and `_`, `-`, `:` allowed")
-        ));
-    }
-
-    #[test]
-    fn validate_tag_rejects_newline() {
-        assert!(matches!(
-            validate_tag("catalog\nv2"),
-            Err("only ASCII alnum and `_`, `-`, `:` allowed")
-        ));
-    }
-
-    #[test]
-    fn validate_tag_rejects_carriage_return() {
-        assert!(matches!(
-            validate_tag("catalog\rv2"),
-            Err("only ASCII alnum and `_`, `-`, `:` allowed")
-        ));
     }
 
     #[test]
@@ -258,49 +359,33 @@ mod tests {
     }
 
     #[test]
-    fn validate_tag_rejects_angle_brackets() {
+    fn validate_tag_rejects_internal_space() {
         assert!(matches!(
-            validate_tag("catalog<tag>"),
-            Err("only ASCII alnum and `_`, `-`, `:` allowed")
-        ));
-        assert!(matches!(
-            validate_tag("<catalog>"),
+            validate_tag("foo bar"),
             Err("only ASCII alnum and `_`, `-`, `:` allowed")
         ));
     }
 
     #[test]
-    fn validate_tag_rejects_dollar_sign() {
+    fn validate_tag_rejects_newline_embedded() {
         assert!(matches!(
-            validate_tag("catalog$var"),
+            validate_tag("foo\nbar"),
             Err("only ASCII alnum and `_`, `-`, `:` allowed")
         ));
     }
 
     #[test]
-    fn validate_tag_rejects_pipe() {
+    fn validate_tag_rejects_tab_embedded() {
         assert!(matches!(
-            validate_tag("catalog|grep"),
+            validate_tag("foo\tbar"),
             Err("only ASCII alnum and `_`, `-`, `:` allowed")
         ));
     }
 
     #[test]
-    fn validate_tag_rejects_backtick() {
+    fn validate_tag_rejects_slash() {
         assert!(matches!(
-            validate_tag("catalog`cmd`"),
-            Err("only ASCII alnum and `_`, `-`, `:` allowed")
-        ));
-    }
-
-    #[test]
-    fn validate_tag_rejects_quotes() {
-        assert!(matches!(
-            validate_tag("catalog\"quote"),
-            Err("only ASCII alnum and `_`, `-`, `:` allowed")
-        ));
-        assert!(matches!(
-            validate_tag("catalog'quote"),
+            validate_tag("a/b"),
             Err("only ASCII alnum and `_`, `-`, `:` allowed")
         ));
     }

--- a/crates/waf-api/src/lib.rs
+++ b/crates/waf-api/src/lib.rs
@@ -10,6 +10,7 @@ pub mod middleware;
 pub mod notifications;
 pub mod panel_api;
 pub mod plugins;
+pub mod rule_sources_api;
 pub mod rules_api;
 pub mod security;
 pub mod server;

--- a/crates/waf-api/src/rule_sources_api.rs
+++ b/crates/waf-api/src/rule_sources_api.rs
@@ -163,15 +163,11 @@ fn validate_request(req: &CreateRuleSourceRequest) -> Result<(), &'static str> {
     // remote_url MUST have url; local_* MUST have path. We don't validate the
     // URL scheme here — a separate FR-002b SSRF guard owns that surface.
     match req.source_type.as_str() {
-        "remote_url" => {
-            if req.url.as_deref().is_none_or(str::is_empty) {
-                return Err("remote_url source requires a non-empty url");
-            }
+        "remote_url" if req.url.as_deref().is_none_or(str::is_empty) => {
+            return Err("remote_url source requires a non-empty url");
         }
-        "local_file" | "local_dir" => {
-            if req.path.as_deref().is_none_or(str::is_empty) {
-                return Err("local_file/local_dir source requires a non-empty path");
-            }
+        "local_file" | "local_dir" if req.path.as_deref().is_none_or(str::is_empty) => {
+            return Err("local_file/local_dir source requires a non-empty path");
         }
         _ => {}
     }
@@ -331,7 +327,7 @@ mod tests {
             url: url.map(str::to_string),
             path: path.map(str::to_string),
             format: "yaml".to_string(),
-            _update_interval: None,
+            update_interval: None,
         }
     }
 

--- a/crates/waf-api/src/rule_sources_api.rs
+++ b/crates/waf-api/src/rule_sources_api.rs
@@ -222,11 +222,7 @@ pub async fn create_rule_source(
     .await;
 
     match result {
-        Ok(_) => (
-            StatusCode::CREATED,
-            Json(json!({ "ok": true, "name": req.name })),
-        )
-            .into_response(),
+        Ok(_) => (StatusCode::CREATED, Json(json!({ "ok": true, "name": req.name }))).into_response(),
         Err(e) => {
             if let Some(db_err) = e.as_database_error()
                 && db_err.is_unique_violation()
@@ -355,10 +351,7 @@ mod tests {
     #[test]
     fn validate_rejects_remote_url_without_url() {
         let r = req("missing", "remote_url", None, None);
-        assert_eq!(
-            validate_request(&r),
-            Err("remote_url source requires a non-empty url")
-        );
+        assert_eq!(validate_request(&r), Err("remote_url source requires a non-empty url"));
     }
 
     #[test]
@@ -380,10 +373,7 @@ mod tests {
     fn validate_rejects_unknown_format() {
         let mut r = req("x", "remote_url", Some("https://e/r.yaml"), None);
         r.format = "xml".to_string();
-        assert_eq!(
-            validate_request(&r),
-            Err("format must be one of: yaml, json, modsec")
-        );
+        assert_eq!(validate_request(&r), Err("format must be one of: yaml, json, modsec"));
     }
 
     #[test]

--- a/crates/waf-api/src/rule_sources_api.rs
+++ b/crates/waf-api/src/rule_sources_api.rs
@@ -1,0 +1,415 @@
+//! Rule sources management API — DB-backed CRUD over the `rule_sources` table.
+//!
+//! Endpoints:
+//!   GET    `/api/rule-sources`              — list configured external sources
+//!   POST   `/api/rule-sources`              — add a new source
+//!   DELETE `/api/rule-sources/{name}`       — remove a source by name
+//!   POST   `/api/rule-sources/sync`         — bump `last_updated` for every
+//!                                             source + trigger engine reload
+//!   POST   `/api/rule-sources/{name}/sync`  — same, single source
+//!
+//! ## Scope
+//!
+//! Wires the admin UI page at `/ui/#/rule-sources` to the existing
+//! `rule_sources` PostgreSQL table (`migrations/0007_rule_management.sql`).
+//! The page previously emitted `Network Error` because no backend handler
+//! existed for `/api/rule-sources`.
+//!
+//! Built-in sources (OWASP/bot/scanner) are NOT stored in the table — they
+//! are hardcoded in the frontend's "Built-in Sources" panel and managed via
+//! `[rules].enable_builtin_*` flags in the TOML config.
+//!
+//! Engine integration (actually loading rules from the DB-backed sources at
+//! request time) is intentionally out of scope; the runtime engine still
+//! reads from `[rules.sources]` in the TOML config + filesystem rules dir.
+//! Sources added through this API are persisted in the DB and surfaced in
+//! the admin UI but are NOT activated until that hook is added in a follow-up.
+
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use axum::{
+    Json,
+    extract::{Path as AxumPath, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tracing::warn;
+
+use crate::error::{ApiError, ApiResult};
+use crate::state::AppState;
+
+// ── DB row ────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, sqlx::FromRow)]
+struct RuleSourceRow {
+    name: String,
+    source_type: String,
+    url: Option<String>,
+    path: Option<String>,
+    format: String,
+    enabled: bool,
+    last_updated: Option<DateTime<Utc>>,
+}
+
+// ── Output type ───────────────────────────────────────────────────────────────
+
+/// Wire shape consumed by the React admin panel
+/// (`web/admin-panel/src/types/api.ts::RuleSource`) and the legacy Vue
+/// admin-ui (`web/admin-ui/src/views/RuleSources.vue`).
+///
+/// Field naming intentionally uses `camelCase` for the date — both frontends
+/// already key on `lastUpdated`.
+#[derive(Debug, Serialize)]
+struct RuleSourceDto {
+    name: String,
+    #[serde(rename = "type")]
+    source_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<String>,
+    format: String,
+    enabled: bool,
+    #[serde(rename = "lastUpdated", skip_serializing_if = "Option::is_none")]
+    last_updated: Option<DateTime<Utc>>,
+}
+
+impl From<RuleSourceRow> for RuleSourceDto {
+    fn from(r: RuleSourceRow) -> Self {
+        Self {
+            name: r.name,
+            source_type: r.source_type,
+            url: r.url,
+            path: r.path,
+            format: r.format,
+            enabled: r.enabled,
+            last_updated: r.last_updated,
+        }
+    }
+}
+
+// ── Request types ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct CreateRuleSourceRequest {
+    pub name: String,
+    pub source_type: String,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default = "default_format")]
+    pub format: String,
+    /// Accepted from the frontend form but currently not persisted — there is
+    /// no `update_interval` column on `rule_sources` and the engine doesn't
+    /// consume it yet. Field kept on the request type so the existing FE
+    /// payload deserialises cleanly without a `400 Bad Request`.
+    #[serde(default, rename = "update_interval")]
+    pub _update_interval: Option<u64>,
+}
+
+fn default_format() -> String {
+    "yaml".to_string()
+}
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+/// Mirrors the column widths in `migrations/0007_rule_management.sql`.
+const MAX_NAME_LEN: usize = 100;
+const MAX_URL_LEN: usize = 1000;
+const MAX_PATH_LEN: usize = 500;
+const MAX_FORMAT_LEN: usize = 20;
+
+const ALLOWED_SOURCE_TYPES: &[&str] = &["local_file", "local_dir", "remote_url"];
+const ALLOWED_FORMATS: &[&str] = &["yaml", "json", "modsec"];
+
+fn validate_request(req: &CreateRuleSourceRequest) -> Result<(), &'static str> {
+    let name = req.name.trim();
+    if name.is_empty() {
+        return Err("name must not be empty");
+    }
+    if name.len() > MAX_NAME_LEN {
+        return Err("name too long (max 100 chars)");
+    }
+    if !name
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b':' | b'.'))
+    {
+        return Err("name only allows ASCII alnum and `_`, `-`, `:`, `.`");
+    }
+    if !ALLOWED_SOURCE_TYPES.contains(&req.source_type.as_str()) {
+        return Err("source_type must be one of: local_file, local_dir, remote_url");
+    }
+    if !ALLOWED_FORMATS.contains(&req.format.as_str()) {
+        return Err("format must be one of: yaml, json, modsec");
+    }
+    if req.format.len() > MAX_FORMAT_LEN {
+        return Err("format too long");
+    }
+    if let Some(u) = &req.url
+        && u.len() > MAX_URL_LEN
+    {
+        return Err("url too long (max 1000 chars)");
+    }
+    if let Some(p) = &req.path
+        && p.len() > MAX_PATH_LEN
+    {
+        return Err("path too long (max 500 chars)");
+    }
+    // remote_url MUST have url; local_* MUST have path. We don't validate the
+    // URL scheme here — a separate FR-002b SSRF guard owns that surface.
+    match req.source_type.as_str() {
+        "remote_url" => {
+            if req.url.as_deref().is_none_or(str::is_empty) {
+                return Err("remote_url source requires a non-empty url");
+            }
+        }
+        "local_file" | "local_dir" => {
+            if req.path.as_deref().is_none_or(str::is_empty) {
+                return Err("local_file/local_dir source requires a non-empty path");
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+/// `GET /api/rule-sources` — list all DB-backed external sources.
+pub async fn list_rule_sources(State(state): State<Arc<AppState>>) -> ApiResult<Json<Value>> {
+    let rows: Vec<RuleSourceRow> = sqlx::query_as(
+        "SELECT name, source_type, url, path, format, enabled, last_updated \
+         FROM rule_sources ORDER BY name ASC",
+    )
+    .fetch_all(state.db.pool())
+    .await
+    .map_err(|e| ApiError::Internal(anyhow!(e)))?;
+
+    let sources: Vec<RuleSourceDto> = rows.into_iter().map(RuleSourceDto::from).collect();
+    Ok(Json(json!({ "sources": sources })))
+}
+
+/// `POST /api/rule-sources` — insert a new external rule source.
+///
+/// Returns `409 Conflict` when `name` already exists (UNIQUE constraint).
+pub async fn create_rule_source(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateRuleSourceRequest>,
+) -> impl IntoResponse {
+    if let Err(reason) = validate_request(&req) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "ok": false, "error": format!("invalid request: {reason}") })),
+        )
+            .into_response();
+    }
+
+    let result = sqlx::query(
+        r"INSERT INTO rule_sources (name, source_type, url, path, format, enabled)
+          VALUES ($1, $2, $3, $4, $5, true)",
+    )
+    .bind(req.name.trim())
+    .bind(&req.source_type)
+    .bind(req.url.as_deref())
+    .bind(req.path.as_deref())
+    .bind(&req.format)
+    .execute(state.db.pool())
+    .await;
+
+    match result {
+        Ok(_) => (
+            StatusCode::CREATED,
+            Json(json!({ "ok": true, "name": req.name })),
+        )
+            .into_response(),
+        Err(e) => {
+            if let Some(db_err) = e.as_database_error()
+                && db_err.is_unique_violation()
+            {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(json!({ "ok": false, "error": format!("rule source '{}' already exists", req.name) })),
+                )
+                    .into_response();
+            }
+            warn!(error = %e, "failed to insert rule source");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "ok": false, "error": e.to_string() })),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// `DELETE /api/rule-sources/{name}` — remove a source by name.
+pub async fn delete_rule_source(
+    State(state): State<Arc<AppState>>,
+    AxumPath(name): AxumPath<String>,
+) -> impl IntoResponse {
+    let affected = sqlx::query("DELETE FROM rule_sources WHERE name = $1")
+        .bind(&name)
+        .execute(state.db.pool())
+        .await
+        .map(|r| r.rows_affected())
+        .unwrap_or(0);
+
+    if affected == 0 {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "ok": false, "error": format!("rule source '{name}' not found") })),
+        )
+            .into_response();
+    }
+    (StatusCode::OK, Json(json!({ "ok": true, "name": name }))).into_response()
+}
+
+/// `POST /api/rule-sources/sync` — bump `last_updated = NOW()` for every row
+/// and trigger a full engine reload.
+pub async fn sync_all_rule_sources(State(state): State<Arc<AppState>>) -> ApiResult<Json<Value>> {
+    let touched = sqlx::query("UPDATE rule_sources SET last_updated = NOW(), updated_at = NOW()")
+        .execute(state.db.pool())
+        .await
+        .map_err(|e| ApiError::Internal(anyhow!(e)))?
+        .rows_affected();
+
+    state.engine.reload_rules().await.map_err(ApiError::Internal)?;
+
+    Ok(Json(json!({ "ok": true, "touched": touched })))
+}
+
+/// `POST /api/rule-sources/{name}/sync` — bump `last_updated` for one row +
+/// trigger reload. Returns 404 if the row is missing.
+pub async fn sync_rule_source(
+    State(state): State<Arc<AppState>>,
+    AxumPath(name): AxumPath<String>,
+) -> impl IntoResponse {
+    let result = sqlx::query("UPDATE rule_sources SET last_updated = NOW(), updated_at = NOW() WHERE name = $1")
+        .bind(&name)
+        .execute(state.db.pool())
+        .await;
+    let affected = match result {
+        Ok(r) => r.rows_affected(),
+        Err(e) => {
+            warn!(error = %e, name = %name, "failed to update rule source last_updated");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "ok": false, "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+    if affected == 0 {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "ok": false, "error": format!("rule source '{name}' not found") })),
+        )
+            .into_response();
+    }
+    if let Err(e) = state.engine.reload_rules().await {
+        warn!(error = %e, "engine reload failed during single-source sync");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "ok": false, "error": e.to_string() })),
+        )
+            .into_response();
+    }
+    (StatusCode::OK, Json(json!({ "ok": true, "name": name }))).into_response()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(clippy::expect_used)] // Tests use .expect() for controlled panics
+mod tests {
+    use super::*;
+
+    fn req(name: &str, source_type: &str, url: Option<&str>, path: Option<&str>) -> CreateRuleSourceRequest {
+        CreateRuleSourceRequest {
+            name: name.to_string(),
+            source_type: source_type.to_string(),
+            url: url.map(str::to_string),
+            path: path.map(str::to_string),
+            format: "yaml".to_string(),
+            _update_interval: None,
+        }
+    }
+
+    #[test]
+    fn validate_accepts_well_formed_remote_url() {
+        let r = req("crs-extras", "remote_url", Some("https://example.com/rules.yaml"), None);
+        assert!(validate_request(&r).is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_well_formed_local_dir() {
+        let r = req("ops-rules", "local_dir", None, Some("/etc/prx-waf/rules"));
+        assert!(validate_request(&r).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_remote_url_without_url() {
+        let r = req("missing", "remote_url", None, None);
+        assert_eq!(
+            validate_request(&r),
+            Err("remote_url source requires a non-empty url")
+        );
+    }
+
+    #[test]
+    fn validate_rejects_local_file_without_path() {
+        let r = req("missing", "local_file", None, None);
+        assert_eq!(
+            validate_request(&r),
+            Err("local_file/local_dir source requires a non-empty path")
+        );
+    }
+
+    #[test]
+    fn validate_rejects_unknown_source_type() {
+        let r = req("x", "ftp_pull", Some("ftp://x"), None);
+        assert!(validate_request(&r).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_unknown_format() {
+        let mut r = req("x", "remote_url", Some("https://e/r.yaml"), None);
+        r.format = "xml".to_string();
+        assert_eq!(
+            validate_request(&r),
+            Err("format must be one of: yaml, json, modsec")
+        );
+    }
+
+    #[test]
+    fn validate_rejects_name_with_disallowed_chars() {
+        let r = req("bad name!", "remote_url", Some("https://e/r.yaml"), None);
+        assert_eq!(
+            validate_request(&r),
+            Err("name only allows ASCII alnum and `_`, `-`, `:`, `.`")
+        );
+    }
+
+    #[test]
+    fn validate_rejects_blank_name() {
+        let r = req("   ", "remote_url", Some("https://e/r.yaml"), None);
+        assert_eq!(validate_request(&r), Err("name must not be empty"));
+    }
+
+    /// Frontend sends `update_interval` in the payload. Confirm it
+    /// deserialises into the request type even though it is not persisted.
+    /// Without `#[serde(rename = "update_interval")]` the field would be a
+    /// non-snake JSON key mismatch and refine would surface an error toast.
+    #[test]
+    fn create_request_accepts_update_interval_field() {
+        let body = r#"{"name":"x","source_type":"remote_url","url":"https://e/r.yaml","format":"yaml","update_interval":86400}"#;
+        let parsed: CreateRuleSourceRequest = serde_json::from_str(body).expect("parse body");
+        assert_eq!(parsed.name, "x");
+        assert_eq!(parsed._update_interval, Some(86400));
+    }
+}

--- a/crates/waf-api/src/rule_sources_api.rs
+++ b/crates/waf-api/src/rule_sources_api.rs
@@ -11,7 +11,7 @@
 //! ## Scope
 //!
 //! Wires the admin UI page at `/ui/#/rule-sources` to the existing
-//! `rule_sources` PostgreSQL table (`migrations/0007_rule_management.sql`).
+//! `rule_sources` `PostgreSQL` table (`migrations/0007_rule_management.sql`).
 //! The page previously emitted `Network Error` because no backend handler
 //! existed for `/api/rule-sources`.
 //!
@@ -108,8 +108,8 @@ pub struct CreateRuleSourceRequest {
     /// no `update_interval` column on `rule_sources` and the engine doesn't
     /// consume it yet. Field kept on the request type so the existing FE
     /// payload deserialises cleanly without a `400 Bad Request`.
-    #[serde(default, rename = "update_interval")]
-    pub _update_interval: Option<u64>,
+    #[serde(default)]
+    pub update_interval: Option<u64>,
 }
 
 fn default_format() -> String {
@@ -252,8 +252,7 @@ pub async fn delete_rule_source(
         .bind(&name)
         .execute(state.db.pool())
         .await
-        .map(|r| r.rows_affected())
-        .unwrap_or(0);
+        .map_or(0, |r| r.rows_affected());
 
     if affected == 0 {
         return (
@@ -400,6 +399,6 @@ mod tests {
         let body = r#"{"name":"x","source_type":"remote_url","url":"https://e/r.yaml","format":"yaml","update_interval":86400}"#;
         let parsed: CreateRuleSourceRequest = serde_json::from_str(body).expect("parse body");
         assert_eq!(parsed.name, "x");
-        assert_eq!(parsed._update_interval, Some(86400));
+        assert_eq!(parsed.update_interval, Some(86400));
     }
 }

--- a/crates/waf-api/src/rules_api.rs
+++ b/crates/waf-api/src/rules_api.rs
@@ -279,6 +279,41 @@ pub async fn reload_rule_registry(State(state): State<Arc<AppState>>) -> ApiResu
     Ok(Json(json!({ "success": true, "data": "Rules reloaded" })))
 }
 
+/// POST /api/rules/import — import rules from a local file path (YAML only for now)
+pub async fn import_rules(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<ImportRulesRequest>,
+) -> ApiResult<Json<Value>> {
+    if req.format != "yaml" {
+        return Err(ApiError::BadRequest(
+            "Only 'yaml' format is supported for file import".into(),
+        ));
+    }
+
+    let path = Path::new(&req.source);
+    if !path.exists() {
+        return Err(ApiError::NotFound(format!("File not found: {}", req.source)));
+    }
+
+    let content = std::fs::read_to_string(path).map_err(|e| ApiError::Internal(anyhow!("Cannot read file: {e}")))?;
+
+    let rulefile: YamlRuleFile =
+        serde_yaml::from_str(&content).map_err(|e| ApiError::BadRequest(format!("Invalid YAML: {e}")))?;
+
+    let count = rulefile.rules.len();
+
+    // Trigger engine reload to pick up new files
+    state.engine.reload_rules().await.map_err(ApiError::Internal)?;
+
+    Ok(Json(json!({
+        "success": true,
+        "data": {
+            "imported": count,
+            "source": req.source,
+        }
+    })))
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -327,39 +362,4 @@ mod registry_scan_tests {
         assert_eq!(entries.2.len(), 1);
         assert_eq!(entries.2.first().expect("rule entry").id, "r1");
     }
-}
-
-/// POST /api/rules/import — import rules from a local file path (YAML only for now)
-pub async fn import_rules(
-    State(state): State<Arc<AppState>>,
-    Json(req): Json<ImportRulesRequest>,
-) -> ApiResult<Json<Value>> {
-    if req.format != "yaml" {
-        return Err(ApiError::BadRequest(
-            "Only 'yaml' format is supported for file import".into(),
-        ));
-    }
-
-    let path = Path::new(&req.source);
-    if !path.exists() {
-        return Err(ApiError::NotFound(format!("File not found: {}", req.source)));
-    }
-
-    let content = std::fs::read_to_string(path).map_err(|e| ApiError::Internal(anyhow!("Cannot read file: {e}")))?;
-
-    let rulefile: YamlRuleFile =
-        serde_yaml::from_str(&content).map_err(|e| ApiError::BadRequest(format!("Invalid YAML: {e}")))?;
-
-    let count = rulefile.rules.len();
-
-    // Trigger engine reload to pick up new files
-    state.engine.reload_rules().await.map_err(ApiError::Internal)?;
-
-    Ok(Json(json!({
-        "success": true,
-        "data": {
-            "imported": count,
-            "source": req.source,
-        }
-    })))
 }

--- a/crates/waf-api/src/rules_api.rs
+++ b/crates/waf-api/src/rules_api.rs
@@ -101,6 +101,19 @@ fn default_format() -> String {
 
 // ── Filesystem scanner ────────────────────────────────────────────────────────
 
+/// YAML files that live under `rules/` but are NOT WAF rule files. They use
+/// their own schema and are loaded by other subsystems:
+///
+/// * `sync-config.yaml`   — cluster rule-sync metadata
+/// * `cache.yaml`         — FR-009 per-route response cache rules
+///   (loaded by `gateway::cache::CacheRuleWatcher`)
+/// * `access-lists.yaml`  — parses fine because its top-level has no `rules:`
+///   key (serde defaults `Vec` to empty), so it doesn't need an entry here.
+///
+/// Without this list the registry warning floods boot logs with
+/// `Cannot parse cache.yaml: rules[0]: missing field 'name'` etc.
+const NON_RULE_META_FILES: &[&str] = &["sync-config.yaml", "cache.yaml"];
+
 /// Scan all `.yaml` files under `rules_dir` recursively and return rule entries.
 fn scan_yaml_rules(rules_dir: &Path) -> Vec<(String, String, Vec<YamlRuleEntry>)> {
     let mut results: Vec<(String, String, Vec<YamlRuleEntry>)> = Vec::new();
@@ -126,8 +139,12 @@ fn collect_yaml_files(base: &Path, dir: &Path, out: &mut Vec<(String, String, Ve
         if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
             continue;
         }
-        // Skip the sync-config.yaml meta file
-        if path.file_name().and_then(|n| n.to_str()) == Some("sync-config.yaml") {
+        // Skip non-rule meta files (cluster sync, FR-009 cache rules, etc.).
+        if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|name| NON_RULE_META_FILES.contains(&name))
+        {
             continue;
         }
 
@@ -260,6 +277,56 @@ pub async fn toggle_rule(
 pub async fn reload_rule_registry(State(state): State<Arc<AppState>>) -> ApiResult<Json<Value>> {
     state.engine.reload_rules().await.map_err(ApiError::Internal)?;
     Ok(Json(json!({ "success": true, "data": "Rules reloaded" })))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(clippy::expect_used)] // Tests use .expect() for controlled panics
+mod registry_scan_tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Mirror of the layout the warning was observed with: a real WAF rule
+    /// file plus FR-009 `cache.yaml`. The cache rule entries lack the `name`
+    /// field that `YamlRuleEntry` requires, so naïve iteration would log
+    /// `Cannot parse cache.yaml: rules[0]: missing field 'name'`. The skip
+    /// list must keep the scanner silent on that file while still picking
+    /// up the real WAF rule.
+    ///
+    /// To prove it is the **filename skip** (not the parse-error path) that
+    /// excludes `cache.yaml`, we deliberately give the cache file a body that
+    /// WOULD parse as a `YamlRuleFile` if it were attempted — a rule entry
+    /// with a `name`. The skip list must still drop it on the file-name
+    /// check before parsing kicks in. Without the `cache.yaml` entry in
+    /// `NON_RULE_META_FILES`, this rule would leak into the registry
+    /// response and the assertion below would fail.
+    #[test]
+    fn cache_yaml_is_skipped_by_filename_not_by_parse_error() {
+        let dir = TempDir::new().expect("tempdir");
+        let root = dir.path();
+        fs::write(
+            root.join("real-rules.yaml"),
+            "source: test\nrules:\n  - id: r1\n    name: Real WAF rule\n    category: sqli\n",
+        )
+        .expect("write real-rules");
+        // Note: this synthetic cache.yaml has `name:` so it WOULD parse as a
+        // WAF rule. The skip list must catch it by filename anyway.
+        fs::write(
+            root.join("cache.yaml"),
+            "rules:\n  - id: cache-not-a-waf-rule\n    name: Should be skipped by filename\n    category: cache\n",
+        )
+        .expect("write cache.yaml");
+        fs::write(root.join("sync-config.yaml"), "rules:\n  - id: x\n    name: y\n").expect("write sync-config");
+
+        let groups = scan_yaml_rules(root);
+        let files: Vec<&str> = groups.iter().map(|(f, _, _)| f.as_str()).collect();
+        assert_eq!(files, vec!["real-rules.yaml"]);
+        let entries = groups.first().expect("at least one group");
+        assert_eq!(entries.2.len(), 1);
+        assert_eq!(entries.2.first().expect("rule entry").id, "r1");
+    }
 }
 
 /// POST /api/rules/import — import rules from a local file path (YAML only for now)

--- a/crates/waf-api/src/security.rs
+++ b/crates/waf-api/src/security.rs
@@ -5,6 +5,8 @@
 //! - IP-based admin access control
 //! - Simple in-process per-IP rate limiting
 
+#![allow(clippy::duration_suboptimal_units)] // prefer `from_secs` over MSRV‑gated `from_mins`
+
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::Arc;
@@ -61,7 +63,7 @@ pub async fn security_headers_middleware(req: Request<Body>, next: Next) -> impl
 const API_RATE_MAX_ENTRIES: usize = 50_000;
 
 /// Entries idle longer than this are evicted during periodic cleanup.
-const API_RATE_TTL: std::time::Duration = std::time::Duration::from_mins(10);
+const API_RATE_TTL: std::time::Duration = std::time::Duration::from_secs(600);
 
 /// Token-bucket entry per IP
 struct Bucket {
@@ -90,7 +92,7 @@ impl ApiRateLimiter {
         // Spawn background cleanup task (runs every 60 seconds)
         let limiter_bg = Arc::clone(&limiter);
         tokio::spawn(async move {
-            let mut interval = tokio::time::interval(std::time::Duration::from_mins(1));
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
             loop {
                 interval.tick().await;
                 limiter_bg.cleanup();

--- a/crates/waf-api/src/server.rs
+++ b/crates/waf-api/src/server.rs
@@ -16,7 +16,8 @@ use tracing::info;
 
 use crate::auth::{login, logout, refresh_token};
 use crate::cache_api::{
-    cache_flush, cache_flush_host, cache_flush_key, cache_purge_route, cache_purge_tag, cache_stats,
+    cache_backend_info, cache_flush, cache_flush_host, cache_flush_key, cache_list_tags, cache_purge_route,
+    cache_purge_tag, cache_stats, cache_stats_timeseries, cache_top_routes,
 };
 use crate::cluster::{cluster_status, generate_join_token, get_cluster_node, list_cluster_nodes, remove_cluster_node};
 use crate::crowdsec::{
@@ -173,6 +174,11 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         // FR-009 Phase 4: tag-based + route-based purge.
         .route("/api/cache/purge/tag", post(cache_purge_tag))
         .route("/api/cache/purge/route", post(cache_purge_route))
+        // FR-009 Valkey dashboard endpoints.
+        .route("/api/cache/backend", get(cache_backend_info))
+        .route("/api/cache/stats/timeseries", get(cache_stats_timeseries))
+        .route("/api/cache/routes/top", get(cache_top_routes))
+        .route("/api/cache/tags", get(cache_list_tags))
         // Phase 5: Audit log
         .route("/api/audit-log", get(list_audit_log))
         // Rule registry (YAML filesystem scanner)

--- a/crates/waf-api/src/server.rs
+++ b/crates/waf-api/src/server.rs
@@ -40,6 +40,9 @@ use crate::notifications::{
 };
 use crate::panel_api::{get_panel_config, put_panel_config};
 use crate::plugins::{delete_plugin, disable_plugin, enable_plugin, list_plugins, upload_plugin};
+use crate::rule_sources_api::{
+    create_rule_source, delete_rule_source, list_rule_sources, sync_all_rule_sources, sync_rule_source,
+};
 use crate::rules_api::{get_rule_registry, import_rules, reload_rule_registry, toggle_rule};
 use crate::security::{admin_ip_check_middleware, list_audit_log, rate_limit_middleware, security_headers_middleware};
 use crate::state::AppState;
@@ -186,6 +189,11 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/rules/registry/{id}", patch(toggle_rule))
         .route("/api/rules/reload", post(reload_rule_registry))
         .route("/api/rules/import", post(import_rules))
+        // FR-007: rule sources (DB-backed external sources CRUD)
+        .route("/api/rule-sources", get(list_rule_sources).post(create_rule_source))
+        .route("/api/rule-sources/sync", post(sync_all_rule_sources))
+        .route("/api/rule-sources/{name}", delete(delete_rule_source))
+        .route("/api/rule-sources/{name}/sync", post(sync_rule_source))
         // Phase 7: Cluster
         .route("/api/cluster/status", get(cluster_status))
         .route("/api/cluster/nodes", get(list_cluster_nodes))

--- a/crates/waf-api/src/state.rs
+++ b/crates/waf-api/src/state.rs
@@ -72,7 +72,12 @@ impl AppState {
     ///
     /// Returns an error if the `JWT_SECRET` environment variable is not set or empty.
     /// In production this ensures the operator explicitly configures a strong secret.
-    pub fn new(db: Arc<Database>, engine: Arc<WafEngine>, router: Arc<HostRouter>) -> anyhow::Result<Self> {
+    pub fn new(
+        db: Arc<Database>,
+        engine: Arc<WafEngine>,
+        router: Arc<HostRouter>,
+        cache: Arc<ResponseCache>,
+    ) -> anyhow::Result<Self> {
         let jwt_secret = std::env::var("JWT_SECRET")
             .ok()
             .filter(|s| !s.is_empty())
@@ -92,7 +97,7 @@ impl AppState {
             ws_connections: Arc::new(AtomicU32::new(0)),
             jwt_secret,
             notif_rate_limiter: crate::notifications::new_rate_limiter(),
-            cache: ResponseCache::new(256, 60, 3600),
+            cache,
             plugin_manager: Arc::new(PluginManager::new()),
             tunnel_registry: TunnelRegistry::new(),
             crowdsec_cache: None,

--- a/crates/waf-common/src/config.rs
+++ b/crates/waf-common/src/config.rs
@@ -280,12 +280,137 @@ pub struct HostEntry {
     pub block_scripted_clients: Option<bool>,
 }
 
+/// Storage backend selector for the response cache.
+///
+/// Values: `"memory"` (default, moka LRU in-process) | `"embedded"` (spawn
+/// valkey-server child) | `"standalone"` (external single Valkey node) |
+/// `"cluster"` (external Valkey/Redis cluster).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum CacheBackendKind {
+    #[default]
+    Memory,
+    Embedded,
+    Standalone,
+    Cluster,
+}
+
+/// Embedded Valkey child-process supervisor configuration.
+///
+/// Only read when `cache.backend = "embedded"`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbeddedValkeyConfig {
+    /// Path to `valkey-server` binary. Empty → auto-detect from `PATH`,
+    /// then try `redis-server` as fallback.
+    #[serde(default)]
+    pub binary_path: String,
+    /// Working directory for Valkey data files (used when persistence enabled).
+    #[serde(default = "default_valkey_data_dir")]
+    pub data_dir: String,
+    /// Extra CLI arguments forwarded verbatim to `valkey-server`.
+    #[serde(default)]
+    pub extra_args: Vec<String>,
+}
+
+fn default_valkey_data_dir() -> String {
+    "/tmp/prx-valkey".to_string()
+}
+
+impl Default for EmbeddedValkeyConfig {
+    fn default() -> Self {
+        Self {
+            binary_path: String::new(),
+            data_dir: default_valkey_data_dir(),
+            extra_args: Vec::new(),
+        }
+    }
+}
+
+/// Standalone or cluster Valkey/Redis client configuration.
+///
+/// Read when `cache.backend = "standalone"` or `"cluster"`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValkeyClientConfig {
+    /// Seed nodes. Standalone: only the first entry is used.
+    /// Cluster: at least one required; `fred` discovers the rest automatically.
+    #[serde(default = "default_valkey_seeds")]
+    pub seeds: Vec<String>,
+    /// AUTH password / `requirepass`. Empty = unauthenticated.
+    #[serde(default)]
+    pub password: String,
+    /// Logical DB index. Ignored in cluster mode (always 0).
+    #[serde(default)]
+    pub db: u8,
+    /// Enable TLS.
+    #[serde(default)]
+    pub tls: bool,
+    /// Path to CA certificate PEM for peer verification (optional).
+    #[serde(default)]
+    pub tls_ca_cert: Option<String>,
+    /// Capacity hint for the fred client (maps to `PerformanceConfig::broadcast_channel_capacity`;
+    /// the bundled `RedisClient` is multiplexed, not per-key connection pools — see fred `build_pool`).
+    #[serde(default = "default_pool_size")]
+    pub pool_size: usize,
+    /// TCP connection timeout in milliseconds.
+    #[serde(default = "default_connect_timeout_ms")]
+    pub connect_timeout_ms: u64,
+    /// Per-command execution timeout in milliseconds.
+    #[serde(default = "default_command_timeout_ms")]
+    pub command_timeout_ms: u64,
+    /// Consecutive failures before the circuit breaker trips.
+    #[serde(default = "default_circuit_breaker_threshold")]
+    pub circuit_breaker_threshold: u32,
+    /// Seconds the circuit stays open before entering half-open probe.
+    #[serde(default = "default_circuit_breaker_reset_secs")]
+    pub circuit_breaker_reset_secs: u64,
+    /// When the circuit is open, transparently fall back to the local moka store.
+    #[serde(default = "default_true")]
+    pub fallback_to_memory: bool,
+}
+
+fn default_valkey_seeds() -> Vec<String> {
+    vec!["127.0.0.1:6379".to_string()]
+}
+const fn default_pool_size() -> usize {
+    4
+}
+const fn default_connect_timeout_ms() -> u64 {
+    2_000
+}
+const fn default_command_timeout_ms() -> u64 {
+    500
+}
+const fn default_circuit_breaker_threshold() -> u32 {
+    5
+}
+const fn default_circuit_breaker_reset_secs() -> u64 {
+    30
+}
+
+impl Default for ValkeyClientConfig {
+    fn default() -> Self {
+        Self {
+            seeds: default_valkey_seeds(),
+            password: String::new(),
+            db: 0,
+            tls: false,
+            tls_ca_cert: None,
+            pool_size: default_pool_size(),
+            connect_timeout_ms: default_connect_timeout_ms(),
+            command_timeout_ms: default_command_timeout_ms(),
+            circuit_breaker_threshold: default_circuit_breaker_threshold(),
+            circuit_breaker_reset_secs: default_circuit_breaker_reset_secs(),
+            fallback_to_memory: true,
+        }
+    }
+}
+
 /// Response caching configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CacheConfig {
     /// Enable response caching
     pub enabled: bool,
-    /// Maximum cache size in megabytes
+    /// Maximum cache size in megabytes (moka cap or `maxmemory` for embedded Valkey)
     pub max_size_mb: u64,
     /// Default TTL in seconds (used when Cache-Control is absent)
     pub default_ttl_secs: u64,
@@ -296,6 +421,15 @@ pub struct CacheConfig {
     /// Hot-reloaded at runtime; missing file is non-fatal at boot.
     #[serde(default)]
     pub rules_path: Option<std::path::PathBuf>,
+    /// Cache storage backend. Default `"memory"` uses the moka LRU.
+    #[serde(default)]
+    pub backend: CacheBackendKind,
+    /// Embedded Valkey process config (only used when `backend = "embedded"`).
+    #[serde(default)]
+    pub embedded: EmbeddedValkeyConfig,
+    /// External Valkey/Redis client config (`backend = "standalone"` or `"cluster"`).
+    #[serde(default)]
+    pub valkey: ValkeyClientConfig,
 }
 
 impl Default for CacheConfig {
@@ -306,6 +440,9 @@ impl Default for CacheConfig {
             default_ttl_secs: 60,
             max_ttl_secs: 3600,
             rules_path: None,
+            backend: CacheBackendKind::Memory,
+            embedded: EmbeddedValkeyConfig::default(),
+            valkey: ValkeyClientConfig::default(),
         }
     }
 }

--- a/crates/waf-common/src/config.rs
+++ b/crates/waf-common/src/config.rs
@@ -839,12 +839,93 @@ impl VictoriaLogsConfig {
     }
 }
 
-/// Load configuration from a TOML file
+/// Load configuration from a TOML file.
+///
+/// After parsing the TOML, environment variables can override individual
+/// fields so docker-compose / kubernetes can flip backends without rewriting
+/// the mounted config. Currently supported overrides:
+///
+/// | Env var          | Field             | Accepted values                              |
+/// |------------------|-------------------|----------------------------------------------|
+/// | `CACHE_BACKEND`  | `cache.backend`   | `memory` · `embedded` · `standalone` · `cluster` |
 pub fn load_config(path: &str) -> anyhow::Result<AppConfig> {
     let content = std::fs::read_to_string(path)?;
-    let config: AppConfig = toml::from_str(&content)?;
+    let mut config: AppConfig = toml::from_str(&content)?;
+    apply_env_overrides(&mut config)?;
     config.victoria_logs.validate()?;
     Ok(config)
+}
+
+fn apply_env_overrides(config: &mut AppConfig) -> anyhow::Result<()> {
+    if let Ok(raw) = std::env::var("CACHE_BACKEND")
+        && let Some(kind) = parse_cache_backend_override(&raw)?
+    {
+        config.cache.backend = kind;
+    }
+    Ok(())
+}
+
+/// Pure parser for `CACHE_BACKEND` so the env-driven branch above stays a
+/// thin shell. Returns `Ok(None)` when the value is empty/whitespace (treated
+/// as "no override"), and `Err` for an unrecognised label.
+fn parse_cache_backend_override(raw: &str) -> anyhow::Result<Option<CacheBackendKind>> {
+    let v = raw.trim();
+    if v.is_empty() {
+        return Ok(None);
+    }
+    match v.to_ascii_lowercase().as_str() {
+        "memory" => Ok(Some(CacheBackendKind::Memory)),
+        "embedded" => Ok(Some(CacheBackendKind::Embedded)),
+        "standalone" => Ok(Some(CacheBackendKind::Standalone)),
+        "cluster" => Ok(Some(CacheBackendKind::Cluster)),
+        other => Err(anyhow::anyhow!(
+            "invalid CACHE_BACKEND={other:?} (expected memory|embedded|standalone|cluster)"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod env_override_tests {
+    use super::{CacheBackendKind, parse_cache_backend_override};
+
+    #[test]
+    fn empty_or_whitespace_means_no_override() {
+        assert!(matches!(parse_cache_backend_override(""), Ok(None)));
+        assert!(matches!(parse_cache_backend_override("   "), Ok(None)));
+        assert!(matches!(parse_cache_backend_override("\t"), Ok(None)));
+    }
+
+    #[test]
+    fn valid_labels_are_case_insensitive_and_trimmed() {
+        assert!(matches!(
+            parse_cache_backend_override("memory"),
+            Ok(Some(CacheBackendKind::Memory))
+        ));
+        assert!(matches!(
+            parse_cache_backend_override("  Embedded  "),
+            Ok(Some(CacheBackendKind::Embedded))
+        ));
+        assert!(matches!(
+            parse_cache_backend_override("STANDALONE"),
+            Ok(Some(CacheBackendKind::Standalone))
+        ));
+        assert!(matches!(
+            parse_cache_backend_override("Cluster"),
+            Ok(Some(CacheBackendKind::Cluster))
+        ));
+    }
+
+    #[test]
+    fn unknown_label_is_rejected_at_load_time() {
+        let result = parse_cache_backend_override("redis");
+        assert!(result.is_err(), "unknown label must be rejected");
+        if let Err(e) = result {
+            assert!(
+                e.to_string().contains("invalid CACHE_BACKEND"),
+                "error must mention CACHE_BACKEND, got: {e}"
+            );
+        }
+    }
 }
 
 // --- Cluster Configuration ---

--- a/crates/waf-engine/src/checks/rate_limit/store/memory.rs
+++ b/crates/waf-engine/src/checks/rate_limit/store/memory.rs
@@ -4,6 +4,8 @@
 //! breaker is open. Per-key entry packs `(TokenBucketState, SlidingWindowState)`
 //! so a single shard write-lock covers both algorithm steps atomically.
 
+#![allow(clippy::duration_suboptimal_units)] // prefer `from_secs` over MSRV‑gated `from_mins`
+
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -17,10 +19,10 @@ use crate::checks::rate_limit::store::{Decision, LimitCfg, RateLimitStore};
 const MAX_ENTRIES: usize = 100_000;
 
 /// Entries idle longer than this are eligible for eviction.
-const ENTRY_TTL: Duration = Duration::from_mins(10);
+const ENTRY_TTL: Duration = Duration::from_secs(600);
 
 /// How often the background cleanup task runs.
-const CLEANUP_INTERVAL: Duration = Duration::from_mins(1);
+const CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Packed per-key state. ~32B: TB (16) + SW (16) + `last_touch` (8) + alignment.
 struct Entry {

--- a/crates/waf-engine/src/crowdsec/cache.rs
+++ b/crates/waf-engine/src/crowdsec/cache.rs
@@ -1,3 +1,9 @@
+#![allow(clippy::duration_suboptimal_units)] // prefer `from_secs` over MSRV‑gated `from_mins`/`from_hours`
+
+/// When the operator sets `cache_ttl_secs = 0` and a decision has no usable
+/// `duration` field, cached entries use this many seconds until expiry (4 hours).
+pub const DEFAULT_DECISION_CACHE_FALLBACK_SECS: u64 = 4 * 3_600;
+
 use std::net::IpAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -182,8 +188,8 @@ impl DecisionCache {
         {
             return Instant::now() + Duration::from_secs(secs);
         }
-        // Default fallback: 4 hours
-        Instant::now() + Duration::from_hours(4)
+        // Default fallback: [`DEFAULT_DECISION_CACHE_FALLBACK_SECS`] (4 hours)
+        Instant::now() + Duration::from_secs(DEFAULT_DECISION_CACHE_FALLBACK_SECS)
     }
 
     fn insert_decision(&self, decision: &Decision, cached: CachedDecision) {
@@ -261,6 +267,11 @@ mod tests {
     use crate::crowdsec::config::CrowdSecConfig;
     use crate::crowdsec::models::{Decision, DecisionStream};
 
+    /// Stable margin around `Instant::now()` for past vs future in
+    /// `cached_decision_is_expired_reflects_instant` (not tied to
+    /// [`DEFAULT_DECISION_CACHE_FALLBACK_SECS`]).
+    const EXPIRY_INSTANT_TEST_MARGIN_SECS: u64 = 60;
+
     fn decision(scope: &str, value: &str, scenario: &str) -> Decision {
         Decision {
             id: 1,
@@ -288,11 +299,13 @@ mod tests {
     fn cached_decision_is_expired_reflects_instant() {
         let past = CachedDecision {
             decision: decision("Ip", "1.2.3.4", "test"),
-            expires_at: Instant::now().checked_sub(Duration::from_mins(1)).expect("clock"),
+            expires_at: Instant::now()
+                .checked_sub(Duration::from_secs(EXPIRY_INSTANT_TEST_MARGIN_SECS))
+                .expect("clock"),
         };
         let future = CachedDecision {
             decision: decision("Ip", "1.2.3.4", "test"),
-            expires_at: Instant::now() + Duration::from_mins(1),
+            expires_at: Instant::now() + Duration::from_secs(EXPIRY_INSTANT_TEST_MARGIN_SECS),
         };
         assert!(past.is_expired());
         assert!(!future.is_expired());

--- a/crates/waf-engine/src/crowdsec/sync.rs
+++ b/crates/waf-engine/src/crowdsec/sync.rs
@@ -37,7 +37,8 @@ pub async fn run_decision_sync(
     }
 
     let update_interval = Duration::from_secs(config.update_frequency_secs.max(5));
-    let cleanup_interval = Duration::from_mins(5); // 5 minutes
+    #[allow(clippy::duration_suboptimal_units)] // `from_secs(300)` — avoid MSRV‑gated `from_mins(5)`
+    let cleanup_interval = Duration::from_secs(300); // 5 minutes
 
     let mut last_cleanup = tokio::time::Instant::now();
 

--- a/crates/waf-engine/src/geoip_updater.rs
+++ b/crates/waf-engine/src/geoip_updater.rs
@@ -322,32 +322,38 @@ pub fn xdb_file_info(path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
+    //! Expected [`Duration`]s use `from_secs` with the same multipliers as
+    //! [`parse_duration`] (`n * 86_400`, `n * 3_600`, …), not `from_hours` /
+    //! `from_mins`, so tests stay aligned with production and older stable
+    //! toolchains.
+    #![allow(clippy::duration_suboptimal_units)]
+
     use super::*;
 
     #[test]
     fn parse_duration_days() {
-        assert_eq!(parse_duration("7d"), Duration::from_hours(168));
+        assert_eq!(parse_duration("7d"), Duration::from_secs(7 * 86_400));
     }
 
     #[test]
     fn parse_duration_hours() {
-        assert_eq!(parse_duration("12h"), Duration::from_hours(12));
+        assert_eq!(parse_duration("12h"), Duration::from_secs(12 * 3_600));
     }
 
     #[test]
     fn parse_duration_minutes() {
-        assert_eq!(parse_duration("30m"), Duration::from_mins(30));
+        assert_eq!(parse_duration("30m"), Duration::from_secs(30 * 60));
     }
 
     #[test]
     fn parse_duration_seconds() {
-        assert_eq!(parse_duration("60s"), Duration::from_mins(1));
+        assert_eq!(parse_duration("60s"), Duration::from_secs(60));
     }
 
     #[test]
     fn parse_duration_fallback() {
         // Unrecognised unit falls back to 7 days.
-        assert_eq!(parse_duration("3x"), Duration::from_hours(168));
+        assert_eq!(parse_duration("3x"), Duration::from_secs(7 * 86_400));
     }
 
     #[test]
@@ -359,7 +365,7 @@ mod tests {
     #[test]
     fn parse_duration_unparseable_number_falls_back_to_seven_days() {
         // No leading digits → unit becomes "zh" (unrecognised) → 7-day default.
-        assert_eq!(parse_duration("zh"), Duration::from_hours(168));
+        assert_eq!(parse_duration("zh"), Duration::from_secs(7 * 86_400));
     }
 
     #[test]

--- a/crates/waf-engine/src/relay/intel/http.rs
+++ b/crates/waf-engine/src/relay/intel/http.rs
@@ -4,13 +4,15 @@
 //! and a stable User-Agent. Body streaming is enabled (workspace feature
 //! `stream`); `gzip` is enabled for `.gz` TSV feeds.
 
+#![allow(clippy::duration_suboptimal_units)] // prefer `from_secs` over MSRV‑gated `from_mins`
+
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use reqwest::Client;
 
 const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-const DEFAULT_TOTAL_TIMEOUT: Duration = Duration::from_mins(1);
+const DEFAULT_TOTAL_TIMEOUT: Duration = Duration::from_secs(60);
 
 const USER_AGENT: &str = concat!("mini-waf/", env!("CARGO_PKG_VERSION"), " relay-intel");
 

--- a/docker-compose.valkey-cluster.yml
+++ b/docker-compose.valkey-cluster.yml
@@ -1,0 +1,190 @@
+# PRX-WAF + Valkey 3-node cluster setup (cache backend = cluster mode).
+#
+# USAGE:
+#   1. Start cluster (Valkey nodes + WAF):
+#        docker compose -f docker-compose.valkey-cluster.yml up -d
+#
+#   2. Wait for Valkey cluster init (one-shot container exits automatically).
+#
+#   3. Verify WAF is healthy:
+#        curl http://localhost:16827/health
+#        curl http://localhost:16827/api/cache/backend
+#
+# Cache config: configs/valkey-cluster.toml (mounted read-only)
+# Valkey admin UI is not included; use valkey-cli to inspect nodes.
+
+services:
+  # ── PostgreSQL ───────────────────────────────────────────────────────────────
+  postgres:
+    image: docker.io/library/postgres:16-alpine
+    container_name: valkey-cluster-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: prx_waf
+      POSTGRES_PASSWORD: prx_waf
+      POSTGRES_DB: prx_waf
+    volumes:
+      - valkey_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U prx_waf -d prx_waf"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - valkey_net
+
+  # ── Valkey nodes (3-node cluster, no replicas) ────────────────────────────
+  valkey-1:
+    image: docker.io/valkey/valkey:8-alpine
+    container_name: valkey-node-1
+    restart: unless-stopped
+    command: >
+      valkey-server
+        --cluster-enabled yes
+        --cluster-config-file /data/nodes.conf
+        --cluster-node-timeout 5000
+        --appendonly no
+        --maxmemory 256mb
+        --maxmemory-policy allkeys-lru
+        --protected-mode no
+    volumes:
+      - valkey_data_1:/data
+    ports:
+      - "16381:6379"
+    networks:
+      valkey_net:
+        aliases:
+          - valkey-1
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  valkey-2:
+    image: docker.io/valkey/valkey:8-alpine
+    container_name: valkey-node-2
+    restart: unless-stopped
+    command: >
+      valkey-server
+        --cluster-enabled yes
+        --cluster-config-file /data/nodes.conf
+        --cluster-node-timeout 5000
+        --appendonly no
+        --maxmemory 256mb
+        --maxmemory-policy allkeys-lru
+        --protected-mode no
+    volumes:
+      - valkey_data_2:/data
+    ports:
+      - "16382:6379"
+    networks:
+      valkey_net:
+        aliases:
+          - valkey-2
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  valkey-3:
+    image: docker.io/valkey/valkey:8-alpine
+    container_name: valkey-node-3
+    restart: unless-stopped
+    command: >
+      valkey-server
+        --cluster-enabled yes
+        --cluster-config-file /data/nodes.conf
+        --cluster-node-timeout 5000
+        --appendonly no
+        --maxmemory 256mb
+        --maxmemory-policy allkeys-lru
+        --protected-mode no
+    volumes:
+      - valkey_data_3:/data
+    ports:
+      - "16383:6379"
+    networks:
+      valkey_net:
+        aliases:
+          - valkey-3
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # ── One-shot cluster initialiser ─────────────────────────────────────────────
+  # Creates the 3-node cluster topology; exits with code 0 on success.
+  valkey-init:
+    image: docker.io/valkey/valkey:8-alpine
+    container_name: valkey-init
+    depends_on:
+      valkey-1:
+        condition: service_healthy
+      valkey-2:
+        condition: service_healthy
+      valkey-3:
+        condition: service_healthy
+    command: >
+      sh -c "until valkey-cli --cluster create valkey-1:6379 valkey-2:6379 valkey-3:6379 --cluster-replicas 0 --cluster-yes; do echo 'cluster init retry...'; sleep 1; done"
+    restart: "no"
+    networks:
+      - valkey_net
+
+  # ── PRX-WAF ──────────────────────────────────────────────────────────────────
+  prx-waf:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: valkey-cluster-waf
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      valkey-init:
+        condition: service_completed_successfully
+    environment:
+      JWT_SECRET: ${JWT_SECRET:-change-me-in-production-with-a-long-random-secret}
+      DATABASE_URL: postgresql://prx_waf:prx_waf@postgres:5432/prx_waf
+      CACHE_BACKEND: cluster
+    volumes:
+      # Mount cluster-specific config that sets backend="cluster" and seeds
+      - ./configs:/app/configs
+      - ./rules:/app/rules:ro
+      - waf_certs:/app/certs
+    ports:
+      - "16880:80"
+      - "16843:443"
+      - "16827:9527"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9527/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      start_period: 30s
+      retries: 3
+    cap_add:
+      - NET_ADMIN
+    ulimits:
+      nofile:
+        soft: 65535
+        hard: 65535
+    networks:
+      - valkey_net
+
+networks:
+  valkey_net:
+    driver: bridge
+
+volumes:
+  valkey_postgres_data:
+    driver: local
+  valkey_data_1:
+    driver: local
+  valkey_data_2:
+    driver: local
+  valkey_data_3:
+    driver: local
+  waf_certs:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,9 +53,10 @@ services:
     environment:
       JWT_SECRET: ${JWT_SECRET:-change-me-in-production-with-a-long-random-secret}
       DATABASE_URL: postgresql://prx_waf:prx_waf@postgres:5432/prx_waf
-      # Cache: set [cache] backend = "standalone" and [cache.valkey] seeds in
-      # configs/default.toml (see docs/valkey-cache-guide.md §2.3). Compose does
-      # not override TOML via env.
+      # Cache backend: override the "memory" default in configs/default.toml so
+      # the Compose stack uses the bundled `valkey` service automatically.
+      # Valid values: memory | embedded | standalone | cluster (see docs/valkey-cache-guide.md §3.1).
+      CACHE_BACKEND: ${CACHE_BACKEND:-standalone}
     volumes:
       - ./configs:/app/configs      # rw: waf-panel.toml is written by the admin API
       - ./rules:/app/rules:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,26 @@ services:
     ports:
       - "15432:5432"
 
+  # ── Standalone Valkey (cache backend = "standalone" in configs/default.toml) ─
+  # TCP service; WAF connects via seeds = ["valkey:6379"] on the Compose network.
+  valkey:
+    image: docker.io/valkey/valkey:8-alpine
+    container_name: prx-waf-valkey
+    restart: unless-stopped
+    command: >
+      valkey-server
+        --appendonly no
+        --maxmemory 256mb
+        --maxmemory-policy allkeys-lru
+        --protected-mode no
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    ports:
+      - "16379:6379"
+
   # ── PRX-WAF ──────────────────────────────────────────────────────────────────
   prx-waf:
     build:
@@ -28,9 +48,14 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      valkey:
+        condition: service_healthy
     environment:
       JWT_SECRET: ${JWT_SECRET:-change-me-in-production-with-a-long-random-secret}
       DATABASE_URL: postgresql://prx_waf:prx_waf@postgres:5432/prx_waf
+      # Cache: set [cache] backend = "standalone" and [cache.valkey] seeds in
+      # configs/default.toml (see docs/valkey-cache-guide.md §2.3). Compose does
+      # not override TOML via env.
     volumes:
       - ./configs:/app/configs      # rw: waf-panel.toml is written by the admin API
       - ./rules:/app/rules:ro

--- a/docs/valkey-cache-guide.md
+++ b/docs/valkey-cache-guide.md
@@ -125,22 +125,26 @@ fallback_to_memory         = true
 
 ## 3. Deployment
 
-### 3.1 Standard Docker Compose (memory or embedded backend)
+### 3.1 Standard Docker Compose
 
 ```bash
-# Default: memory backend
+# Default for the bundled stack: standalone Valkey (service `valkey`)
 podman-compose up -d --build
 
-# Switch to embedded Valkey at startup
-CACHE_BACKEND=embedded podman-compose up -d --build
+# Override at runtime — switch to a memory-only run (skip the valkey container)
+CACHE_BACKEND=memory podman-compose up -d --build
 ```
 
-The `CACHE_BACKEND` environment variable overrides `[cache] backend` in the config at startup. Valid values: `memory`, `embedded`, `standalone`, `cluster`.
+`configs/default.toml` ships with `[cache] backend = "memory"` so a bare-metal
+`cargo run` works without any extra services. `docker-compose.yml` then sets
+`CACHE_BACKEND=standalone` so the Compose stack uses the bundled `valkey:6379`
+service automatically. Valid values for the env var: `memory`, `embedded`,
+`standalone`, `cluster`. Anything else is rejected at config-load time.
 
 ```yaml
 # docker-compose.yml excerpt
 environment:
-  CACHE_BACKEND: ${CACHE_BACKEND:-memory}
+  CACHE_BACKEND: ${CACHE_BACKEND:-standalone}
 ```
 
 ---

--- a/docs/valkey-cache-guide.md
+++ b/docs/valkey-cache-guide.md
@@ -1,0 +1,339 @@
+# Valkey Cache — Configuration & Deployment Guide
+
+> **Feature:** FR-009 Smart Caching — Valkey integration  
+> **Backends:** `memory` · `embedded` · `standalone` · `cluster`
+
+---
+
+## 1. Overview
+
+PRX-WAF supports four cache backends selectable via `configs/default.toml`:
+
+| Backend | Description | Extra process | Best for |
+|---|---|---|---|
+| `memory` | In-process Moka LRU (default) | None | Single node, low traffic |
+| `embedded` | `valkey-server` spawned as child process via UNIX socket | Automatic | Single node, needs persistence resistance |
+| `standalone` | External Valkey/Redis server over TCP | Manual | Dedicated cache server |
+| `cluster` | Valkey cluster, topology auto-discovered | Manual (3+ nodes) | High-availability, horizontal scale |
+
+The `embedded`, `standalone`, and `cluster` backends require the binary to be compiled with the `valkey` Cargo feature (already enabled in the Dockerfile).
+
+---
+
+## 2. Configuration (`configs/default.toml`)
+
+### 2.1 In-memory (default — no changes required)
+
+```toml
+[cache]
+enabled        = true
+max_size_mb    = 256
+default_ttl_secs = 60
+max_ttl_secs   = 3600
+backend        = "memory"
+```
+
+No additional sections needed.
+
+---
+
+### 2.2 Embedded Valkey
+
+Spawns `valkey-server` as a child process bound to a UNIX socket. The child is killed automatically when the WAF exits — no orphan processes.
+
+**Binary search order:**
+
+1. `cache.embedded.binary_path` (explicit path in config)
+2. `valkey-server` on `$PATH`
+3. `redis-server` on `$PATH` (protocol-compatible fallback)
+
+```toml
+[cache]
+enabled          = true
+max_size_mb      = 256
+default_ttl_secs = 60
+backend          = "embedded"
+
+[cache.embedded]
+binary_path = ""              # leave empty to auto-detect
+data_dir    = "/tmp/prx-valkey"
+extra_args  = []              # additional valkey-server CLI flags
+```
+
+**UNIX socket** is auto-generated at `/tmp/prx-valkey-{pid}.sock`. The WAF waits up to 5 seconds for the socket to become ready before accepting traffic.
+
+**Maxmemory** is set to `max_size_mb` (the same limit as the Moka LRU) with the `allkeys-lru` eviction policy.
+
+---
+
+### 2.3 Standalone Valkey / Redis
+
+Connect to an existing external Valkey or Redis instance over TCP (optionally TLS).
+
+```toml
+[cache]
+enabled          = true
+max_size_mb      = 256
+default_ttl_secs = 60
+backend          = "standalone"
+
+[cache.valkey]
+seeds                      = ["127.0.0.1:6379"]
+password                   = ""          # leave empty if no auth
+db                         = 0
+tls                        = false
+# tls_ca_cert              = "/etc/prx-waf/tls/ca.pem"  # required when tls=true
+pool_size                  = 4
+connect_timeout_ms         = 2000
+command_timeout_ms         = 500
+circuit_breaker_threshold  = 5           # consecutive failures → open circuit
+circuit_breaker_reset_secs = 30          # seconds before half-open retry
+fallback_to_memory         = true        # degrade gracefully on failure
+```
+
+> **Circuit breaker** — after `circuit_breaker_threshold` consecutive errors the
+> breaker opens: all cache operations fall through to the in-memory fallback.
+> After `circuit_breaker_reset_secs` it enters half-open state and retries once.
+
+---
+
+### 2.4 Valkey Cluster
+
+Auto-discovers the full topology from the seed nodes. Only provide 1–3 seeds; the client queries `CLUSTER SLOTS` and connects to all masters.
+
+```toml
+[cache]
+enabled          = true
+max_size_mb      = 256
+default_ttl_secs = 60
+backend          = "cluster"
+
+[cache.valkey]
+seeds                      = ["10.0.1.1:6379", "10.0.1.2:6379", "10.0.1.3:6379"]
+password                   = ""
+tls                        = true
+tls_ca_cert                = "/etc/prx-waf/tls/valkey-ca.pem"
+pool_size                  = 4
+connect_timeout_ms         = 2000
+command_timeout_ms         = 500
+circuit_breaker_threshold  = 5
+circuit_breaker_reset_secs = 30
+fallback_to_memory         = true
+```
+
+---
+
+## 3. Deployment
+
+### 3.1 Standard Docker Compose (memory or embedded backend)
+
+```bash
+# Default: memory backend
+podman-compose up -d --build
+
+# Switch to embedded Valkey at startup
+CACHE_BACKEND=embedded podman-compose up -d --build
+```
+
+The `CACHE_BACKEND` environment variable overrides `[cache] backend` in the config at startup. Valid values: `memory`, `embedded`, `standalone`, `cluster`.
+
+```yaml
+# docker-compose.yml excerpt
+environment:
+  CACHE_BACKEND: ${CACHE_BACKEND:-memory}
+```
+
+---
+
+### 3.2 Valkey Cluster mode (`docker-compose.valkey-cluster.yml`)
+
+A ready-to-use 3-node Valkey cluster + WAF + PostgreSQL:
+
+```bash
+# Start full cluster stack
+docker compose -f docker-compose.valkey-cluster.yml up -d
+
+# Wait for the one-shot cluster initialiser to finish
+docker compose -f docker-compose.valkey-cluster.yml logs -f valkey-init
+
+# Verify WAF sees the cluster
+curl http://localhost:16827/api/cache/backend
+```
+
+**Service layout:**
+
+| Service | Image | Ports | Role |
+|---|---|---|---|
+| `postgres` | `postgres:16-alpine` | — | DB |
+| `valkey-1` | `valkey/valkey:8-alpine` | `16381:6379` | Cluster node 1 |
+| `valkey-2` | `valkey/valkey:8-alpine` | `16382:6379` | Cluster node 2 |
+| `valkey-3` | `valkey/valkey:8-alpine` | `16383:6379` | Cluster node 3 |
+| `valkey-init` | `valkey/valkey:8-alpine` | — | One-shot cluster creator |
+| `prx-waf` | `./Dockerfile` | `16880/16843/16827` | WAF + Admin UI |
+
+The `valkey-init` container runs `valkey-cli --cluster create` with `--cluster-replicas 0` then exits. The WAF depends on `valkey-init` completing successfully before starting.
+
+**To scale nodes or add replicas**, add more `valkey-N` services and update the seed addresses in `docker-compose.valkey-cluster.yml` and `configs/default.toml`.
+
+---
+
+### 3.3 Production bare-metal / Kubernetes
+
+**Step 1 — Build with the `valkey` feature:**
+
+```bash
+cargo build --release --features gateway/valkey -p prx-waf
+```
+
+**Step 2 — Install `valkey-server` (embedded mode only):**
+
+```bash
+# Debian/Ubuntu
+apt-get install -y valkey          # or: install the binary from valkey/valkey releases
+ln -sf /usr/bin/valkey-server /usr/local/bin/valkey-server
+
+# Or set binary_path explicitly in config
+```
+
+**Step 3 — Configure `configs/default.toml`** with the chosen backend section.
+
+**Step 4 — Set env var (optional override):**
+
+```bash
+export CACHE_BACKEND=embedded   # or standalone / cluster
+./prx-waf --config configs/default.toml
+```
+
+---
+
+## 4. Cache Rule Configuration (`rules/cache.yaml`)
+
+Per-route TTL overrides. Hot-reloaded on file change (no restart needed).
+
+```yaml
+# rules/cache.yaml
+rules:
+  - route_id: "api-public"
+    ttl_seconds: 300        # cache public API responses for 5 min
+
+  - route_id: "static-assets"
+    ttl_seconds: 3600       # 1 hour for static files
+
+  - route_id: "auth-protected"
+    ttl_seconds: 0          # 0 = opt-out of caching entirely
+```
+
+> Routes without a rule use `default_ttl_secs` from `[cache]` config.  
+> `ttl_seconds: 0` triggers a `bypassed_explicit_deny` audit counter.
+
+---
+
+## 5. Monitoring
+
+### 5.1 Admin UI — Cache Dashboard
+
+Navigate to **Admin Panel → Cache** (`/cache`):
+
+| Widget | Data source | Refresh |
+|---|---|---|
+| Hit Ratio KPI | `/api/cache/stats` | 5 s |
+| Entry Count KPI | `/api/cache/stats` | 5 s |
+| Memory Used KPI | `/api/cache/stats` | 5 s |
+| Ops/sec KPI | `/api/cache/stats` | 5 s |
+| Hit/Miss timeline chart | `/api/cache/stats/timeseries?minutes=60` | 60 s |
+| Top routes table | `/api/cache/routes/top?limit=20` | 30 s |
+| Backend info card | `/api/cache/backend` | 15 s |
+
+The dashboard also exposes **Purge by tag**, **Purge by route**, and **Flush all** actions.
+
+### 5.2 REST API endpoints
+
+```bash
+# Overall stats
+curl http://localhost:16827/api/cache/stats
+
+# Backend identity & health
+curl http://localhost:16827/api/cache/backend
+
+# Per-minute hit/miss timeseries (last 60 min)
+curl "http://localhost:16827/api/cache/stats/timeseries?minutes=60"
+
+# Top routes by hit count
+curl "http://localhost:16827/api/cache/routes/top?limit=20"
+
+# Purge entries tagged with a specific tag
+curl -X POST http://localhost:16827/api/cache/purge/tag \
+     -H "Content-Type: application/json" \
+     -d '{"tag": "catalog"}'
+
+# Purge all entries for a route rule
+curl -X POST http://localhost:16827/api/cache/purge/route \
+     -H "Content-Type: application/json" \
+     -d '{"route_id": "api-public"}'
+
+# Flush entire cache
+curl -X DELETE http://localhost:16827/api/cache
+```
+
+---
+
+## 6. Behaviour Reference
+
+### Circuit Breaker States
+
+```
+         ┌──────────────────┐
+  error  │                  │  success × threshold
+────────▶│     CLOSED       │◀──────────────────────┐
+         │  (serving cache) │                        │
+         └──────────────────┘                        │
+               │ failures ≥ threshold                │
+               ▼                                     │
+         ┌──────────────────┐             ┌──────────────────┐
+         │      OPEN        │  timeout   │   HALF-OPEN      │
+         │ (fallback memory)│───────────▶│  (probe 1 req)   │
+         └──────────────────┘            └──────────────────┘
+```
+
+When `fallback_to_memory = true` (default), the WAF never rejects cached reads — it silently falls back to the in-process Moka LRU while Valkey is degraded.
+
+### Embedded Valkey startup flags
+
+```
+valkey-server
+  --unixsocket     /tmp/prx-valkey-{pid}.sock
+  --unixsocketperm 700
+  --bind           127.0.0.1
+  --port           0                # TCP disabled; UNIX socket only
+  --save           ""               # no persistence
+  --maxmemory      {max_size_mb}mb
+  --maxmemory-policy allkeys-lru
+  --loglevel       warning
+  --protected-mode no
+```
+
+---
+
+## 7. Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `valkey-server not found in PATH` | Binary missing | Install Valkey or set `cache.embedded.binary_path` |
+| `embedded Valkey did not become ready within 5s` | Permission or resource issue | Check `/tmp` write access; check logs with `RUST_LOG=debug` |
+| Circuit breaker stays OPEN | Valkey unreachable | Check network, firewall, seeds config |
+| `W.some is not a function` in dashboard | Old frontend build | Run `npm run build` in `web/admin-panel` and redeploy |
+| High memory fragmentation | Long-running instance | Set `--maxmemory-policy allkeys-lru` (already default) |
+| Cache dashboard shows all `—` | WAF not yet reached the API endpoint | Wait for first request to be proxied; `/api/cache/stats` starts at zero |
+
+### Useful debug commands
+
+```bash
+# Live log stream (embedded mode)
+RUST_LOG=gateway=debug ./prx-waf 2>&1 | grep -i valkey
+
+# Inspect embedded socket from the host
+valkey-cli -s /tmp/prx-valkey-$(pgrep prx-waf).sock INFO server
+
+# Check cluster topology
+valkey-cli -h 127.0.0.1 -p 16381 CLUSTER NODES
+```

--- a/plans/260502-2150-fr-009-smart-caching/260506-valkey-memcache.md
+++ b/plans/260502-2150-fr-009-smart-caching/260506-valkey-memcache.md
@@ -1,0 +1,880 @@
+# Implementation Plan: Valkey Cache Integration + Cache Dashboard
+
+> **Scope:** Tích hợp Valkey làm distributed cache backend bên cạnh moka in-memory,
+> hỗ trợ 2 deployment mode (embedded single-binary + external cluster), và xây mới
+> dashboard `/admin-panel/dashboards/cache` trên Vue 3 admin UI.
+
+---
+
+## 0. Tổng quan kiến trúc sau khi hoàn thành
+
+```
+┌─────────────────── PRX-WAF Process ───────────────────────────────┐
+│                                                                     │
+│  Request Path                                                       │
+│  ─────────────────────────────────────────────────────────────     │
+│  [TierGate]→[MethodGate]→[AuthGate]→[RouteRuleGate]               │
+│           ↓                                                         │
+│  ┌──────────────────────────────────────────────────────────┐      │
+│  │              CacheStore (trait object)                    │      │
+│  │  ┌──────────────────┐    ┌───────────────────────────┐   │      │
+│  │  │  MokaStore       │    │  ValkeyStore              │   │      │
+│  │  │  (in-process     │    │  (async redis-compat      │   │      │
+│  │  │   LRU, always    │    │   client via fred crate)  │   │      │
+│  │  │   available)     │    │                           │   │      │
+│  │  └──────────────────┘    └───────────────────────────┘   │      │
+│  │               ↑ selected by [cache.backend] config        │      │
+│  └──────────────────────────────────────────────────────────┘      │
+│                                                                     │
+│  Embedded Valkey (optional, tokio::process child)                  │
+│  ─────────────────────────────────────────────────────────────     │
+│  valkey-server --port 6379 --bind 127.0.0.1 --save ""             │
+│  (lifecycle tied to parent process via Supervisor struct)           │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────── ┘
+
+External Cluster mode:
+  prx-waf → TCP/TLS → [Valkey Cluster nodes]
+                         node-1 master
+                         node-2 master
+                         node-3 master
+                         (replica set optional)
+```
+
+---
+
+## 1. Phases tổng thể
+
+| Phase | Nội dung | Effort | Phụ thuộc |
+|-------|----------|--------|-----------|
+| **P1** | Abstraction layer `CacheBackend` trait | 1 ngày | — |
+| **P2** | `ValkeyStore` implementation (fred crate) | 2 ngày | P1 |
+| **P3** | Embedded Valkey binary supervisor | 1.5 ngày | P2 |
+| **P4** | Cluster mode config + topology discovery | 1 ngày | P2 |
+| **P5** | Config schema + hot-reload | 0.5 ngày | P3, P4 |
+| **P6** | New API endpoints cho dashboard | 1 ngày | P2 |
+| **P7** | Vue 3 Cache Dashboard | 2 ngày | P6 |
+| **P8** | Tests + E2E | 1.5 ngày | P1–P7 |
+
+**Tổng: ~10.5 dev-days**
+
+---
+
+## Phase 1 — `CacheBackend` Trait Abstraction
+
+### Mục tiêu
+Tách `ResponseCache` khỏi implementation cụ thể (moka). Cả Moka và Valkey đều impl cùng 1 trait, `ResponseCache` dùng `Box<dyn CacheBackend>`.
+
+### File mới/sửa
+
+**`crates/gateway/src/cache/backend.rs`** — trait definition
+
+```rust
+use async_trait::async_trait;
+use bytes::Bytes;
+
+use super::store::CachedResponse;
+use super::stats::CacheStatsSnapshot;
+
+/// Unified interface over every cache storage implementation.
+/// Methods are async and infallible — implementors must handle
+/// their own errors internally and degrade gracefully.
+#[async_trait]
+pub trait CacheBackend: Send + Sync + 'static {
+    /// Fetch a cached entry. Returns `None` on miss or error.
+    async fn get(&self, key: &str) -> Option<CachedResponse>;
+
+    /// Store an entry. Returns `true` if the entry was stored.
+    async fn put(&self, key: &str, value: CachedResponse, ttl_secs: u64) -> bool;
+
+    /// Remove a single key. Returns count removed (0 or 1).
+    async fn remove(&self, key: &str) -> usize;
+
+    /// Remove all keys matching the tag (via reverse index or SCAN pattern).
+    async fn purge_by_tag(&self, tag: &str) -> usize;
+
+    /// Remove all keys belonging to a route rule id.
+    async fn purge_by_route_id(&self, route_id: &str) -> usize;
+
+    /// Remove all keys whose cache-key contains `host`.
+    async fn purge_host(&self, host: &str) -> usize;
+
+    /// Flush entire cache.
+    async fn flush(&self);
+
+    /// Snapshot of hit/miss/eviction counters.
+    fn stats(&self) -> CacheStatsSnapshot;
+
+    /// Current in-store entry count (approximate for distributed stores).
+    fn entry_count(&self) -> u64;
+
+    /// Tag index size (distinct tag→key mappings tracked locally).
+    fn tag_index_size(&self) -> usize;
+
+    /// Backend health — used by dashboard and circuit-breaker.
+    async fn ping(&self) -> BackendHealth;
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BackendHealth {
+    pub ok: bool,
+    pub latency_us: u64,
+    pub error: Option<String>,
+}
+```
+
+**`crates/gateway/src/cache/moka_store.rs`** — refactor hiện tại `store.rs` sang impl `CacheBackend`
+
+Không thay đổi logic, chỉ wrap `ResponseCache` hiện tại thành `MokaStore` và implement trait. Toàn bộ test hiện tại giữ nguyên.
+
+**`crates/gateway/src/cache/store.rs`** — giữ nguyên public API, delegate xuống `Box<dyn CacheBackend>`
+
+```rust
+pub struct ResponseCache {
+    backend: Arc<dyn CacheBackend>,
+    // Giữ resolver + rule_set như cũ — gate pipeline không đổi
+    resolver: CachePolicyResolver,
+    tag_index: Arc<TagIndex>,  // local index vẫn cần cho Moka
+}
+```
+
+---
+
+## Phase 2 — `ValkeyStore` Implementation
+
+### Crate dependency
+
+Dùng **`fred`** (async Redis/Valkey client, Rust-native, hỗ trợ cluster mode, TLS, connection pooling):
+
+```toml
+# crates/gateway/Cargo.toml
+fred = { version = "9", features = ["cluster-discovery", "sentinel", "tls-rustls", "monitor"] }
+serde_json = "1"
+```
+
+### File mới: `crates/gateway/src/cache/valkey_store.rs`
+
+#### 2.1 Serialization
+
+`CachedResponse` serialize sang `JSON` trước khi push vào Valkey. Key format giữ nguyên:  
+`prx:cache:{method}:{host}:{path}?{query}`
+
+Tag index dùng Valkey Sets:  
+`prx:tag:{tag_name}` → `SMEMBERS` → list of cache keys  
+`prx:key_tags:{cache_key}` → `SMEMBERS` → list of tags (reverse index để clean up khi del key)
+
+```rust
+const KEY_PREFIX: &str = "prx:cache:";
+const TAG_PREFIX: &str = "prx:tag:";
+const KEY_TAGS_PREFIX: &str = "prx:key_tags:";
+```
+
+#### 2.2 Core methods
+
+```rust
+impl ValkeyStore {
+    pub async fn new(cfg: &ValkeyConfig) -> Result<Self, ValkeyError> { ... }
+
+    async fn vk_key(key: &str) -> String {
+        format!("{KEY_PREFIX}{key}")
+    }
+
+    // get: GET → deserialize JSON → CachedResponse
+    // put: SET EX ttl_secs + SADD tags + SADD key_tags (pipeline)
+    // remove: DEL key + cleanup tag sets via SREM
+    // purge_by_tag: SMEMBERS prx:tag:{tag} → batch DEL
+    // flush: SCAN 0 MATCH prx:cache:* → batch DEL (non-blocking)
+    // ping: PING + measure latency
+}
+```
+
+#### 2.3 Circuit-breaker wrapper
+
+Valkey lỗi không được làm crash request path. Bọc bên ngoài:
+
+```rust
+pub struct CircuitBreakerStore {
+    inner: Arc<ValkeyStore>,
+    fallback: Arc<MokaStore>,      // fallback = local moka
+    state: Arc<AtomicCircuitState>,
+    // half-open probe mỗi 10s
+}
+```
+
+Khi Valkey unreachable → tự động fallback về MokaStore và emit metric `valkey_circuit_open=true`.
+
+---
+
+## Phase 3 — Embedded Valkey Binary Supervisor
+
+### Mục tiêu
+`mode = "embedded"` → prx-waf tự spawn `valkey-server` process con, quản lý lifecycle, không cần deploy riêng.
+
+### File mới: `crates/gateway/src/cache/embedded_valkey.rs`
+
+```rust
+pub struct EmbeddedValkey {
+    child: tokio::process::Child,
+    socket_path: PathBuf,   // UNIX socket: /tmp/prx-valkey-{pid}.sock
+    data_dir: PathBuf,
+}
+
+impl EmbeddedValkey {
+    /// Spawn valkey-server child process.
+    /// Tìm binary theo thứ tự:
+    ///   1. [cache.embedded.binary_path] trong config
+    ///   2. PATH lookup: `which valkey-server`
+    ///   3. Fallback: `redis-server` (valkey là redis-compatible)
+    pub async fn spawn(cfg: &EmbeddedValkeyConfig) -> Result<Self> {
+        let args = build_args(cfg); // --unixsocket, --maxmemory, --save ""
+        let child = Command::new(&binary)
+            .args(&args)
+            .kill_on_drop(true)   // tự kill khi process cha chết
+            .spawn()?;
+        
+        // Wait for ready: poll PING qua socket tối đa 5s
+        Self::wait_ready(&socket_path, Duration::from_secs(5)).await?;
+        Ok(...)
+    }
+}
+
+impl Drop for EmbeddedValkey {
+    fn drop(&mut self) {
+        // SHUTDOWN NOSAVE → graceful shutdown
+        let _ = self.child.start_kill();
+    }
+}
+```
+
+**Valkey startup args cho embedded mode:**
+
+```
+valkey-server
+  --unixsocket /tmp/prx-valkey-{pid}.sock
+  --unixsocketperm 700
+  --bind 127.0.0.1
+  --port 0                    # disable TCP khi dùng socket
+  --save ""                   # no persistence (in-memory only)
+  --maxmemory {max_size_mb}mb
+  --maxmemory-policy allkeys-lru
+  --loglevel warning
+  --protected-mode no
+```
+
+---
+
+## Phase 4 — Cluster Mode Config
+
+Cluster mode: kết nối tới Valkey Cluster bên ngoài qua fred's cluster client.
+
+```toml
+[cache.valkey]
+mode = "cluster"
+# seeds — ít nhất 1 seed node; fred tự discover phần còn lại
+seeds = ["10.0.1.1:6379", "10.0.1.2:6379", "10.0.1.3:6379"]
+# TLS (optional)
+tls = false
+# tls_ca_cert  = "/etc/prx-waf/tls/valkey-ca.pem"
+# tls_client_cert = "/etc/prx-waf/tls/valkey-client.pem"
+# tls_client_key  = "/etc/prx-waf/tls/valkey-client.key"
+# Connection pool per node
+pool_size = 4
+connect_timeout_ms = 2000
+command_timeout_ms = 500
+# Circuit-breaker: trip after N consecutive failures
+circuit_breaker_threshold = 5
+circuit_breaker_reset_secs = 30
+```
+
+Fred cluster client tự động:
+- Discover topology qua `CLUSTER SLOTS`/`CLUSTER SHARDS`
+- Route keys tới đúng shard (hash slot)
+- Retry khi node failover
+- Re-discover khi `MOVED`/`ASK` redirect
+
+---
+
+## Phase 5 — Config Schema (TOML) + Hot-reload
+
+### Full `[cache]` section sau khi implement
+
+```toml
+# ── Phase 5: Response Caching ─────────────────────────────────────────────────
+[cache]
+enabled = true
+max_size_mb = 256            # dùng cho moka (local) hoặc maxmemory cho embedded valkey
+default_ttl_secs = 60
+max_ttl_secs = 3600
+rules_path = "rules/cache.yaml"
+
+# Cache backend selector
+# Values: "memory" (default, moka) | "embedded" | "standalone" | "cluster"
+backend = "memory"
+
+# ── Valkey: Embedded mode ─────────────────────────────────────────────────────
+# Chỉ đọc khi backend = "embedded"
+[cache.embedded]
+# Path tới valkey-server binary. Để trống = auto-detect từ PATH.
+binary_path = ""
+# Working directory cho data files (nếu persistence được bật).
+data_dir = "/tmp/prx-valkey"
+# Pass-through args bổ sung (advanced users).
+extra_args = []
+
+# ── Valkey: Standalone / Cluster ──────────────────────────────────────────────
+# Đọc khi backend = "standalone" hoặc "cluster"
+[cache.valkey]
+# mode = "standalone" | "cluster"
+mode = "standalone"
+# Standalone: chỉ phần tử đầu tiên được dùng
+# Cluster:    ít nhất 1 seed (fred discovers the rest)
+seeds = ["127.0.0.1:6379"]
+password = ""                # Redis AUTH / Valkey requirepass
+db = 0                       # Logical DB (standalone only; cluster luôn db=0)
+tls = false
+pool_size = 4
+connect_timeout_ms = 2000
+command_timeout_ms = 500
+circuit_breaker_threshold = 5
+circuit_breaker_reset_secs = 30
+# Khi circuit open, dùng local moka làm fallback
+fallback_to_memory = true
+```
+
+### Hot-reload
+
+Config Valkey **không** hot-reload vì reconnect là operation nặng. Thay đổi backend yêu cầu restart.  
+`rules_path` (cache.yaml) vẫn hot-reload như hiện tại (CacheRuleWatcher + notify, 200ms debounce).
+
+---
+
+## Phase 6 — New API Endpoints cho Dashboard
+
+Thêm vào `crates/waf-api/src/cache_api.rs` và đăng ký trong `server.rs`:
+
+### 6.1 Backend info
+
+```
+GET /api/cache/backend
+```
+
+Response:
+```json
+{
+  "backend": "embedded",
+  "valkey_version": "7.2.4",
+  "mode": "embedded",
+  "connected": true,
+  "nodes": [
+    { "addr": "127.0.0.1:6379", "role": "master", "slots": "0-16383" }
+  ],
+  "memory_used_bytes": 12582912,
+  "memory_max_bytes": 268435456,
+  "keyspace": { "db0": { "keys": 1842, "expires": 1201 } },
+  "health": { "ok": true, "latency_us": 142 },
+  "circuit_breaker": "closed"
+}
+```
+
+### 6.2 Extended stats (bổ sung vào `/api/cache/stats`)
+
+```json
+{
+  // Hiện có
+  "hits": 98421,
+  "misses": 3211,
+  "evictions": 421,
+  "stores": 3890,
+  "entry_count": 1842,
+  "bypassed_critical": 5012,
+  "bypassed_authenticated": 8711,
+  "bypassed_explicit_deny": 2100,
+  "purges_tag": 500,
+  "purges_route": 120,
+  "tag_index_size": 312,
+
+  // Thêm mới
+  "hit_ratio": 0.968,
+  "backend": "embedded",
+  "memory_used_bytes": 12582912,
+  "memory_max_bytes": 268435456,
+  "memory_fragmentation_ratio": 1.08,
+  "valkey_ops_per_sec": 2840,
+  "connected_clients": 4,
+  "last_updated_at": "2026-05-06T10:30:00Z"
+}
+```
+
+### 6.3 Timeseries stats (polling cho chart)
+
+```
+GET /api/cache/stats/timeseries?minutes=60
+```
+
+Response: array 60 điểm, mỗi điểm:
+```json
+{
+  "ts": "2026-05-06T09:35:00Z",
+  "hits": 1240,
+  "misses": 38,
+  "hit_ratio": 0.97,
+  "memory_used_bytes": 11200000,
+  "stores": 42
+}
+```
+
+Lưu timeseries vào in-memory ring buffer (60 × 1-min buckets) trong `CacheStats`.
+
+### 6.4 Top cached routes
+
+```
+GET /api/cache/routes/top?limit=20
+```
+
+Response:
+```json
+[
+  { "route_id": "static-assets", "hits": 45200, "misses": 120, "entry_count": 842 },
+  { "route_id": "public-catalog", "hits": 12100, "misses": 840, "entry_count": 391 }
+]
+```
+
+### 6.5 Tag listing
+
+```
+GET /api/cache/tags
+```
+
+Response:
+```json
+[
+  { "tag": "static", "entry_count": 842 },
+  { "tag": "catalog", "entry_count": 391 },
+  { "tag": "marketing", "entry_count": 98 }
+]
+```
+
+### 6.6 WebSocket stream — cache events
+
+Thêm event type `cache_event` vào `/ws/events`:
+
+```json
+{
+  "type": "cache_event",
+  "ts": "2026-05-06T10:30:00Z",
+  "event": "hit",        // "hit" | "miss" | "store" | "evict" | "purge_tag" | "purge_route"
+  "key_prefix": "GET:example.com:/catalog/",
+  "route_id": "public-catalog",
+  "ttl_secs": 300
+}
+```
+
+Emit sampling 1% events để không flood WebSocket.
+
+---
+
+## Phase 7 — Vue 3 Cache Dashboard
+
+### 7.1 Route mới
+
+```
+/admin-panel/dashboards/cache
+```
+
+Thêm vào `web/admin-ui/src/router/index.ts`:
+
+```ts
+{
+  path: '/dashboards/cache',
+  component: () => import('../views/dashboards/CacheDashboard.vue'),
+  meta: { requiresAuth: true }
+}
+```
+
+Thêm menu item trong `Layout.vue` sidebar dưới mục "Dashboards".
+
+### 7.2 API module mới
+
+**`web/admin-ui/src/api/cache.ts`**
+
+```typescript
+import api from './index'
+
+export interface CacheStats { /* map từ Phase 6.2 */ }
+export interface CacheBackendInfo { /* map từ Phase 6.1 */ }
+export interface CacheTimeseriesPoint { /* map từ Phase 6.3 */ }
+export interface TopRoute { /* map từ Phase 6.4 */ }
+export interface TagEntry { /* map từ Phase 6.5 */ }
+
+export const cacheApi = {
+  stats: ()          => api.get<CacheStats>('/api/cache/stats'),
+  backend: ()        => api.get<CacheBackendInfo>('/api/cache/backend'),
+  timeseries: (m=60) => api.get<CacheTimeseriesPoint[]>(`/api/cache/stats/timeseries?minutes=${m}`),
+  topRoutes: (n=20)  => api.get<TopRoute[]>(`/api/cache/routes/top?limit=${n}`),
+  tags: ()           => api.get<TagEntry[]>('/api/cache/tags'),
+  purgeTag: (tag: string)       => api.post('/api/cache/purge/tag', { tag }),
+  purgeRoute: (route_id: string) => api.post('/api/cache/purge/route', { route_id }),
+  flush: ()          => api.delete('/api/cache'),
+  purgeHost: (host: string) => api.delete(`/api/cache/host/${host}`),
+}
+```
+
+### 7.3 View: `CacheDashboard.vue`
+
+#### Layout tổng thể
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Header: "Cache Dashboard"  [Backend: embedded ●]  [Refresh]     │
+├──────────┬──────────┬──────────┬──────────────────────────────  │
+│ Hit Ratio│  Entries │Mem Used  │ Ops/sec                        │ ← KPI row
+│  96.8%   │   1,842  │ 12.0 MB  │  2,840                         │
+├──────────┴──────────┴──────────┴──────────────────────────────  │
+│                                                                   │
+│  [Hit/Miss Timeline — 60 min area chart]                         │ ← Chart row
+│                                                                   │
+├────────────────────────┬────────────────────────────────────────┤
+│ Top Cached Routes      │ Tag Distribution (donut)               │
+│ ─────────────────────  │ ────────────────────────────────────── │
+│ static-assets  45.2k   │  static 45%  catalog 21%  ...          │
+│ public-catalog 12.1k   │                                         │
+│ [Purge] button each    │                                         │
+├────────────────────────┴────────────────────────────────────────┤
+│ Backend Info                                                      │
+│  Mode: embedded   Version: 7.2.4   Circuit: ● Closed             │
+│  Memory: ████████░░░░░  12 MB / 256 MB  (4.7%)                   │
+│  Nodes: [table nếu cluster]                                       │
+├─────────────────────────────────────────────────────────────────┤
+│ Actions: [Purge by Tag ▼] [Purge by Route ▼] [Flush All Cache]  │
+├─────────────────────────────────────────────────────────────────┤
+│ Live Cache Events (WebSocket stream, 50 entries ring buffer)     │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+#### Polling intervals
+
+| Data | Interval |
+|------|----------|
+| KPI stats | 5s |
+| Backend info | 15s |
+| Timeseries | 60s |
+| Top routes | 30s |
+| Tags | 30s |
+| Live events | WebSocket push |
+
+#### Component breakdown
+
+```
+views/dashboards/CacheDashboard.vue       ← container, data fetching
+  components/cache/
+    CacheKpiRow.vue                       ← 4 KPI cards
+    CacheHitMissChart.vue                 ← recharts AreaChart (hoặc Chart.js)
+    CacheTopRoutesTable.vue               ← table + per-row Purge button
+    CacheTagDonut.vue                     ← donut chart breakdown by tag
+    CacheBackendCard.vue                  ← backend mode/version/memory bar
+    CacheActionsBar.vue                   ← purge/flush action buttons + confirm modal
+    CacheLiveEvents.vue                   ← WebSocket feed, monospace list
+```
+
+#### Valkey-specific display logic
+
+```typescript
+// Chỉ show khi backend != "memory"
+const showValkeyInfo = computed(() => stats.backend !== 'memory')
+
+// Memory bar
+const memoryPercent = computed(() =>
+  backend.memory_max_bytes > 0
+    ? (backend.memory_used_bytes / backend.memory_max_bytes * 100).toFixed(1)
+    : null
+)
+
+// Circuit breaker badge
+const circuitColor = computed(() =>
+  backend.circuit_breaker === 'closed' ? 'green'
+  : backend.circuit_breaker === 'half_open' ? 'yellow'
+  : 'red'
+)
+```
+
+#### i18n keys cần thêm (vào tất cả 11 locales)
+
+```json
+{
+  "cache": {
+    "title": "Cache Dashboard",
+    "hitRatio": "Hit Ratio",
+    "entries": "Entries",
+    "memoryUsed": "Memory Used",
+    "opsPerSec": "Ops / sec",
+    "backend": "Backend",
+    "mode": "Mode",
+    "version": "Version",
+    "circuitBreaker": "Circuit Breaker",
+    "topRoutes": "Top Cached Routes",
+    "tagDistribution": "Tag Distribution",
+    "liveEvents": "Live Cache Events",
+    "purgeTag": "Purge by Tag",
+    "purgeRoute": "Purge by Route",
+    "flushAll": "Flush All Cache",
+    "confirmFlush": "This will evict ALL cached entries. Proceed?",
+    "purged": "Purged {n} entries",
+    "backendInfo": "Backend Info",
+    "nodes": "Nodes",
+    "slots": "Slots",
+    "role": "Role",
+    "hitMissTimeline": "Hit / Miss Timeline (60 min)"
+  }
+}
+```
+
+---
+
+## Phase 8 — Tests
+
+### Unit tests (Rust)
+
+**`crates/gateway/src/cache/valkey_store_test.rs`**
+- `test_put_get_roundtrip` — store + retrieve entry
+- `test_ttl_expiry` — entry expired after TTL
+- `test_purge_by_tag` — tag set cleaned up
+- `test_circuit_breaker_trips_after_threshold` — mock Valkey failure
+- `test_fallback_to_moka_when_circuit_open` — reads from MokaStore
+
+**`crates/gateway/src/cache/embedded_test.rs`**
+- `test_embedded_spawn_and_ping` — spawn real valkey-server, PING
+- `test_embedded_kill_on_drop` — process exits when `EmbeddedValkey` dropped
+
+### Integration tests
+
+**`tests/runners/cache.sh`** — new runner:
+```bash
+# Test 1: memory backend (baseline)
+# Test 2: embedded backend — spawn, hit/miss, purge, stats
+# Test 3: standalone backend — connect to test Redis, same ops
+# Test 4: cluster backend — 3-node cluster, topology discovery
+# Test 5: circuit breaker — kill Valkey, assert fallback active
+```
+
+### E2E — dashboard smoke test
+
+Thêm vào `tests/runners/api.sh`:
+```bash
+# GET /api/cache/backend — 200, json has "backend" field
+# GET /api/cache/stats   — includes new "hit_ratio", "memory_used_bytes"
+# GET /api/cache/stats/timeseries?minutes=5 — array
+# GET /api/cache/routes/top — array
+# GET /api/cache/tags — array
+```
+
+---
+
+## Dependency changes
+
+### `crates/gateway/Cargo.toml`
+
+```toml
+# Valkey / Redis async client (cluster-aware, TLS, connection pool)
+fred = { version = "9", features = [
+    "cluster-discovery",
+    "pool-prefer-active",
+    "tls-rustls-native-certs",
+    "monitor",
+], optional = true }
+
+[features]
+default = []
+valkey = ["dep:fred"]
+```
+
+Feature `valkey` mặc định **disabled** trong CI build thuần memory, **enabled** khi build production binary (Dockerfile).
+
+### `web/admin-ui/package.json`
+
+Không cần thêm dependency mới — dùng `axios` (có sẵn) cho API calls, `Chart.js` hoặc `recharts` cho charts (cả 2 đã có trong codebase theo codebase-summary.md).
+
+---
+
+## Docker & Deployment changes
+
+### `docker-compose.yml` (single-node)
+
+```yaml
+services:
+  prx-waf:
+    environment:
+      # Embedded mode: không cần service riêng
+      CACHE_BACKEND: embedded
+    volumes:
+      - ./configs/default.toml:/app/configs/default.toml
+```
+
+### `docker-compose.cluster.yml` (3-node cluster)
+
+```yaml
+services:
+  valkey-1:
+    image: valkey/valkey:8-alpine
+    command: >
+      valkey-server
+        --cluster-enabled yes
+        --cluster-config-file /data/nodes.conf
+        --cluster-node-timeout 5000
+        --appendonly no
+        --maxmemory 512mb
+        --maxmemory-policy allkeys-lru
+    ports: ["6379:6379"]
+
+  valkey-2:
+    image: valkey/valkey:8-alpine
+    command: >
+      valkey-server
+        --cluster-enabled yes
+        --cluster-config-file /data/nodes.conf
+        --cluster-node-timeout 5000
+        --appendonly no
+        --maxmemory 512mb
+        --maxmemory-policy allkeys-lru
+    ports: ["6380:6379"]
+
+  valkey-3:
+    image: valkey/valkey:8-alpine
+    command: >
+      valkey-server
+        --cluster-enabled yes
+        --cluster-config-file /data/nodes.conf
+        --cluster-node-timeout 5000
+        --appendonly no
+        --maxmemory 512mb
+        --maxmemory-policy allkeys-lru
+    ports: ["6381:6379"]
+
+  valkey-init:
+    image: valkey/valkey:8-alpine
+    depends_on: [valkey-1, valkey-2, valkey-3]
+    command: >
+      sh -c "sleep 2 && valkey-cli --cluster create
+        valkey-1:6379 valkey-2:6379 valkey-3:6379
+        --cluster-replicas 0 --cluster-yes"
+    restart: "no"
+
+  prx-waf:
+    environment:
+      CACHE_BACKEND: cluster
+    # default.toml mount với [cache.valkey] seeds = ["valkey-1:6379", ...]
+```
+
+---
+
+## Config mẫu hoàn chỉnh
+
+### `default.toml` (embedded mode)
+
+```toml
+[cache]
+enabled = true
+max_size_mb = 256
+default_ttl_secs = 60
+max_ttl_secs = 3600
+rules_path = "rules/cache.yaml"
+backend = "embedded"
+
+[cache.embedded]
+binary_path = ""    # auto-detect
+data_dir = "/tmp/prx-valkey"
+```
+
+### `default.toml` (standalone mode)
+
+```toml
+[cache]
+enabled = true
+max_size_mb = 256
+default_ttl_secs = 60
+max_ttl_secs = 3600
+rules_path = "rules/cache.yaml"
+backend = "standalone"
+
+[cache.valkey]
+mode = "standalone"
+seeds = ["127.0.0.1:6379"]
+password = ""
+pool_size = 4
+connect_timeout_ms = 2000
+command_timeout_ms = 500
+circuit_breaker_threshold = 5
+circuit_breaker_reset_secs = 30
+fallback_to_memory = true
+```
+
+### `default.toml` (cluster mode)
+
+```toml
+[cache]
+enabled = true
+max_size_mb = 256
+default_ttl_secs = 60
+max_ttl_secs = 3600
+rules_path = "rules/cache.yaml"
+backend = "cluster"
+
+[cache.valkey]
+mode = "cluster"
+seeds = ["10.0.1.1:6379", "10.0.1.2:6379", "10.0.1.3:6379"]
+password = ""
+tls = true
+tls_ca_cert  = "/etc/prx-waf/tls/valkey-ca.pem"
+pool_size = 4
+connect_timeout_ms = 2000
+command_timeout_ms = 500
+circuit_breaker_threshold = 5
+circuit_breaker_reset_secs = 30
+fallback_to_memory = true
+```
+
+---
+
+## Checklist tổng thể
+
+### Rust backend
+- [ ] P1: `CacheBackend` trait + `BackendHealth` struct
+- [ ] P1: Refactor `store.rs` → `MokaStore` impl trait
+- [ ] P2: `ValkeyStore` (fred client, standalone + cluster via mode flag)
+- [ ] P2: Key/tag scheme (`prx:cache:*`, `prx:tag:*`, `prx:key_tags:*`)
+- [ ] P2: `CircuitBreakerStore` wrapper + fallback logic
+- [ ] P3: `EmbeddedValkey` supervisor (spawn, wait_ready, kill_on_drop)
+- [ ] P4: Cluster topology discovery + MOVED/ASK handling (handled by fred)
+- [ ] P5: TOML config structs (`EmbeddedValkeyConfig`, `ValkeyConfig`)
+- [ ] P5: `CacheConfig` extended với `backend` discriminant
+- [ ] P6: `GET /api/cache/backend` endpoint
+- [ ] P6: Extend `GET /api/cache/stats` với memory/ops fields
+- [ ] P6: `GET /api/cache/stats/timeseries` + ring buffer
+- [ ] P6: `GET /api/cache/routes/top`
+- [ ] P6: `GET /api/cache/tags`
+- [ ] P6: WebSocket `cache_event` type (1% sampling)
+- [ ] P8: Unit tests ValkeyStore
+- [ ] P8: Unit tests CircuitBreaker
+- [ ] P8: Integration test embedded spawn
+- [ ] P8: Integration test cluster
+
+### Vue 3 frontend
+- [ ] P7: Route `/dashboards/cache` + sidebar menu item
+- [ ] P7: `api/cache.ts` module với tất cả 7 endpoints
+- [ ] P7: `CacheDashboard.vue` container
+- [ ] P7: `CacheKpiRow.vue` — 4 KPI cards
+- [ ] P7: `CacheHitMissChart.vue` — 60-min area chart
+- [ ] P7: `CacheTopRoutesTable.vue` — table + per-row purge
+- [ ] P7: `CacheTagDonut.vue` — donut breakdown
+- [ ] P7: `CacheBackendCard.vue` — mode/version/memory bar/nodes table
+- [ ] P7: `CacheActionsBar.vue` — purge/flush actions + confirm modal
+- [ ] P7: `CacheLiveEvents.vue` — WebSocket feed
+- [ ] P7: i18n keys thêm vào 11 locales
+- [ ] P7: Polling intervals theo bảng Phase 7.3
+- [ ] P7: Valkey-specific conditional display (showValkeyInfo)
+- [ ] P8: API smoke tests cho 5 endpoints mới
+
+### DevOps
+- [ ] `docker-compose.yml` — env var `CACHE_BACKEND=embedded`
+- [ ] `docker-compose.cluster.yml` — valkey-1/2/3 + init container
+- [ ] Dockerfile — enable feature flag `--features valkey`
+- [ ] Docs update: `docs/system-architecture.md`, `docs/deployment-guide.md`

--- a/web/admin-panel/src/App.tsx
+++ b/web/admin-panel/src/App.tsx
@@ -42,6 +42,7 @@ import { ClusterOverviewPage } from "./pages/cluster/overview";
 import { ClusterNodeDetailPage } from "./pages/cluster/node-detail";
 import { ClusterTokensPage } from "./pages/cluster/tokens";
 import { ClusterSyncPage } from "./pages/cluster/sync";
+import { CacheDashboardPage } from "./pages/cache";
 
 // Each Refine `resource` is what binds list/create/edit/delete pages,
 // the data provider, and the navigation system. Path on resource is what
@@ -67,6 +68,7 @@ const resources = [
   { name: "cluster", list: "/cluster" },
   { name: "cluster-tokens", list: "/cluster/tokens" },
   { name: "cluster-sync", list: "/cluster/sync" },
+  { name: "cache", list: "/cache" },
 ];
 
 export const App: React.FC = () => {
@@ -130,6 +132,7 @@ export const App: React.FC = () => {
                   <Route path="/cluster/nodes/:id" element={<ClusterNodeDetailPage />} />
                   <Route path="/cluster/tokens" element={<ClusterTokensPage />} />
                   <Route path="/cluster/sync" element={<ClusterSyncPage />} />
+                  <Route path="/cache" element={<CacheDashboardPage />} />
                   <Route path="*" element={<ErrorComponent />} />
                 </Route>
 

--- a/web/admin-panel/src/i18n/locales/en.json
+++ b/web/admin-panel/src/i18n/locales/en.json
@@ -22,7 +22,9 @@
     "rules": "Rules",
     "ruleManager": "Rule Manager",
     "ruleSources": "Rule Sources",
-    "botDetection": "Bot Detection"
+    "botDetection": "Bot Detection",
+    "cache": "Cache",
+    "cacheDashboard": "Cache Dashboard"
   },
   "common": {
     "save": "Save",
@@ -461,5 +463,35 @@
     "syncInSync": "In sync",
     "syncDriftAlert": "Rules version drift detected",
     "syncNoCluster": "Cluster not enabled"
+  },
+  "cache": {
+    "title": "Cache Dashboard",
+    "subtitle": "Real-time cache performance metrics",
+    "hitRatio": "Hit Ratio",
+    "entries": "Entries",
+    "opsPerSec": "Ops / sec",
+    "tagIndex": "Tag index (keys)",
+    "memoryUsed": "Memory Used",
+    "backend": "Backend",
+    "mode": "Mode",
+    "version": "Version",
+    "connected": "Connected",
+    "circuitBreaker": "Circuit Breaker",
+    "topRoutes": "Top Cached Routes",
+    "backendInfo": "Backend Info",
+    "hitMissTimeline": "Hit / Miss Timeline (60 min)",
+    "hits": "Hits",
+    "misses": "Misses",
+    "nodes": "Nodes",
+    "role": "Role",
+    "slots": "Slots",
+    "actions": "Cache Actions",
+    "purgeTag": "Purge by Tag",
+    "purgeRoute": "Purge by Route",
+    "flushAll": "Flush All Cache",
+    "confirmFlush": "This will evict ALL cached entries. Proceed?",
+    "purged": "Purged {{n}} entries",
+    "flushed": "Cache flushed",
+    "purgeError": "Operation failed"
   }
 }

--- a/web/admin-panel/src/i18n/locales/vi.json
+++ b/web/admin-panel/src/i18n/locales/vi.json
@@ -22,7 +22,9 @@
     "rules": "Luật",
     "ruleManager": "Quản lý luật",
     "ruleSources": "Nguồn luật",
-    "botDetection": "Phát hiện bot"
+    "botDetection": "Phát hiện bot",
+    "cache": "Cache",
+    "cacheDashboard": "Bảng điều khiển Cache"
   },
   "common": {
     "save": "Lưu",
@@ -461,5 +463,35 @@
     "syncInSync": "Đồng bộ",
     "syncDriftAlert": "Phát hiện lệch version luật",
     "syncNoCluster": "Cluster chưa bật"
+  },
+  "cache": {
+    "title": "Bảng điều khiển Cache",
+    "subtitle": "Chỉ số hiệu suất cache thời gian thực",
+    "hitRatio": "Tỷ lệ hit",
+    "entries": "Số bản ghi",
+    "opsPerSec": "Ops/giây",
+    "tagIndex": "Chỉ mục tag (số khóa)",
+    "memoryUsed": "Bộ nhớ dùng",
+    "backend": "Backend",
+    "mode": "Chế độ",
+    "version": "Phiên bản",
+    "connected": "Kết nối",
+    "circuitBreaker": "Circuit Breaker",
+    "topRoutes": "Route được cache nhiều nhất",
+    "backendInfo": "Thông tin Backend",
+    "hitMissTimeline": "Biểu đồ Hit/Miss (60 phút)",
+    "hits": "Hit",
+    "misses": "Miss",
+    "nodes": "Nodes",
+    "role": "Vai trò",
+    "slots": "Slots",
+    "actions": "Thao tác Cache",
+    "purgeTag": "Xoá theo Tag",
+    "purgeRoute": "Xoá theo Route",
+    "flushAll": "Xoá toàn bộ Cache",
+    "confirmFlush": "Thao tác này sẽ xoá TẤT CẢ cache. Tiếp tục?",
+    "purged": "Đã xoá {{n}} bản ghi",
+    "flushed": "Đã xoá toàn bộ cache",
+    "purgeError": "Thao tác thất bại"
   }
 }

--- a/web/admin-panel/src/i18n/locales/zh.json
+++ b/web/admin-panel/src/i18n/locales/zh.json
@@ -22,7 +22,9 @@
     "rules": "规则",
     "ruleManager": "规则管理",
     "ruleSources": "规则源",
-    "botDetection": "机器人检测"
+    "botDetection": "机器人检测",
+    "cache": "缓存",
+    "cacheDashboard": "缓存仪表盘"
   },
   "common": {
     "save": "保存",
@@ -414,5 +416,35 @@
     "syncInSync": "已同步",
     "syncDriftAlert": "检测到规则版本差异",
     "syncNoCluster": "集群未启用"
+  },
+  "cache": {
+    "title": "缓存仪表盘",
+    "subtitle": "实时缓存性能指标",
+    "hitRatio": "命中率",
+    "entries": "缓存条目",
+    "opsPerSec": "每秒操作数",
+    "tagIndex": "标签索引（键数）",
+    "memoryUsed": "内存使用",
+    "backend": "后端",
+    "mode": "模式",
+    "version": "版本",
+    "connected": "已连接",
+    "circuitBreaker": "熔断器",
+    "topRoutes": "热门缓存路由",
+    "backendInfo": "后端信息",
+    "hitMissTimeline": "命中/未命中时间线（60分钟）",
+    "hits": "命中",
+    "misses": "未命中",
+    "nodes": "节点",
+    "role": "角色",
+    "slots": "槽位",
+    "actions": "缓存操作",
+    "purgeTag": "按标签清除",
+    "purgeRoute": "按路由清除",
+    "flushAll": "清空全部缓存",
+    "confirmFlush": "此操作将清除所有缓存条目，确认继续？",
+    "purged": "已清除 {{n}} 条记录",
+    "flushed": "缓存已清空",
+    "purgeError": "操作失败"
   }
 }

--- a/web/admin-panel/src/pages/cache/index.tsx
+++ b/web/admin-panel/src/pages/cache/index.tsx
@@ -1,0 +1,518 @@
+import {
+  Row, Col, Card, Statistic, Button, Typography, Space, Table,
+  Progress, Tag, Input, Modal, message, Divider,
+} from "antd";
+import {
+  ReloadOutlined, ThunderboltOutlined, DatabaseOutlined,
+  HddOutlined, PercentageOutlined, DeleteOutlined, ClearOutlined,
+  TagsOutlined,
+} from "@ant-design/icons";
+import { useCustom, useApiUrl } from "@refinedev/core";
+import { useTranslation } from "react-i18next";
+import { Line } from "@ant-design/plots";
+import { useMemo, useState } from "react";
+import dayjs from "dayjs";
+import { httpClient } from "../../utils/axios";
+
+const { Title, Text } = Typography;
+
+// ── API types ─────────────────────────────────────────────────────────────────
+
+interface CacheStats {
+  hit_ratio?: number;
+  entry_count?: number;
+  hits?: number;
+  misses?: number;
+  stores?: number;
+  evictions?: number;
+  memory_used_bytes?: number;
+  backend?: string;
+  valkey_ops_per_sec?: number;
+  tag_index_size?: number;
+}
+
+interface BackendInfo {
+  backend?: string;
+  valkey_version?: string;
+  connected?: boolean;
+  circuit_breaker?: string;
+  memory_used_bytes?: number;
+  memory_max_bytes?: number;
+  nodes?: { addr: string; role: string; slots: string }[];
+}
+
+interface TsBucket {
+  ts: string;
+  hits: number;
+  misses: number;
+  hit_ratio: number;
+}
+
+interface RouteRow {
+  route_id: string;
+  hits: number;
+  entry_count: number;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function fmtBytes(n?: number): string {
+  if (!n) return "—";
+  if (n >= 1_073_741_824) return `${(n / 1_073_741_824).toFixed(1)} GB`;
+  if (n >= 1_048_576) return `${(n / 1_048_576).toFixed(1)} MB`;
+  if (n >= 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${n} B`;
+}
+
+function fmtNum(n?: number): string {
+  if (n === undefined || n === null) return "—";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+function circuitColor(cb?: string): string {
+  if (cb === "closed") return "success";
+  if (cb === "half_open") return "warning";
+  if (cb === "open") return "error";
+  return "default";
+}
+
+/** Normalize Refine `useCustom` payloads across data-provider / version differences. */
+function refineCustomData<T>(h: {
+  data?: T;
+  result?: { data?: T };
+}): T | undefined {
+  return h.data ?? h.result?.data;
+}
+
+function refineCustomRefetch(h: {
+  query?: { refetch?: () => unknown };
+  refetch?: () => void;
+}): void {
+  void h.query?.refetch?.();
+  void h.refetch?.();
+}
+
+function refineCustomLoading(h: {
+  isLoading?: boolean;
+  query?: { isLoading?: boolean; isFetching?: boolean };
+}): { isLoading: boolean; isFetching: boolean } {
+  return {
+    isLoading: h.isLoading ?? h.query?.isLoading ?? false,
+    isFetching: h.query?.isFetching ?? false,
+  };
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export const CacheDashboardPage: React.FC = () => {
+  const { t } = useTranslation();
+  const apiUrl = useApiUrl();
+  const [purgeTagVal, setPurgeTagVal] = useState("");
+  const [purgeRouteVal, setPurgeRouteVal] = useState("");
+  const [flushModal, setFlushModal] = useState(false);
+  const [acting, setActing] = useState(false);
+  // ── Data fetching (each at its own interval) ───────────────────────────────
+
+  const statsQ = useCustom<CacheStats>({
+    url: `${apiUrl}/cache/stats`,
+    method: "get",
+    queryOptions: { staleTime: 4_000, refetchInterval: 5_000 },
+  });
+
+  const backendQ = useCustom<BackendInfo>({
+    url: `${apiUrl}/cache/backend`,
+    method: "get",
+    queryOptions: { staleTime: 14_000, refetchInterval: 15_000 },
+  });
+
+  const tsQ = useCustom<TsBucket[]>({
+    url: `${apiUrl}/cache/stats/timeseries`,
+    method: "get",
+    config: { query: { minutes: 60 } },
+    queryOptions: { staleTime: 59_000, refetchInterval: 60_000 },
+  });
+
+  const routesQ = useCustom<RouteRow[]>({
+    url: `${apiUrl}/cache/routes/top`,
+    method: "get",
+    config: { query: { limit: 20 } },
+    queryOptions: { staleTime: 29_000, refetchInterval: 30_000 },
+  });
+
+  const stats = refineCustomData(statsQ);
+  const backend = refineCustomData(backendQ);
+  const rawTs = refineCustomData(tsQ);
+  const routesRaw = refineCustomData(routesQ);
+  // Defensive: useCustom can return an envelope object instead of a plain array
+  // if the data-provider wrapping changes; Array.isArray guards against that.
+  const routes = Array.isArray(routesRaw) ? routesRaw : [];
+
+  // Flatten timeseries into long-form for @ant-design/plots Line.
+  // `Number(...) || 0` matches TrafficChart's pattern — guards against null/NaN
+  // that would cause @ant-design/plots to crash in its internal useMemo.
+  const tsData = useMemo(() => {
+    const arr = Array.isArray(rawTs) ? rawTs : [];
+    const out: { ts: string; value: number; series: string }[] = [];
+    for (const b of arr) {
+      const label = dayjs(b.ts).format("HH:mm");
+      out.push({ ts: label, value: Number(b.hits) || 0, series: t("cache.hits") });
+      out.push({ ts: label, value: Number(b.misses) || 0, series: t("cache.misses") });
+    }
+    return out;
+  }, [rawTs, t]);
+
+  const memPct = useMemo(() => {
+    if (!backend?.memory_used_bytes || !backend?.memory_max_bytes) return null;
+    return Math.min(100, (backend.memory_used_bytes / backend.memory_max_bytes) * 100);
+  }, [backend]);
+
+  /** In-process Moka has no Valkey `INFO`; show tag-index depth instead of ops/sec. */
+  const fourthKpiIsTagIndex = stats?.backend === "memory";
+
+  const { isLoading, isFetching } = refineCustomLoading(statsQ);
+
+  function refetchAll() {
+    refineCustomRefetch(statsQ);
+    refineCustomRefetch(backendQ);
+    refineCustomRefetch(tsQ);
+    refineCustomRefetch(routesQ);
+  }
+
+  // ── Actions ───────────────────────────────────────────────────────────────
+
+  async function doPurgeTag() {
+    const tag = purgeTagVal.trim();
+    if (!tag) return;
+    setActing(true);
+    try {
+      const r = await httpClient.post("/api/cache/purge/tag", { tag });
+      message.success(t("cache.purged", { n: r.data?.purged ?? 0 }));
+      setPurgeTagVal("");
+      refineCustomRefetch(statsQ);
+    } catch {
+      message.error(t("cache.purgeError"));
+    } finally {
+      setActing(false);
+    }
+  }
+
+  async function doPurgeRoute(routeId: string) {
+    setActing(true);
+    try {
+      const r = await httpClient.post("/api/cache/purge/route", { route_id: routeId });
+      message.success(t("cache.purged", { n: r.data?.purged ?? 0 }));
+      refineCustomRefetch(statsQ);
+      refineCustomRefetch(routesQ);
+    } catch {
+      message.error(t("cache.purgeError"));
+    } finally {
+      setActing(false);
+    }
+  }
+
+  async function doPurgeRouteInput() {
+    const route = purgeRouteVal.trim();
+    if (!route) return;
+    await doPurgeRoute(route);
+    setPurgeRouteVal("");
+  }
+
+  async function doFlush() {
+    setFlushModal(false);
+    setActing(true);
+    try {
+      await httpClient.delete("/api/cache");
+      message.success(t("cache.flushed"));
+      refetchAll();
+    } catch {
+      message.error(t("cache.purgeError"));
+    } finally {
+      setActing(false);
+    }
+  }
+
+  // ── Route columns ─────────────────────────────────────────────────────────
+
+  const routeColumns = [
+    {
+      title: "Route",
+      dataIndex: "route_id",
+      key: "route_id",
+      render: (v: string) => <Text code style={{ fontSize: 12 }}>{v}</Text>,
+    },
+    {
+      title: t("cache.hits"),
+      dataIndex: "hits",
+      key: "hits",
+      align: "right" as const,
+      render: (v: number) => fmtNum(v),
+    },
+    {
+      title: t("cache.entries"),
+      dataIndex: "entry_count",
+      key: "entry_count",
+      align: "right" as const,
+      render: (v: number) => fmtNum(v),
+    },
+    {
+      title: "",
+      key: "action",
+      align: "right" as const,
+      render: (_: unknown, row: RouteRow) => (
+        <Button
+          size="small"
+          danger
+          icon={<DeleteOutlined />}
+          loading={acting}
+          onClick={() => doPurgeRoute(row.route_id)}
+        >
+          {t("cache.purgeRoute")}
+        </Button>
+      ),
+    },
+  ];
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+      {/* Header */}
+      <Space style={{ width: "100%", justifyContent: "space-between" }}>
+        <div>
+          <Title level={4} style={{ margin: 0 }}>{t("cache.title")}</Title>
+          <Text type="secondary" style={{ fontSize: 12 }}>{t("cache.subtitle")}</Text>
+        </div>
+        <Button
+          icon={<ReloadOutlined spin={isFetching} />}
+          onClick={refetchAll}
+          loading={isLoading}
+          type="primary"
+        >
+          {t("common.refresh")}
+        </Button>
+      </Space>
+
+      {/* KPI row */}
+      <Row gutter={[16, 16]}>
+        <Col xs={12} sm={6}>
+          <Card>
+            <Statistic
+              title={t("cache.hitRatio")}
+              value={stats?.hit_ratio != null ? (stats.hit_ratio * 100).toFixed(1) : "—"}
+              suffix={stats?.hit_ratio != null ? "%" : ""}
+              prefix={<PercentageOutlined />}
+              valueStyle={{ color: "#52c41a" }}
+            />
+          </Card>
+        </Col>
+        <Col xs={12} sm={6}>
+          <Card>
+            <Statistic
+              title={t("cache.entries")}
+              value={stats?.entry_count != null ? fmtNum(stats.entry_count) : "—"}
+              prefix={<DatabaseOutlined />}
+              valueStyle={{ color: "#1677ff" }}
+            />
+          </Card>
+        </Col>
+        <Col xs={12} sm={6}>
+          <Card>
+            <Statistic
+              title={t("cache.memoryUsed")}
+              value={fmtBytes(stats?.memory_used_bytes)}
+              prefix={<HddOutlined />}
+              valueStyle={{ color: "#722ed1" }}
+            />
+          </Card>
+        </Col>
+        <Col xs={12} sm={6}>
+          <Card>
+            <Statistic
+              title={fourthKpiIsTagIndex ? t("cache.tagIndex") : t("cache.opsPerSec")}
+              value={
+                fourthKpiIsTagIndex
+                  ? (stats?.tag_index_size != null ? fmtNum(stats.tag_index_size) : "—")
+                  : (stats?.valkey_ops_per_sec != null ? fmtNum(stats.valkey_ops_per_sec) : "—")
+              }
+              prefix={fourthKpiIsTagIndex ? <TagsOutlined /> : <ThunderboltOutlined />}
+              valueStyle={{ color: fourthKpiIsTagIndex ? "#13c2c2" : "#fa8c16" }}
+            />
+          </Card>
+        </Col>
+      </Row>
+
+      {/* Hit / Miss timeline chart */}
+      <Card title={t("cache.hitMissTimeline")}>
+        {tsData.length > 0 ? (
+          <Line
+            data={tsData}
+            xField="ts"
+            yField="value"
+            seriesField="series"
+            height={220}
+            smooth
+            animate={false}
+            color={["#52c41a", "#f5222d"]}
+            point={{ size: 2 }}
+            xAxis={{ tickCount: 6 }}
+          />
+        ) : (
+          <div style={{ height: 220, display: "flex", alignItems: "center", justifyContent: "center" }}>
+            <Text type="secondary">{t("common.noData")}</Text>
+          </div>
+        )}
+      </Card>
+
+      <Row gutter={[16, 16]}>
+        {/* Top routes table */}
+        <Col xs={24} lg={14}>
+          <Card title={t("cache.topRoutes")}>
+            <Table
+              dataSource={routes}
+              columns={routeColumns}
+              rowKey="route_id"
+              size="small"
+              pagination={false}
+              locale={{ emptyText: t("common.noData") }}
+            />
+          </Card>
+        </Col>
+
+        {/* Backend info */}
+        <Col xs={24} lg={10}>
+          <Card title={t("cache.backendInfo")}>
+            <Space direction="vertical" size={12} style={{ width: "100%" }}>
+              <Row gutter={8}>
+                <Col span={12}>
+                  <Text type="secondary">{t("cache.mode")}</Text>
+                  <br />
+                  <Text strong style={{ textTransform: "capitalize" }}>{backend?.backend ?? "—"}</Text>
+                </Col>
+                <Col span={12}>
+                  <Text type="secondary">{t("cache.version")}</Text>
+                  <br />
+                  <Text code>{backend?.valkey_version ?? "—"}</Text>
+                </Col>
+              </Row>
+
+              <Row gutter={8}>
+                <Col span={12}>
+                  <Text type="secondary">{t("cache.circuitBreaker")}</Text>
+                  <br />
+                  <Tag color={circuitColor(backend?.circuit_breaker)}>
+                    {backend?.circuit_breaker ?? "—"}
+                  </Tag>
+                </Col>
+                <Col span={12}>
+                  <Text type="secondary">{t("cache.connected")}</Text>
+                  <br />
+                  <Tag color={backend?.connected ? "success" : "error"}>
+                    {backend?.connected ? "✓" : "✗"}
+                  </Tag>
+                </Col>
+              </Row>
+
+              {/* Memory progress bar */}
+              {memPct !== null && (
+                <div>
+                  <Text type="secondary">{t("cache.memoryUsed")}</Text>
+                  <br />
+                  <Text style={{ fontSize: 12 }}>
+                    {fmtBytes(backend?.memory_used_bytes)} / {fmtBytes(backend?.memory_max_bytes)}
+                  </Text>
+                  <Progress
+                    percent={parseFloat(memPct.toFixed(1))}
+                    size="small"
+                    status={memPct > 80 ? "exception" : memPct > 60 ? "active" : "normal"}
+                    style={{ marginTop: 4 }}
+                  />
+                </div>
+              )}
+
+              {/* Cluster nodes table */}
+              {backend?.nodes && backend.nodes.length > 0 && (
+                <>
+                  <Divider style={{ margin: "8px 0" }} />
+                  <Text type="secondary">{t("cache.nodes")}</Text>
+                  <Table
+                    dataSource={backend.nodes}
+                    rowKey="addr"
+                    size="small"
+                    pagination={false}
+                    columns={[
+                      { title: t("cache.nodes"), dataIndex: "addr", render: (v: string) => <Text code style={{ fontSize: 11 }}>{v}</Text> },
+                      { title: t("cache.role"), dataIndex: "role", render: (v: string) => <Tag>{v}</Tag> },
+                      { title: t("cache.slots"), dataIndex: "slots" },
+                    ]}
+                  />
+                </>
+              )}
+            </Space>
+          </Card>
+        </Col>
+      </Row>
+
+      {/* Actions bar */}
+      <Card title={t("cache.actions")}>
+        <Space wrap size={12}>
+          <Space.Compact>
+            <Input
+              value={purgeTagVal}
+              onChange={e => setPurgeTagVal(e.target.value)}
+              placeholder={t("cache.purgeTag")}
+              style={{ width: 180 }}
+              onPressEnter={doPurgeTag}
+            />
+            <Button
+              onClick={doPurgeTag}
+              disabled={!purgeTagVal.trim()}
+              loading={acting}
+            >
+              {t("cache.purgeTag")}
+            </Button>
+          </Space.Compact>
+
+          <Space.Compact>
+            <Input
+              value={purgeRouteVal}
+              onChange={e => setPurgeRouteVal(e.target.value)}
+              placeholder={t("cache.purgeRoute")}
+              style={{ width: 180 }}
+              onPressEnter={doPurgeRouteInput}
+            />
+            <Button
+              onClick={doPurgeRouteInput}
+              disabled={!purgeRouteVal.trim()}
+              loading={acting}
+            >
+              {t("cache.purgeRoute")}
+            </Button>
+          </Space.Compact>
+
+          <Button
+            danger
+            icon={<ClearOutlined />}
+            onClick={() => setFlushModal(true)}
+            loading={acting}
+          >
+            {t("cache.flushAll")}
+          </Button>
+        </Space>
+      </Card>
+
+      {/* Flush confirm modal */}
+      <Modal
+        title={t("cache.flushAll")}
+        open={flushModal}
+        onOk={doFlush}
+        onCancel={() => setFlushModal(false)}
+        okText={t("cache.flushAll")}
+        okButtonProps={{ danger: true }}
+      >
+        <Text>{t("cache.confirmFlush")}</Text>
+      </Modal>
+    </Space>
+  );
+};

--- a/web/admin-panel/src/utils/nav-items.ts
+++ b/web/admin-panel/src/utils/nav-items.ts
@@ -19,6 +19,7 @@ import {
   BookOutlined,
   BranchesOutlined,
   RobotOutlined,
+  ThunderboltOutlined,
 } from "@ant-design/icons";
 import type { ComponentType } from "react";
 
@@ -55,4 +56,6 @@ export const navItems: NavItem[] = [
   { key: "rules-management", i18nKey: "nav.ruleManager", path: "/rules-management", icon: BookOutlined, section: "nav.rules" },
   { key: "rule-sources", i18nKey: "nav.ruleSources", path: "/rule-sources", icon: BranchesOutlined, section: "nav.rules" },
   { key: "bot-management", i18nKey: "nav.botDetection", path: "/bot-management", icon: RobotOutlined, section: "nav.rules" },
+
+  { key: "cache", i18nKey: "nav.cacheDashboard", path: "/cache", icon: ThunderboltOutlined, section: "nav.cache" },
 ];


### PR DESCRIPTION
## 1. Response cache thông minh (FR-009): backend & vận hành

- **Chọn backend cache** (`memory` \| `embedded` \| `standalone` \| `cluster`) qua TOML; có **ghi đè env `CACHE_BACKEND`** khi load config (Compose/K8s không cần sửa file).
- **`memory`**: LRU Moka trong process (mặc định để dev chạy được không cần Valkey).
- **`standalone` / `cluster`**: client async **`fred`** tới Valkey/Redis; lưu payload JSON + body base64; **tag / route purge** qua các key `prx:tag:*`, `prx:key_tags:*`; **circuit breaker** + fallback Moka khi Valkey lỗi liên tiếp.
- **`embedded`**: spawn **`valkey-server`** con qua UNIX socket, tự dọn lifecycle; Dockerfile **bundle binary** Valkey và build với **`gateway/valkey`**.
- **`ResponseCache`** tách thành **facade + `CacheBackend`**: thống kê (hit/miss, bypass, purge), **timeseries phút**, **top route**, **backend info** (health, memory, ops, …).

---

## 2. Luồng proxy: đọc/ghi cache thật trên gateway

- **GET** không CRITICAL-tier, trong điều kiện code (không Authorization, không cookie): có thể **trả luôn từ cache** nếu trúng key.
- **Miss**: buffer response upstream (giới hạn kích thước body), sau khi stream xong **spawn task `put`** vào cache theo pipeline gate (tier, method, auth, route rule, Cache-Control, …).
- **Body mask** và **response cache** **loại trừ lẫn nhau** (by design): mask đổi byte nên không cache replay được.

---

## 3. API quản trị cache (dashboard)

- Mở rộng **`GET /api/cache/stats`** (hit ratio, backend, memory, ops, clients, …).
- Thêm **`GET /api/cache/backend`**, **`GET /api/cache/stats/timeseries`**, **`GET /api/cache/routes/top`**, **`GET /api/cache/tags`**.
- **Flush / purge host**: với cluster có thể kèm **cảnh báo** SCAN **best-effort theo node**.

---

## 4. Rule sources trên UI (PostgreSQL)

- API **`/api/rule-sources`** (list / create / delete / sync all / sync một nguồn) map bảng **`rule_sources`**.
- **Đồng bộ**: cập nhật `last_updated` + gọi **reload rules engine**.
- **Phạm vi**: bản ghi lưu DB và phục vụ admin UI; hook engine **đọc rule trực tiếp từ các nguồn DB** có thể là bước follow-up (tùy triển khai hiện tại trong nhánh).

---

## 5. Rule registry YAML: tránh nhầm file cấu hình khác

- Bỏ qua theo tên **`sync-config.yaml`**, **`cache.yaml`** khỏi scan WAF rules → giảm/loại warning parse kiểu `missing field 'name'`; có test chứng minh skip theo filename.

---

## 6. App state & bootstrap process

- **`AppState`** nhận **`Arc<ResponseCache>`** từ ngoài (theo `[cache]` thực tế).
- **`seed-admin`**: cache **tối thiểu (0,0,0)** — không phụ thuộc tinh chỉnh TTL/size production.
- **Background**: tick **timeseries cache** định kỳ; giữ sống **watcher `rules/cache.yaml`** và **supervisor embedded Valkey** qua shutdown guards.

---

## 7. Docker & Compose

- **`docker-compose.yml`**: service **Valkey** + env **`CACHE_BACKEND`** (Compose thường trỏ **standalone** tới container Valkey).
- **`docker-compose.valkey-cluster.yml`**: ví dụ cluster 3 node + init + WAF **`CACHE_BACKEND=cluster`**.

---

## 8. VictoriaLogs sidecar: cài binary an toàn

- Đổi tên archive staging; **`is_binary_candidate`** loại file dạng **archive** — tránh nhầm tarball là binary → **`Exec format error (ENOEXEC)`**; có regression test.

---

## 9. Toolchain / Clippy / MSRV

- Thay các **`Duration::from_mins` / `from_hours`** bằng **`from_secs`** (và `#![allow(clippy::duration_suboptimal_units)]` nơi cần) trên các module liên quan (SSL manager, CrowdSec cache/sync, API rate limit, rate limit store, relay HTTP, geoip updater tests, …).

---

## 10. Admin UI (React / Refine)

- Trang **`/cache`** (Cache Dashboard): KPI, chart hit/miss, top routes, backend info, purge tag/route, flush — i18n **en/vi/zh** và mục menu.

---

## 11. Tài liệu & kế hoạch

- **`docs/valkey-cache-guide.md`**: hướng dẫn backend, Compose, cluster, troubleshooting, API.
- **`plans/260502-2150-fr-009-smart-caching/260506-valkey-memcache.md`**: kế hoạch triển khai chi tiết.

---
