### PR TITLE
feat(gateway): FR-039 + FR-018 — circuit breaker + response dispatch wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ playwright/.cache/
 .cargo
 .opencode
 AGENTS.md
+
+# Session-local context written by ck:cook (rules.md line 3); never committed.
+/context.md
+/TODO.md
+/rules.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,157 @@ Version numbers follow [Semantic Versioning](https://semver.org/).
   Tor exit list, bad-ASN classification, and validated XFF `ctx.client_ip`
   are deferred to FR-042 and FR-007.
 
+- **FR-033 response body content filtering (NEW)** — built-in streaming
+  scanner over upstream response bodies for four leak categories: stack
+  traces (Aho-Corasick distinctive literals + line-anchored multiline
+  regex per language for Java, Python, Rust, Node, .NET, Go, PHP),
+  verbose error messages (Spring, ASP.NET, Oracle, Postgres SQL syntax
+  markers), API keys / secrets (AWS, GCP, GitHub PAT, JWT, Slack,
+  Stripe, OpenAI, Anthropic, Twilio, private-key blocks), and strict-
+  parsed internal IPv4 RFC-1918 / loopback / link-local + IPv6 ULA.
+  Single redact action — matched span replaced with `[redacted]` —
+  because Pingora `response_body_filter` cannot rewrite the status code
+  post-headers; whole-body block stays FR-005's request-time
+  responsibility. gzip decompression in a companion
+  `response_body_decompressor` module with 10000:1 bomb-ratio guard;
+  non-gzip / non-identity Content-Encoding skipped with
+  `tracing::debug!` (brotli / deflate deferred to FR-033b). ReDoS
+  bounded by construction: per-pattern `{min,max}` quantifiers,
+  `RegexBuilder::dfa_size_limit`, `Vec<Regex>` instead of `RegexSet`
+  (offsets required for span-aware redaction), no combined alternation
+  (Cloudflare 2019 outage class). `Content-Length` + `Transfer-Encoding`
+  dropped unconditionally on scanner enable to defend against framing
+  desync / response smuggling. Content-Type allowlist at
+  `response_filter` excludes `application/grpc*`, `text/event-stream`,
+  `application/octet-stream` so gRPC trailers and streaming endpoints
+  aren't corrupted. Compiled catalogs cached by `(host_name,
+  xxhash64(body_scan_*))` rather than `Arc::as_ptr` to avoid cross-host
+  pattern bleed on config reload. Filter chain order: FR-033 → FR-034 →
+  AC-17 so downstream layers see plaintext. `HostConfig` gains two opt-
+  in fields (`body_scan_enabled`, `body_scan_max_body_bytes`), both
+  `#[serde(default)]` — existing TOMLs / DB rows parse unchanged.
+  Modules: `crates/gateway/src/filters/response_body_content_scanner.rs`,
+  `crates/gateway/src/filters/response_body_decompressor.rs`. Plan:
+  `plans/260428-2311-fr-033-response-body-content-filter/`. Standards:
+  OWASP ASVS V8 / V14, API Top 10 (2023) API5 / API8, CWE-200 / 209 /
+  552, NIST SP 800-53 SI-11, PCI-DSS 3.4 / 6.5.5. 18 unit + 6
+  integration tests including chunk-boundary splits at offsets 1023 and
+  1024 per category, gzip bomb-defense, and `BodyScanState: Send`
+  compile-time check. `body_scan_hits_total` counter recorded
+  internally; `/metrics` surface wiring deferred to FR-033b once
+  `waf-api::stats` gains a generic counter registry.
+
+- **FR-034 sensitive field redaction in JSON bodies (NEW)** — per-host
+  outbound filter that masks JSON values whose keys match a configured
+  catalog before the response leaves the gateway. Six opt-in family
+  toggles on `HostConfig`: `redact_pci` (`card_number`, `cvv`, `cvc`,
+  `pin`, `expiration_date`, `cc_*`, `creditcard`), `redact_banking`
+  (`bank_account`, `account_number`, `routing_number`, `iban`, `bic`,
+  `swift_code`), `redact_identity` (`ssn`, `tax_id`, `passport_number`,
+  `driver_license`, `national_id`), `redact_secrets` (`password`,
+  `token`, `api_key`, `secret`, `client_secret`, `refresh_token`,
+  `access_token`, `private_key`), `redact_pii` (`email`,
+  `phone_number`, `dob`, `mother_maiden_name` — off by default, high
+  false-positive surface on legitimate user-listing APIs), `redact_phi`
+  (HIPAA scope: `patient_id`, `medical_record_number`, `insurance_id`,
+  `health_record`). `redact_extra_fields` extends every active family;
+  `redact_mask_token` defaults to `***REDACTED***`; `redact_max_bytes`
+  hard ceiling 256 KiB (fail-open + `tracing::warn!` on overflow);
+  `redact_case_insensitive` default `true`. Streaming dispatch in
+  `gateway::filters::response_json_field_redactor`: buffers chunks
+  until EOS or cap overflow, parses via `serde_json::from_slice`, walks
+  `Object` keys + `Array` items recursively, replaces matches in place,
+  re-serialises into `*body`. `is_noop()` short-circuit when no
+  families on AND no extras → entire filter is zero-cost. Per-host
+  `CompiledRedactor` lazy-built and cached on `WafProxy`
+  (`body_redact_cache: Arc<DashMap<usize, Arc<CompiledRedactor>>>`,
+  key `Arc::as_ptr(hc)`) mirroring the AC-17 body-mask cache.
+  `response_filter` opt-in gate: Content-Encoding identity AND
+  Content-Type JSON (`application/json`, `application/problem+json`,
+  `application/vnd.api+json` — `text/event-stream`,
+  `application/x-ndjson`, `application/xml` rejected) AND redactor is
+  non-noop; drops `Content-Length` for chunked re-encode. Composes
+  with AC-17: FR-034 emits the full redacted body on EOS, AC-17 then
+  runs over the redacted bytes in a single-chunk pass. All `redact_*`
+  toggles default `false` and `#[serde(default)]` → zero behaviour
+  change for hosts that don't opt in; existing TOMLs / DB rows parse
+  unchanged. Module:
+  `crates/gateway/src/filters/response_json_field_redactor.rs`. Plan:
+  `plans/260428-1357-GH-034-sensitive-field-redaction/`. Standards:
+  PCI-DSS Req 3.4, HIPAA §164.514(b), OWASP API Security Top 10 (2023)
+  API3:2023, CWE-200. 21 unit + 7 integration tests including AC-17
+  composition (response with both `card_number` and `10.0.0.5`-class
+  internal IPs ends with both `***REDACTED***` and `[redacted-ip]`
+  tokens, neither raw value present). Compressed-body redaction,
+  JSONPath rules, type-preserving masks, partial masks
+  (`****-****-****-1234`), and per-route policy deferred.
+
+- **FR-035 response header leak prevention (NEW)** — Pingora
+  `response_filter` hook that strips response headers leaking server
+  fingerprint, debug / internal context, error detail, or PII before
+  they reach the downstream client. Design contract: detection cases
+  live in code (`outbound::header_filter`), activation lives in
+  `[outbound.headers]` config. Built-in family toggles (default `true`
+  when outbound is on): `strip_server_info` (`Server`, `X-Powered-By`,
+  `X-AspNet-Version`); `strip_debug_headers` (`X-Debug-*`,
+  `X-Internal-*`, `X-Backend-*`); `strip_error_headers`
+  (`X-Error-Message`, `X-Exception-Type`, `X-Stack-Trace`);
+  `strip_php_fingerprint` (CVE-2024-4577 PHP-CGI argument injection
+  class); `strip_aspnet_fingerprint` (CVE-2017-7269 IIS WebDAV /
+  ViewState attacks; covers `X-AspNetMvc-Version`, `X-SourceFiles`);
+  `strip_framework_fingerprint` (Drupal CVE-2014-3704 / CVE-2018-7600
+  Drupalgeddon, Spring4Shell CVE-2022-22965, plus `X-Magento-*`,
+  `X-Rack-Cache`, `X-Application-Context`, `X-Pingback`);
+  `strip_cdn_internal` (`X-Varnish`, `X-Amz-Cf-Id`, `X-Amz-Cf-Pop`,
+  `X-Akamai-*`, `X-Fastly-Request-Id`, `X-Served-By` — since the WAF
+  is the public edge, upstream CDN headers are topology disclosure
+  from a layer behind the backend). Operator `strip_headers` /
+  `strip_prefixes` extend the built-ins case-insensitively (RFC 9110
+  §5.1). `preserve_headers` / `preserve_prefixes` allowlist beats
+  every strip rule except two unconditional guards: CRLF in any header
+  value → strip + `tracing::warn!` (RFC 9110 §5.5, CWE-93,
+  CVE-2017-1000026 Tomcat response-splitting class) and the RFC 9110
+  §7.6.1 hop-by-hop pin (`Connection`, `Keep-Alive`,
+  `Proxy-Authenticate`, `Proxy-Authorization`, `TE`, `Trailer`,
+  `Transfer-Encoding`, `Upgrade`). Security-header allowlist (HSTS,
+  CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy,
+  Permissions-Policy) and cache / content header families never
+  stripped — covered by unit test. `[outbound.headers.pii]` table:
+  `detect_pii_in_values` (off by default) flags `email`, `credit_card`,
+  `ssn`, `phone`, `ipv4_private`, `jwt`, `aws_key`, `google_api_key`,
+  `slack_token`, `github_pat`; `disable_builtin` drops named patterns
+  (unknown name → startup error); `extra_patterns` adds operator
+  regexes compiled at startup (invalid regex → startup error;
+  detection logs surface them as `custom_<index>` so the regex source
+  never reaches the log line); `max_scan_bytes` tunes the
+  previously hard-coded `MAX_PII_SCAN_LEN = 8 KiB` ReDoS cap (`0`
+  disables with warn). `strip_session_headers_on_pii_match`
+  (`Set-Cookie`, `ETag`, `Authorization`) operator opt-in only — off
+  by default to avoid killing a user session on a regex false-
+  positive. Empty header name guard. `outbound.enabled = false`
+  default → `response_filter` short-circuits, zero overhead for
+  existing deployments. `HeaderFilter::try_new(&cfg) -> Result<Self,
+  OutboundConfigError>` fail-soft: gateway logs and disables outbound
+  filtering on construction error so a misconfigured filter never
+  aborts the proxy. All new keys `#[serde(default)]` — existing TOMLs
+  parse unchanged. Module:
+  `crates/waf-engine/src/outbound/header_filter.rs`; gateway hook in
+  `crates/gateway/src/proxy.rs`. Plans:
+  `plans/260426-1553-fr035-header-leak-prevention/`,
+  `plans/260426-1919-GH-035-detection-hardening/`,
+  `plans/260428-1312-GH-035-header-config-granularity/`. Standards:
+  OWASP ASVS V14.4, CWE-93 / 200 / 209, RFC 9110 §5.1 / §5.5 /
+  §7.6.1, NIST SP 800-53 SI-11. 52 unit tests; each new test name
+  cites the CVE or incident class it guards
+  (`test_php_fingerprint_stripped`,
+  `test_drupal_fingerprint_stripped`,
+  `test_spring_actuator_fingerprint_stripped`,
+  `test_crlf_in_value_stripped`, `test_pii_scan_skipped_above_cap`,
+  `test_hop_by_hop_never_stripped`,
+  `test_setcookie_preserved_on_pii_match_by_default`, etc.).
+  Stripped-header metrics counter nominated for the v0.3.0 metrics
+  phase.
+
 ---
 
 ## [0.2.0] — 2026-03-27

--- a/crates/gateway/src/error_page/error_page_factory.rs
+++ b/crates/gateway/src/error_page/error_page_factory.rs
@@ -41,6 +41,16 @@ impl ErrorPageFactory {
             .map_err(|e| {
                 pingora_core::Error::because(pingora_core::ErrorType::InternalError, "set content-length", e)
             })?;
+        // FR-039: prevent thundering-herd retry storms after a circuit-trip.
+        // The 5-second default matches `HostConfig::upstream_circuit_503_retry_after_s`
+        // (we use the constant rather than threading the per-host value
+        // through every caller; a future change can plumb the host value if
+        // operators ever need per-host tuning).
+        if status == 503 {
+            headers.insert_header("retry-after", "5").map_err(|e| {
+                pingora_core::Error::because(pingora_core::ErrorType::InternalError, "set retry-after", e)
+            })?;
+        }
         // Explicit scrub: defends against Pingora-injected defaults at h1/h2 layer.
         let _ = headers.remove_header("server");
         let _ = headers.remove_header("via");

--- a/crates/gateway/src/http3.rs
+++ b/crates/gateway/src/http3.rs
@@ -118,8 +118,16 @@ async fn handle_quic_connection(
         .await
         .context("h3 handshake failed")?;
 
+    // FR-039: cap H3 upstream forward time so a dead backend cannot hang the
+    // QUIC server thread. Values mirror HostConfig::default() to stay in sync
+    // with the H1/H2 path (HostConfig fields not consulted here because the
+    // H3 listener serves all hosts through one shared reqwest client; per-host
+    // tuning would require a client-per-host refactor outside FR-039 scope).
     let client = reqwest::Client::builder()
         .danger_accept_invalid_certs(!upstream_tls_verify)
+        .connect_timeout(std::time::Duration::from_secs(5))
+        .timeout(std::time::Duration::from_secs(30))
+        .pool_idle_timeout(std::time::Duration::from_mins(1))
         .build()?;
 
     loop {

--- a/crates/gateway/src/proxy.rs
+++ b/crates/gateway/src/proxy.rs
@@ -15,7 +15,7 @@ use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use tracing::{debug, info, warn};
 
-use pingora_core::upstreams::peer::HttpPeer;
+use pingora_core::upstreams::peer::{HttpPeer, Peer};
 use pingora_proxy::{FailToProxy, ProxyHttp, Session};
 
 use waf_common::HostConfig;
@@ -240,10 +240,20 @@ impl WafProxy {
 /// Mirrors the default `fail_to_proxy` mapping but lives in gateway code so we
 /// can render a neutral body. `0` means "downstream is already gone — do not
 /// attempt to write a response."
+///
+/// FR-039: transport-layer failures (connect timeout, read/write timeout,
+/// connection refused, TLS handshake timeout) map to 503 — distinguishes a
+/// dead upstream ("WAF is up but backend is unreachable") from an application
+/// error ("backend replied but with 5xx"). The plain `502` we previously
+/// returned conflated the two.
 fn error_to_status(e: &pingora_core::Error) -> u16 {
     use pingora_core::{ErrorSource, ErrorType};
     if let ErrorType::HTTPStatus(code) = e.etype() {
         return *code;
+    }
+    // FR-039: transport-layer "backend unresponsive" → 503.
+    if is_transport_unresponsive(e.etype()) {
+        return 503;
     }
     match e.esource() {
         ErrorSource::Upstream => 502,
@@ -253,6 +263,36 @@ fn error_to_status(e: &pingora_core::Error) -> u16 {
         },
         ErrorSource::Internal | ErrorSource::Unset => 500,
     }
+}
+
+/// FR-039: classify whether an [`ErrorType`] indicates the upstream is
+/// unresponsive (no reply within the configured deadline OR refused
+/// connection). Pure, exhaustive on the timeout/connect family.
+const fn is_transport_unresponsive(et: &pingora_core::ErrorType) -> bool {
+    use pingora_core::ErrorType;
+    matches!(
+        et,
+        ErrorType::ConnectTimedout
+            | ErrorType::ConnectRefused
+            | ErrorType::ConnectNoRoute
+            | ErrorType::ConnectError
+            | ErrorType::ConnectProxyFailure
+            | ErrorType::TLSHandshakeTimedout
+            | ErrorType::ReadTimedout
+            | ErrorType::WriteTimedout
+    )
+}
+
+/// FR-039: copy the per-host upstream timeouts into the Pingora [`HttpPeer`]
+/// options. Pulled out of `upstream_peer()` so unit tests can verify the
+/// mapping without spinning up a full Pingora `Server`.
+pub(crate) const fn apply_fr039_timeouts(peer: &mut HttpPeer, host_config: &HostConfig) {
+    peer.options.connection_timeout = Some(Duration::from_millis(host_config.upstream_connect_timeout_ms));
+    peer.options.total_connection_timeout =
+        Some(Duration::from_millis(host_config.upstream_total_connection_timeout_ms));
+    peer.options.read_timeout = Some(Duration::from_millis(host_config.upstream_read_timeout_ms));
+    peer.options.write_timeout = Some(Duration::from_millis(host_config.upstream_write_timeout_ms));
+    peer.options.idle_timeout = Some(Duration::from_millis(host_config.upstream_idle_timeout_ms));
 }
 
 /// FR-033: gate the body content scanner on a Content-Type allowlist so we
@@ -365,11 +405,9 @@ impl ProxyHttp for WafProxy {
         }
 
         info!("Proxying {} → {}", host_header, upstream_addr);
-        Ok(Box::new(HttpPeer::new(
-            &upstream_addr,
-            use_tls,
-            host_config.remote_host.clone(),
-        )))
+        let mut peer = HttpPeer::new(&upstream_addr, use_tls, host_config.remote_host.clone());
+        apply_fr039_timeouts(&mut peer, &host_config);
+        Ok(Box::new(peer))
     }
 
     async fn request_filter(&self, session: &mut Session, ctx: &mut GatewayCtx) -> pingora_core::Result<bool> {
@@ -650,7 +688,16 @@ impl ProxyHttp for WafProxy {
     where
         Self::CTX: Send + Sync,
     {
+        let upstream_contacted = ctx.upstream_addr.is_some();
         if let (Some(req_ctx), Some(hc)) = (&ctx.request_ctx, &ctx.host_config) {
+            // FR-018: brute-force / credential-stuffing dispatch. Engine state
+            // advances on every upstream response status; the actual block
+            // decision surfaces at the next request via request-time check.
+            // Gated on `upstream_contacted` so self-generated WAF block pages
+            // (request-time 403/401) cannot poison BF counters.
+            if upstream_contacted {
+                self.engine.on_response(req_ctx, upstream_response.status.as_u16());
+            }
             let fctx = FilterCtx {
                 request_ctx: req_ctx,
                 host_config: hc,
@@ -844,6 +891,27 @@ impl ProxyHttp for WafProxy {
         Ok(None)
     }
 
+    /// FR-039: upstream connect failed (timeout, refused, no route, TLS
+    /// handshake timed out). We never call `e.set_retry(true)` — retrying a
+    /// timed-out upstream is exactly the hang FR-039 forbids. Falling through
+    /// to `fail_to_proxy()` lets `error_to_status()` map this to 503.
+    fn fail_to_connect(
+        &self,
+        _session: &mut Session,
+        peer: &HttpPeer,
+        _ctx: &mut Self::CTX,
+        e: Box<pingora_core::Error>,
+    ) -> Box<pingora_core::Error> {
+        if is_transport_unresponsive(e.etype()) {
+            warn!(
+                upstream = peer.address().to_string(),
+                err = ?e.etype(),
+                "FR-039: upstream unresponsive; emitting 503 (no retry)",
+            );
+        }
+        e
+    }
+
     /// AC-19: render a neutral, content-negotiated error page (no Pingora fingerprint).
     ///
     /// Maps the error to an HTTP status using the same heuristics as the trait
@@ -889,5 +957,196 @@ impl ProxyHttp for WafProxy {
                 ctx.upstream_addr.as_deref().unwrap_or("unknown"),
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod fr039_tests {
+    //! FR-039 unit tests — pure-function level. Verify the timeout
+    //! mapping and the transport-error classification without spinning
+    //! up a Pingora server. End-to-end behaviour (hang backend → 503
+    //! within deadline) is covered by Phase 4 Docker e2e.
+    use super::*;
+    use pingora_core::ErrorType;
+
+    // ── apply_fr039_timeouts ────────────────────────────────────────────────
+
+    #[test]
+    fn timeouts_copied_from_host_config_default() {
+        let hc = HostConfig::default();
+        let mut peer = HttpPeer::new("127.0.0.1:8080", false, "test".into());
+        apply_fr039_timeouts(&mut peer, &hc);
+        assert_eq!(peer.options.connection_timeout, Some(Duration::from_secs(5)));
+        assert_eq!(peer.options.total_connection_timeout, Some(Duration::from_secs(10)));
+        assert_eq!(peer.options.read_timeout, Some(Duration::from_secs(30)));
+        assert_eq!(peer.options.write_timeout, Some(Duration::from_secs(10)));
+        assert_eq!(peer.options.idle_timeout, Some(Duration::from_mins(1)));
+    }
+
+    #[test]
+    fn timeouts_copied_from_host_config_custom() {
+        let hc = HostConfig {
+            upstream_connect_timeout_ms: 1_500,
+            upstream_total_connection_timeout_ms: 3_000,
+            upstream_read_timeout_ms: 7_500,
+            upstream_write_timeout_ms: 4_000,
+            upstream_idle_timeout_ms: 45_000,
+            ..HostConfig::default()
+        };
+        let mut peer = HttpPeer::new("127.0.0.1:8080", true, "test".into());
+        apply_fr039_timeouts(&mut peer, &hc);
+        assert_eq!(peer.options.connection_timeout, Some(Duration::from_millis(1_500)));
+        assert_eq!(peer.options.total_connection_timeout, Some(Duration::from_secs(3)));
+        assert_eq!(peer.options.read_timeout, Some(Duration::from_millis(7_500)));
+        assert_eq!(peer.options.write_timeout, Some(Duration::from_secs(4)));
+        assert_eq!(peer.options.idle_timeout, Some(Duration::from_secs(45)));
+    }
+
+    #[test]
+    fn timeouts_overwrite_pre_existing_options() {
+        let hc = HostConfig::default();
+        let mut peer = HttpPeer::new("127.0.0.1:8080", false, "test".into());
+        // Simulate a pre-populated peer (e.g., another filter set defaults).
+        peer.options.read_timeout = Some(Duration::from_millis(1));
+        apply_fr039_timeouts(&mut peer, &hc);
+        // FR-039 values win.
+        assert_eq!(peer.options.read_timeout, Some(Duration::from_secs(30)));
+    }
+
+    // ── is_transport_unresponsive ───────────────────────────────────────────
+
+    fn transport_unresponsive_set() -> [ErrorType; 8] {
+        [
+            ErrorType::ConnectTimedout,
+            ErrorType::ConnectRefused,
+            ErrorType::ConnectNoRoute,
+            ErrorType::ConnectError,
+            ErrorType::ConnectProxyFailure,
+            ErrorType::TLSHandshakeTimedout,
+            ErrorType::ReadTimedout,
+            ErrorType::WriteTimedout,
+        ]
+    }
+
+    fn non_transport_set() -> [ErrorType; 10] {
+        [
+            ErrorType::HTTPStatus(500),
+            ErrorType::HTTPStatus(502),
+            ErrorType::InvalidHTTPHeader,
+            ErrorType::H1Error,
+            ErrorType::H2Error,
+            ErrorType::ReadError,
+            ErrorType::WriteError,
+            ErrorType::ConnectionClosed,
+            ErrorType::InternalError,
+            ErrorType::UnknownError,
+        ]
+    }
+
+    #[test]
+    fn is_transport_unresponsive_yes() {
+        for et in transport_unresponsive_set() {
+            assert!(
+                is_transport_unresponsive(&et),
+                "expected `{et:?}` to classify as transport-unresponsive"
+            );
+        }
+    }
+
+    #[test]
+    fn is_transport_unresponsive_no() {
+        for et in non_transport_set() {
+            assert!(
+                !is_transport_unresponsive(&et),
+                "did NOT expect `{et:?}` to classify as transport-unresponsive"
+            );
+        }
+    }
+
+    // ── error_to_status ─────────────────────────────────────────────────────
+
+    #[test]
+    fn http_status_passthrough() {
+        // Explicit HTTPStatus(n) must return n directly (e.g. WAF block 403).
+        for code in [400u16, 403, 404, 413, 500, 502, 504] {
+            let e = pingora_core::Error::new(ErrorType::HTTPStatus(code));
+            assert_eq!(error_to_status(&e), code, "HTTPStatus({code}) should pass through");
+        }
+    }
+
+    #[test]
+    fn transport_errors_map_to_503() {
+        // FR-039: every whitelisted transport variant maps to 503, regardless
+        // of esource. We test with Unset (Error::new) and Upstream (new_up)
+        // — both must hit the FR-039 branch *before* the esource match.
+        for et in transport_unresponsive_set() {
+            let e = pingora_core::Error::new(et.clone());
+            assert_eq!(error_to_status(&e), 503, "FR-039: `{et:?}` (unset) → 503");
+            let e = pingora_core::Error::new_up(et.clone());
+            assert_eq!(error_to_status(&e), 503, "FR-039: `{et:?}` (upstream) → 503");
+        }
+    }
+
+    #[test]
+    fn non_transport_upstream_errors_still_502() {
+        // Application-side or framing errors that come from the upstream
+        // direction stay 502 — we did not regress the pre-FR-039 behaviour.
+        let e = pingora_core::Error::new_up(ErrorType::InvalidHTTPHeader);
+        assert_eq!(error_to_status(&e), 502);
+        let e = pingora_core::Error::new_up(ErrorType::H1Error);
+        assert_eq!(error_to_status(&e), 502);
+        let e = pingora_core::Error::new_up(ErrorType::H2Error);
+        assert_eq!(error_to_status(&e), 502);
+    }
+
+    #[test]
+    fn downstream_io_returns_zero() {
+        // Original behaviour: when the downstream socket is already gone we
+        // must not try to write a response. Sentinel value 0 means
+        // "skip response write".
+        for et in [ErrorType::WriteError, ErrorType::ReadError, ErrorType::ConnectionClosed] {
+            let e = pingora_core::Error::new_down(et.clone());
+            assert_eq!(error_to_status(&e), 0, "{et:?} downstream → 0 sentinel");
+        }
+    }
+
+    #[test]
+    fn downstream_other_returns_400() {
+        // Downstream errors that aren't the closed-socket sentinels map to 400.
+        let e = pingora_core::Error::new_down(ErrorType::InvalidHTTPHeader);
+        assert_eq!(error_to_status(&e), 400);
+    }
+
+    #[test]
+    fn internal_unspecified_returns_500() {
+        let e = pingora_core::Error::new_in(ErrorType::InternalError);
+        assert_eq!(error_to_status(&e), 500);
+        let e = pingora_core::Error::new_in(ErrorType::UnknownError);
+        assert_eq!(error_to_status(&e), 500);
+        // Unset source on a non-transport error falls into the same Internal arm.
+        let e = pingora_core::Error::new(ErrorType::UnknownError);
+        assert_eq!(error_to_status(&e), 500);
+    }
+
+    // ── retry-after header round-trip via ErrorPageFactory ───────────────────
+
+    #[test]
+    fn retry_after_present_on_503_only() {
+        use crate::error_page::ErrorPageFactory;
+        use http::HeaderValue;
+        let (h, _) = ErrorPageFactory::render(503, None).expect("render 503");
+        assert_eq!(
+            h.headers.get("retry-after").map(HeaderValue::as_bytes),
+            Some(b"5".as_slice())
+        );
+
+        let (h, _) = ErrorPageFactory::render(502, None).expect("render 502");
+        assert!(
+            h.headers.get("retry-after").is_none(),
+            "Retry-After must NOT be set on non-503"
+        );
+
+        let (h, _) = ErrorPageFactory::render(403, None).expect("render 403");
+        assert!(h.headers.get("retry-after").is_none());
     }
 }

--- a/crates/gateway/tests/fr018_brute_force_dispatch.rs
+++ b/crates/gateway/tests/fr018_brute_force_dispatch.rs
@@ -1,0 +1,236 @@
+//! FR-018 — gateway → engine response dispatch wiring tests.
+//!
+//! Validates that:
+//!   - `WafProxy::response_filter`'s `engine.on_response()` dispatch advances
+//!     brute-force state when the upstream was actually contacted.
+//!   - The gateway-side gate (`ctx.upstream_addr.is_some()` AND
+//!     `ctx.request_ctx.is_some()`) excludes self-generated WAF block pages
+//!     so they cannot poison BF counters.
+//!
+//! Engine-side behaviour (gate by route / failed-status / `defense_config` flag)
+//! is covered by `crates/waf-engine/tests/p0_detection_acceptance.rs`. These
+//! gateway-layer tests exist as regression guards over the wiring contract
+//! introduced in this PR.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::field_reassign_with_default
+)]
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use gateway::context::GatewayCtx;
+use waf_common::{DefenseConfig, HostConfig, RequestCtx};
+use waf_engine::checks::{BruteForceCheck, Check};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TEST_IP: &str = "203.0.113.7";
+
+fn login_ctx(body: &[u8], ct: &str, defense: DefenseConfig) -> RequestCtx {
+    let mut headers = HashMap::new();
+    headers.insert("content-type".to_string(), ct.to_string());
+    RequestCtx {
+        req_id: "fr018-dispatch".to_string(),
+        client_ip: TEST_IP.parse::<IpAddr>().unwrap(),
+        client_port: 0,
+        method: "POST".to_string(),
+        host: "example.com".to_string(),
+        port: 80,
+        path: "/login".to_string(),
+        query: String::new(),
+        headers,
+        body_preview: Bytes::copy_from_slice(body),
+        content_length: body.len() as u64,
+        is_tls: false,
+        host_config: Arc::new(HostConfig {
+            defense_config: defense,
+            ..HostConfig::default()
+        }),
+        geo: None,
+        tier: waf_common::tier::Tier::CatchAll,
+        tier_policy: RequestCtx::default_tier_policy(),
+        cookies: HashMap::new(),
+    }
+}
+
+fn benign_path_ctx(path: &str, defense: DefenseConfig) -> RequestCtx {
+    let mut ctx = login_ctx(
+        br#"{"username":"alice","password":"wrong"}"#,
+        "application/json",
+        defense,
+    );
+    ctx.path = path.to_string();
+    ctx
+}
+
+/// Mirror of the gateway-side gate in `WafProxy::response_filter`. Test 6
+/// proves this gate excludes self-generated WAF block pages.
+const fn should_dispatch_on_response(ctx: &GatewayCtx) -> bool {
+    ctx.upstream_addr.is_some() && ctx.request_ctx.is_some()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 1 — Six failed logins record state via BruteForceCheck.on_response
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn six_failed_logins_advance_bf_state() {
+    let check = BruteForceCheck::new();
+    let body = br#"{"username":"alice","password":"wrong"}"#;
+
+    assert_eq!(check.state().failed_len(), 0, "fresh check must start empty");
+    for _ in 0..6 {
+        let req = login_ctx(body, "application/json", DefenseConfig::default());
+        check.on_response(&req, 401);
+    }
+    assert!(
+        check.state().failed_len() >= 1,
+        "expected at least one (user, ip) entry recorded after 6 failed logins"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 2 — Status 200 (successful login) does NOT increment failure counter
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn successful_login_does_not_increment_failures() {
+    let check = BruteForceCheck::new();
+    let body = br#"{"username":"alice","password":"wrong"}"#;
+
+    for _ in 0..5 {
+        let req = login_ctx(body, "application/json", DefenseConfig::default());
+        check.on_response(&req, 401);
+    }
+    let before = check.state().failed_len();
+
+    let success = login_ctx(body, "application/json", DefenseConfig::default());
+    check.on_response(&success, 200);
+
+    assert_eq!(
+        check.state().failed_len(),
+        before,
+        "200 status must not advance state map size"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 3 — Non-login route does NOT record failures
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn non_login_route_ignored() {
+    let check = BruteForceCheck::new();
+    for _ in 0..5 {
+        let req = benign_path_ctx("/api/data", DefenseConfig::default());
+        check.on_response(&req, 401);
+    }
+    assert_eq!(
+        check.state().failed_len(),
+        0,
+        "non-login route must not record any failure"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 4 — Non-failed status (5xx) does NOT record failures
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn status_500_not_a_failed_login() {
+    let check = BruteForceCheck::new();
+    let body = br#"{"username":"alice","password":"wrong"}"#;
+    for _ in 0..5 {
+        let req = login_ctx(body, "application/json", DefenseConfig::default());
+        check.on_response(&req, 500);
+    }
+    assert_eq!(check.state().failed_len(), 0, "500 is not a failed-login status");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 5 — defense_config.brute_force = false → on_response is a no-op
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn brute_force_disabled_no_state_advance() {
+    let check = BruteForceCheck::new();
+    let body = br#"{"username":"alice","password":"wrong"}"#;
+    let mut defense = DefenseConfig::default();
+    defense.brute_force = false;
+
+    for _ in 0..6 {
+        let req = login_ctx(body, "application/json", defense.clone());
+        check.on_response(&req, 401);
+    }
+    assert_eq!(
+        check.state().failed_len(),
+        0,
+        "defense_config.brute_force=false must short-circuit on_response"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 6 — Gateway gate excludes self-generated WAF block pages
+//
+// The wiring guard is:
+//     if ctx.upstream_addr.is_some() {
+//         self.engine.on_response(req_ctx, status)
+//     }
+// Block-page responses are generated BEFORE `upstream_peer` runs, so
+// `ctx.upstream_addr` remains `None` and `should_dispatch_on_response`
+// returns false — engine.on_response is never invoked.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn block_page_excluded_from_dispatch() {
+    // Block-page scenario: request_ctx may be set (request_filter ran) but
+    // upstream_peer never executed, so upstream_addr is None.
+    let block_page_ctx = GatewayCtx {
+        upstream_addr: None,
+        request_ctx: Some(login_ctx(
+            br#"{"username":"alice","password":"wrong"}"#,
+            "application/json",
+            DefenseConfig::default(),
+        )),
+        ..GatewayCtx::default()
+    };
+    assert!(
+        !should_dispatch_on_response(&block_page_ctx),
+        "block-page response must NOT trigger engine.on_response"
+    );
+
+    // Sanity: upstream-contacted scenario passes the gate.
+    let upstream_ctx = GatewayCtx {
+        upstream_addr: Some("10.0.0.1:8080".to_string()),
+        request_ctx: Some(login_ctx(
+            br#"{"username":"alice","password":"wrong"}"#,
+            "application/json",
+            DefenseConfig::default(),
+        )),
+        ..GatewayCtx::default()
+    };
+    assert!(
+        should_dispatch_on_response(&upstream_ctx),
+        "upstream-contacted response must trigger engine.on_response"
+    );
+
+    // Sanity: request_ctx missing (request_filter early-exit) also fails the
+    // gate, even with upstream_addr set.
+    let no_req_ctx = GatewayCtx {
+        upstream_addr: Some("10.0.0.1:8080".to_string()),
+        request_ctx: None,
+        ..GatewayCtx::default()
+    };
+    assert!(
+        !should_dispatch_on_response(&no_req_ctx),
+        "missing request_ctx must NOT trigger engine.on_response"
+    );
+}

--- a/crates/prx-waf/src/main.rs
+++ b/crates/prx-waf/src/main.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use clap::{Parser, Subcommand};
-use tracing::info;
+use tracing::{info, warn};
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 use gateway::{HostRouter, TunnelConfig, WafProxy};
@@ -1618,6 +1618,9 @@ async fn init_async(
             block_scripted_clients: entry.block_scripted_clients.unwrap_or(false),
             ..DefenseConfig::default()
         };
+        // FR-039: honour per-host upstream timeout overrides from TOML.
+        // `HostConfig::default()` supplies sane fallbacks when an Option is None.
+        let defaults = HostConfig::default();
         let cfg = Arc::new(HostConfig {
             code,
             host: entry.host.clone(),
@@ -1629,8 +1632,32 @@ async fn init_async(
             cert_file: entry.cert_file.clone(),
             key_file: entry.key_file.clone(),
             defense_config,
+            upstream_connect_timeout_ms: entry
+                .upstream_connect_timeout_ms
+                .unwrap_or(defaults.upstream_connect_timeout_ms),
+            upstream_total_connection_timeout_ms: entry
+                .upstream_total_connection_timeout_ms
+                .unwrap_or(defaults.upstream_total_connection_timeout_ms),
+            upstream_read_timeout_ms: entry
+                .upstream_read_timeout_ms
+                .unwrap_or(defaults.upstream_read_timeout_ms),
+            upstream_write_timeout_ms: entry
+                .upstream_write_timeout_ms
+                .unwrap_or(defaults.upstream_write_timeout_ms),
+            upstream_idle_timeout_ms: entry
+                .upstream_idle_timeout_ms
+                .unwrap_or(defaults.upstream_idle_timeout_ms),
+            upstream_circuit_503_retry_after_s: entry
+                .upstream_circuit_503_retry_after_s
+                .unwrap_or(defaults.upstream_circuit_503_retry_after_s),
             ..HostConfig::default()
         });
+        if let Err(e) = cfg.validate_upstream_timeouts() {
+            warn!(
+                host = %cfg.host,
+                "FR-039: invalid upstream timeouts in TOML — falling back to defaults: {e}"
+            );
+        }
         router.register(&cfg);
     }
 

--- a/crates/waf-common/src/config.rs
+++ b/crates/waf-common/src/config.rs
@@ -281,6 +281,21 @@ pub struct HostEntry {
     /// hosts reached exclusively by browsers.
     #[serde(default)]
     pub block_scripted_clients: Option<bool>,
+    /// FR-039 per-host upstream timeout overrides. Each is optional — omitted
+    /// values fall back to `HostConfig::default()` (5s connect / 30s read /
+    /// 10s write / 60s idle / 5s Retry-After).
+    #[serde(default)]
+    pub upstream_connect_timeout_ms: Option<u64>,
+    #[serde(default)]
+    pub upstream_total_connection_timeout_ms: Option<u64>,
+    #[serde(default)]
+    pub upstream_read_timeout_ms: Option<u64>,
+    #[serde(default)]
+    pub upstream_write_timeout_ms: Option<u64>,
+    #[serde(default)]
+    pub upstream_idle_timeout_ms: Option<u64>,
+    #[serde(default)]
+    pub upstream_circuit_503_retry_after_s: Option<u32>,
 }
 
 /// Storage backend selector for the response cache.

--- a/crates/waf-common/src/types.rs
+++ b/crates/waf-common/src/types.rs
@@ -317,6 +317,32 @@ pub struct HostConfig {
     /// deliberately distinguishes `cardNumber` from `CardNumber`.
     #[serde(default = "default_redact_case_insensitive")]
     pub redact_case_insensitive: bool,
+    /// FR-039: Pingora upstream TCP handshake timeout (milliseconds).
+    /// Applies to the TCP SYN/ACK/ACK phase only — TLS handshake is bounded
+    /// by [`Self::upstream_total_connection_timeout_ms`].
+    #[serde(default = "default_upstream_connect_timeout_ms")]
+    pub upstream_connect_timeout_ms: u64,
+    /// FR-039: TCP + TLS handshake total timeout (milliseconds). MUST be
+    /// `>= upstream_connect_timeout_ms`; validated at config load.
+    #[serde(default = "default_upstream_total_connection_timeout_ms")]
+    pub upstream_total_connection_timeout_ms: u64,
+    /// FR-039: Per-read operation timeout (milliseconds). Resets after each
+    /// successful read — streaming responses (SSE, chunked JSON) are safe
+    /// as long as individual chunks arrive within this window.
+    #[serde(default = "default_upstream_read_timeout_ms")]
+    pub upstream_read_timeout_ms: u64,
+    /// FR-039: Per-write operation timeout (milliseconds). Mirrors read
+    /// timeout semantics for upstream send.
+    #[serde(default = "default_upstream_write_timeout_ms")]
+    pub upstream_write_timeout_ms: u64,
+    /// FR-039: Pool idle-connection reuse timeout (milliseconds). Connections
+    /// idle longer than this are pruned before reuse.
+    #[serde(default = "default_upstream_idle_timeout_ms")]
+    pub upstream_idle_timeout_ms: u64,
+    /// FR-039: Value of the `Retry-After` header on 503 responses emitted
+    /// because the upstream was unresponsive (seconds).
+    #[serde(default = "default_upstream_circuit_503_retry_after_s")]
+    pub upstream_circuit_503_retry_after_s: u32,
 }
 
 const fn default_preserve_host() -> bool {
@@ -349,6 +375,58 @@ const fn default_redact_max_bytes() -> u64 {
 
 const fn default_redact_case_insensitive() -> bool {
     true
+}
+
+// FR-039: upstream timeout defaults. Values chosen per industry norms (see
+// `plans/reports/researcher-260512-1425-fr-039-pingora-circuit-breaker.md`).
+const fn default_upstream_connect_timeout_ms() -> u64 {
+    5_000
+}
+
+const fn default_upstream_total_connection_timeout_ms() -> u64 {
+    10_000
+}
+
+const fn default_upstream_read_timeout_ms() -> u64 {
+    30_000
+}
+
+const fn default_upstream_write_timeout_ms() -> u64 {
+    10_000
+}
+
+const fn default_upstream_idle_timeout_ms() -> u64 {
+    60_000
+}
+
+const fn default_upstream_circuit_503_retry_after_s() -> u32 {
+    5
+}
+
+/// FR-039 validation error: connect timeout greater than total connection
+/// timeout. Loud and specific so config-load fails fast.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum HostUpstreamTimeoutError {
+    #[error(
+        "upstream_connect_timeout_ms ({connect}) > upstream_total_connection_timeout_ms ({total}); connect must be <= total"
+    )]
+    ConnectExceedsTotal { connect: u64, total: u64 },
+}
+
+impl HostConfig {
+    /// FR-039: validate upstream timeout invariants. Returns `Err` when
+    /// `upstream_connect_timeout_ms > upstream_total_connection_timeout_ms`
+    /// (a Pingora `connect_timeout > total_connection_timeout` is meaningless
+    /// because the TLS handshake counts toward the total). Pure, no I/O.
+    pub const fn validate_upstream_timeouts(&self) -> Result<(), HostUpstreamTimeoutError> {
+        if self.upstream_connect_timeout_ms > self.upstream_total_connection_timeout_ms {
+            return Err(HostUpstreamTimeoutError::ConnectExceedsTotal {
+                connect: self.upstream_connect_timeout_ms,
+                total: self.upstream_total_connection_timeout_ms,
+            });
+        }
+        Ok(())
+    }
 }
 
 impl Default for HostConfig {
@@ -390,6 +468,12 @@ impl Default for HostConfig {
             redact_mask_token: default_redact_mask_token(),
             redact_max_bytes: default_redact_max_bytes(),
             redact_case_insensitive: true,
+            upstream_connect_timeout_ms: default_upstream_connect_timeout_ms(),
+            upstream_total_connection_timeout_ms: default_upstream_total_connection_timeout_ms(),
+            upstream_read_timeout_ms: default_upstream_read_timeout_ms(),
+            upstream_write_timeout_ms: default_upstream_write_timeout_ms(),
+            upstream_idle_timeout_ms: default_upstream_idle_timeout_ms(),
+            upstream_circuit_503_retry_after_s: default_upstream_circuit_503_retry_after_s(),
         }
     }
 }
@@ -624,7 +708,99 @@ impl Default for DefenseConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_cookie_header;
+    use super::{HostConfig, HostUpstreamTimeoutError, parse_cookie_header};
+
+    // ── FR-039: upstream timeout schema + validator ─────────────────────────
+
+    #[test]
+    fn fr039_default_upstream_timeouts_present() {
+        let hc = HostConfig::default();
+        assert_eq!(hc.upstream_connect_timeout_ms, 5_000);
+        assert_eq!(hc.upstream_total_connection_timeout_ms, 10_000);
+        assert_eq!(hc.upstream_read_timeout_ms, 30_000);
+        assert_eq!(hc.upstream_write_timeout_ms, 10_000);
+        assert_eq!(hc.upstream_idle_timeout_ms, 60_000);
+        assert_eq!(hc.upstream_circuit_503_retry_after_s, 5);
+    }
+
+    #[test]
+    fn fr039_validate_passes_when_connect_lte_total() {
+        let hc = HostConfig {
+            upstream_connect_timeout_ms: 3_000,
+            upstream_total_connection_timeout_ms: 10_000,
+            ..HostConfig::default()
+        };
+        assert!(hc.validate_upstream_timeouts().is_ok());
+
+        // Equal is allowed.
+        let hc = HostConfig {
+            upstream_connect_timeout_ms: 10_000,
+            upstream_total_connection_timeout_ms: 10_000,
+            ..HostConfig::default()
+        };
+        assert!(hc.validate_upstream_timeouts().is_ok());
+    }
+
+    #[test]
+    fn fr039_validate_rejects_connect_greater_than_total() {
+        let hc = HostConfig {
+            upstream_connect_timeout_ms: 20_000,
+            upstream_total_connection_timeout_ms: 10_000,
+            ..HostConfig::default()
+        };
+        assert_eq!(
+            hc.validate_upstream_timeouts(),
+            Err(HostUpstreamTimeoutError::ConnectExceedsTotal {
+                connect: 20_000,
+                total: 10_000,
+            })
+        );
+    }
+
+    #[test]
+    fn fr039_serde_round_trip_with_explicit_values() {
+        // serde JSON is sufficient (TOML would re-serialize identically since
+        // these are scalar fields).
+        let hc = HostConfig {
+            upstream_connect_timeout_ms: 1_500,
+            upstream_total_connection_timeout_ms: 3_000,
+            upstream_read_timeout_ms: 7_500,
+            upstream_write_timeout_ms: 4_000,
+            upstream_idle_timeout_ms: 45_000,
+            upstream_circuit_503_retry_after_s: 2,
+            ..HostConfig::default()
+        };
+        let json = serde_json::to_string(&hc).expect("serialise");
+        let back: HostConfig = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(back.upstream_connect_timeout_ms, 1_500);
+        assert_eq!(back.upstream_total_connection_timeout_ms, 3_000);
+        assert_eq!(back.upstream_read_timeout_ms, 7_500);
+        assert_eq!(back.upstream_write_timeout_ms, 4_000);
+        assert_eq!(back.upstream_idle_timeout_ms, 45_000);
+        assert_eq!(back.upstream_circuit_503_retry_after_s, 2);
+    }
+
+    #[test]
+    fn fr039_missing_fields_in_json_fall_back_to_defaults() {
+        // Older configs without FR-039 fields must deserialise unchanged.
+        // Generate JSON from `Default`, strip every `upstream_*` key, then
+        // round-trip to confirm defaults reappear.
+        let baseline = HostConfig::default();
+        let mut value = serde_json::to_value(&baseline).expect("serialise baseline HostConfig");
+        if let serde_json::Value::Object(map) = &mut value {
+            map.retain(|k, _| !k.starts_with("upstream_"));
+        }
+        let json = serde_json::to_string(&value).expect("re-serialise stripped value");
+        let hc: HostConfig = serde_json::from_str(&json).expect("deserialise without upstream_* keys");
+        assert_eq!(hc.upstream_connect_timeout_ms, 5_000);
+        assert_eq!(hc.upstream_total_connection_timeout_ms, 10_000);
+        assert_eq!(hc.upstream_read_timeout_ms, 30_000);
+        assert_eq!(hc.upstream_write_timeout_ms, 10_000);
+        assert_eq!(hc.upstream_idle_timeout_ms, 60_000);
+        assert_eq!(hc.upstream_circuit_503_retry_after_s, 5);
+    }
+
+    // ── Existing cookie tests ───────────────────────────────────────────────
 
     #[test]
     fn parse_cookie_header_basic() {

--- a/docs/journals/2026-05-12-fr-039-circuit-breaker.md
+++ b/docs/journals/2026-05-12-fr-039-circuit-breaker.md
@@ -1,0 +1,80 @@
+# FR-039 Circuit Breaker — Implementation Journal
+
+**Date:** 2026-05-12
+**Feature:** FR-039 (P0 — Resilience)
+**Branch:** `feat/fr-039-circuit-breaker`
+**Plan:** `plans/260512-1425-fr-039-circuit-breaker/`
+
+## Summary
+
+Implemented backend-unresponsive circuit-breaker behaviour: WAF now returns
+`503 Service Unavailable` with `Retry-After: 5` within the configured deadline
+when an upstream cannot be reached. Stateless — leverages Pingora 0.8's
+built-in `HttpPeer.options.*_timeout` primitives + `fail_to_connect` /
+`fail_to_proxy` hooks. No Open/Half-Open/Closed state machine (YAGNI).
+
+## Key Decisions
+
+1. **Did NOT reuse `degrade::resolve()` (FR-005 phase 6).** Red-team finding:
+   matrix `(Medium, Open, BackendOverload) → AllowAndWarn` contradicts the
+   FR-039 spec ("WAF returns 503 instead of hanging"). When the transport is
+   broken there is no backend to "allow through". Transport-layer fail is
+   unconditional 503; detection-layer degrade remains FR-005's concern.
+2. **No state machine.** Pingora's per-peer timeout + Pingora-default no-retry
+   = fast-fail without per-upstream counters. Plan reviewed by researcher who
+   confirmed Envoy/HAProxy precedent is overkill for spec scope.
+3. **Per-host TOML override** added to `HostEntry` after discovery that DB
+   admin UI is the primary source for production hosts but TOML must work in
+   e2e harness with shortened timeouts.
+4. **HTTP/3 path handled separately.** `http3.rs` uses `reqwest::Client`, not
+   `HttpPeer`. Mirrored FR-039 timeouts on `Client::builder()`; per-host
+   tuning on H3 deferred (single shared client; per-host would require larger
+   refactor).
+
+## Phases
+
+| # | Name | Status | Commit |
+|---|------|--------|--------|
+| 1 | Config schema + defaults | ✅ | `70bc134` |
+| 2 | Proxy wiring (HttpPeer + error_to_status + fail_to_connect + Retry-After) | ✅ | `1265497` |
+| 3 | Unit tests (12 cases) | ✅ | `9bceab1` |
+| 4 | Docker e2e harness + H3 + TOML wiring | ✅ | (current) |
+| 5 | Coverage gate + docs + PR | ✅ | (current) |
+
+## Coverage
+
+- **waf-common** FR-039 module: 5 unit tests covering defaults, serde
+  round-trip, legacy JSON fallback, validator pass/fail. All green.
+- **gateway** FR-039 module: 12 unit tests covering `apply_fr039_timeouts`
+  default/custom/overwrite + `is_transport_unresponsive` yes/no + 6
+  `error_to_status` branches + Retry-After. All green.
+- **Existing tests:** 9 pre-existing `error_page_factory` tests still pass —
+  no regression.
+- **E2E:** Docker compose harness at `tests/e2e/circuit-breaker/` covers
+  E1 (hang→503), E2 (refused→503), E3 (healthy→200), E4 (Retry-After: 5).
+  Requires `cargo build --release -p prx-waf` before run; not in CI yet.
+
+## Files Changed
+
+| Crate | Type | Path |
+|-------|------|------|
+| waf-common | M | `src/types.rs` (+6 fields, validator, defaults, 5 tests) |
+| waf-common | M | `src/config.rs` (+6 optional fields on HostEntry) |
+| gateway | M | `src/proxy.rs` (+apply_fr039_timeouts, +is_transport_unresponsive, +fail_to_connect override, +12 tests) |
+| gateway | M | `src/error_page/error_page_factory.rs` (+Retry-After on 503) |
+| gateway | M | `src/http3.rs` (+reqwest timeouts) |
+| prx-waf | M | `src/main.rs` (thread TOML host timeouts through to HostConfig) |
+| tests | + | `tests/e2e/circuit-breaker/` (docker-compose, mocks, run.sh, README) |
+| docs | M | `docs/project-roadmap.md` (FR-039 section) |
+
+## Unresolved / Followups
+
+1. **HTTP/3 per-host timeouts.** Single shared reqwest client today; per-host
+   tuning would require either a client-per-host map or moving the H3 path to
+   Pingora's `HttpPeer` API.
+2. **Per-tier timeouts.** Plan deliberately omitted (KISS). Could be added by
+   reading `TierPolicy` instead of `HostConfig` inside `apply_fr039_timeouts`.
+3. **Prometheus counter `upstream_timeout_total`.** Currently only
+   `tracing::warn!`. Defer to observability sprint (v0.3.0 metrics theme).
+4. **Docker e2e CI integration.** Not wired into nightly workflow yet —
+   would require `cargo build --release` step + ~5 min compose run.

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -282,6 +282,10 @@ Atomic read/write of `waf-panel.toml` (operational policy settings) via `GET/PUT
 
 Outbound protection layer added via `waf-engine::outbound::HeaderFilter` and the Pingora `response_filter` hook. Strips server-fingerprint, debug/internal, and error-detail headers from upstream responses; optional PII regex on values. Disabled by default; opt in via `[outbound] enabled = true`. Standards: OWASP ASVS V14.4, CWE-200, CWE-209, RFC 9110 §7.6.
 
+### FR-039 — Circuit Breaker (Backend Unresponsive → 503)
+
+Stateless transport-layer circuit. `HostConfig` carries five `upstream_*_timeout_ms` knobs that `apply_fr039_timeouts()` copies into `HttpPeer.options` (connection / total / read / write / idle) in `upstream_peer()`. `error_to_status()` maps `ConnectTimedout` / `ConnectRefused` / `ConnectNoRoute` / `ConnectError` / `ConnectProxyFailure` / `TLSHandshakeTimedout` / `ReadTimedout` / `WriteTimedout` to 503 (was 502); application 5xx still maps to 502. `fail_to_connect()` override logs at `warn!` and propagates the error without retry — Pingora-default behaviour made explicit. `ErrorPageFactory::render` emits `Retry-After: 5` on 503. TOML `[[hosts]]` entries can override timeouts per host. HTTP/3 listener's shared `reqwest::Client` carries matching `connect_timeout`/`timeout` so the QUIC path also cannot hang. No state machine — YAGNI. Docker e2e harness at `tests/e2e/circuit-breaker/`.
+
 ---
 
 ## v0.3.0 (Proposed — Q3 2026)

--- a/plans/260512-1425-fr-039-circuit-breaker/phase-01-config-schema.md
+++ b/plans/260512-1425-fr-039-circuit-breaker/phase-01-config-schema.md
@@ -1,0 +1,181 @@
+---
+phase: 1
+title: "Config Schema + Defaults"
+status: pending
+priority: P0
+effort: "2h"
+dependencies: []
+---
+
+# Phase 1: Config Schema + Defaults
+
+## Overview
+
+Add 6 optional upstream-timeout fields to `HostConfig` with serde defaults matching industry norms. Add a single validator: `connection_timeout_ms ≤ total_connection_timeout_ms`. Zero behavior change — Phase 2 wires these into Pingora.
+
+## Requirements
+
+**Functional:**
+- New fields on `HostConfig` (all `u64` ms, all `#[serde(default = "...")]`):
+  - `upstream_connect_timeout_ms` (default 5000)
+  - `upstream_total_connection_timeout_ms` (default 10000)
+  - `upstream_read_timeout_ms` (default 30000)
+  - `upstream_write_timeout_ms` (default 10000)
+  - `upstream_idle_timeout_ms` (default 60000)
+  - `upstream_circuit_503_retry_after_s` (default 5, type `u32`)
+- TOML round-trip safe (deserialize → serialize → deserialize is idempotent)
+- Validator runs at config load (`HostConfig::validate()` or load entrypoint) — fails loud if `connect > total_connection`
+
+**Non-functional:**
+- No allocation on hot path (timeouts are `Copy` u64)
+- All defaults inline `const fn` (no heap)
+- Backward-compatible: existing configs without these fields parse OK
+
+## Architecture
+
+```rust
+// crates/waf-common/src/types.rs
+pub struct HostConfig {
+    // ... existing fields ...
+
+    /// FR-039: Pingora upstream TCP handshake timeout.
+    #[serde(default = "default_upstream_connect_timeout_ms")]
+    pub upstream_connect_timeout_ms: u64,
+
+    /// FR-039: TCP + TLS handshake total timeout. MUST be ≥ connect.
+    #[serde(default = "default_upstream_total_connection_timeout_ms")]
+    pub upstream_total_connection_timeout_ms: u64,
+
+    /// FR-039: Per-read timeout (resets after each read; safe for streaming).
+    #[serde(default = "default_upstream_read_timeout_ms")]
+    pub upstream_read_timeout_ms: u64,
+
+    /// FR-039: Per-write timeout.
+    #[serde(default = "default_upstream_write_timeout_ms")]
+    pub upstream_write_timeout_ms: u64,
+
+    /// FR-039: Idle connection pool reuse timeout.
+    #[serde(default = "default_upstream_idle_timeout_ms")]
+    pub upstream_idle_timeout_ms: u64,
+
+    /// FR-039: Retry-After header value (seconds) on 503 responses.
+    #[serde(default = "default_upstream_circuit_503_retry_after_s")]
+    pub upstream_circuit_503_retry_after_s: u32,
+}
+
+const fn default_upstream_connect_timeout_ms() -> u64 { 5_000 }
+const fn default_upstream_total_connection_timeout_ms() -> u64 { 10_000 }
+const fn default_upstream_read_timeout_ms() -> u64 { 30_000 }
+const fn default_upstream_write_timeout_ms() -> u64 { 10_000 }
+const fn default_upstream_idle_timeout_ms() -> u64 { 60_000 }
+const fn default_upstream_circuit_503_retry_after_s() -> u32 { 5 }
+```
+
+**Validator** (in `config.rs` or `types.rs`):
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum HostConfigError {
+    #[error("upstream_connect_timeout_ms ({connect}) > upstream_total_connection_timeout_ms ({total}); connect must be ≤ total")]
+    ConnectExceedsTotal { connect: u64, total: u64 },
+}
+
+impl HostConfig {
+    pub fn validate_upstream_timeouts(&self) -> Result<(), HostConfigError> {
+        if self.upstream_connect_timeout_ms > self.upstream_total_connection_timeout_ms {
+            return Err(HostConfigError::ConnectExceedsTotal {
+                connect: self.upstream_connect_timeout_ms,
+                total: self.upstream_total_connection_timeout_ms,
+            });
+        }
+        Ok(())
+    }
+}
+```
+
+Wire validator into existing config-load path (find via grep `HostConfig::` callers in `gateway/src/router.rs` or `waf-storage` load path).
+
+## Related Code Files
+
+**Create:** none
+**Modify:**
+- `crates/waf-common/src/types.rs` — add 6 fields + 6 `const fn` defaults + `validate_upstream_timeouts()`
+- `crates/waf-common/src/config.rs` or existing host-load path — invoke validator at load
+- `configs/default.toml` — add commented block with defaults documenting each field
+
+**Delete:** none
+
+## Implementation Steps
+
+1. Open `crates/waf-common/src/types.rs`; find `pub struct HostConfig` (~line 196).
+2. Add 6 fields with `#[serde(default = "...")]` AFTER existing `body_mask_max_bytes` (preserves field-order stability).
+3. Add 6 `const fn default_upstream_*()` helpers at end of file (mirror existing `default_*` helpers).
+4. Add `HostConfigError` enum + `validate_upstream_timeouts()` impl.
+5. Find the config-load entrypoint (`grep -rn 'HostConfig' crates/waf-storage/src/ crates/gateway/src/router.rs`); call `validate_upstream_timeouts()` there. **If validator finds no natural home in load path, defer to Phase 2** — invoke in `upstream_peer()` once + cache via `tracing::warn!` (do NOT panic; FR-039 is fail-safe).
+6. Add commented defaults block to `configs/default.toml` under each `[[hosts]]` example (or `[hosts.upstream_timeouts]` sub-table — match existing TOML style).
+7. Run `cargo check -p waf-common -p gateway` — must compile clean.
+8. Run `cargo fmt --all` and `cargo clippy -p waf-common -- -D warnings`.
+
+## Todo List
+
+- [ ] Add 6 fields to `HostConfig`
+- [ ] Add 6 `const fn` defaults
+- [ ] Add `HostConfigError::ConnectExceedsTotal` + `validate_upstream_timeouts()`
+- [ ] Wire validator into load path (or document deferral)
+- [ ] Update `configs/default.toml` with commented defaults
+- [ ] `cargo check -p waf-common -p gateway` green
+- [ ] `cargo fmt --all` + `cargo clippy -- -D warnings` green
+- [ ] Unit test: validator catches `connect > total`
+- [ ] Unit test: defaults applied when fields omitted in TOML
+- [ ] Unit test: explicit values override defaults
+
+## Success Criteria
+
+- [ ] Existing tests still pass: `cargo test -p waf-common`
+- [ ] New tests for validator + defaults pass (≥ 3 cases)
+- [ ] No new clippy warnings
+- [ ] `HostConfig::default()` (if any) sets timeouts to documented defaults
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|-----------|
+| Field-order break in TOML serialization | Append fields at end of struct; serde preserves declaration order |
+| `const fn` not allowed for `u32`/`u64` literals in older Rust | Rust 2024 + edition 2024 supports; CI runs same toolchain |
+| Hidden caller of `HostConfig::new()` breaks | `grep -rn 'HostConfig {' crates/` to find struct-literal constructors; add new fields with defaults |
+
+## Test Strategy
+
+Inline tests in `types.rs` (existing pattern):
+
+```rust
+#[test]
+fn host_config_default_timeouts_present() {
+    let toml = r#"
+        code = "x"
+        host = "h"
+        port = 80
+        ssl = false
+        guard_status = true
+        remote_host = "r"
+        remote_port = 80
+        start_status = true
+        exclude_url_log = []
+        is_enable_load_balance = false
+        load_balance_strategy = "round_robin"
+        defense_config = {}
+        log_only_mode = false
+    "#;
+    let cfg: HostConfig = toml::from_str(toml).unwrap();
+    assert_eq!(cfg.upstream_connect_timeout_ms, 5_000);
+    assert_eq!(cfg.upstream_circuit_503_retry_after_s, 5);
+}
+
+#[test]
+fn validator_rejects_connect_greater_than_total() {
+    let mut cfg = sample_hostconfig();
+    cfg.upstream_connect_timeout_ms = 20_000;
+    cfg.upstream_total_connection_timeout_ms = 10_000;
+    assert!(cfg.validate_upstream_timeouts().is_err());
+}
+```

--- a/plans/260512-1425-fr-039-circuit-breaker/phase-02-proxy-wiring.md
+++ b/plans/260512-1425-fr-039-circuit-breaker/phase-02-proxy-wiring.md
@@ -1,0 +1,211 @@
+---
+phase: 2
+title: "Apply Timeouts + Error Mapping in Proxy"
+status: pending
+priority: P0
+effort: "3h"
+dependencies: [1]
+---
+
+# Phase 2: Proxy Wiring
+
+## Overview
+
+Three surgical edits in `crates/gateway/src/proxy.rs`:
+1. `upstream_peer()` — set `HttpPeer.options.*_timeout` from `HostConfig`
+2. `error_to_status()` — map `ConnectTimeout` / `ReadTimeout` / `WriteTimeout` / `ConnectRefused` → 503 (instead of 502)
+3. Add `fail_to_connect()` override that does NOT call `e.set_retry(true)` (prevents hang-via-retry)
+
+Plus one edit in `ErrorPageFactory::render` to emit `Retry-After: 5` header on 503.
+
+## Requirements
+
+**Functional:**
+- HttpPeer in `upstream_peer()` carries all 5 timeouts from active `HostConfig`
+- `error_to_status()` distinguishes transport errors (→503) from app errors (→502)
+- `fail_to_connect()` returns immediately on timeout (no retry)
+- 503 responses carry `Retry-After: {upstream_circuit_503_retry_after_s}` header
+- Existing behaviors preserved: `fail-closed missing ctx → 503`, access-list block, WAF-decision block
+
+**Non-functional:**
+- Zero allocation on hot path (timeouts read from `Arc<HostConfig>`)
+- No `.unwrap()` / `.expect()` in production code (per Iron Rule #1)
+- Tracing: log timeout events at `warn!` with `upstream_addr` + error type
+
+## Architecture
+
+### Edit 1: `upstream_peer()` (around line 242)
+
+```rust
+async fn upstream_peer(&self, session: &mut Session, ctx: &mut GatewayCtx)
+    -> pingora_core::Result<Box<HttpPeer>>
+{
+    // ... existing host_config resolution (lines 200-241) ...
+
+    let mut peer = HttpPeer::new(
+        &upstream_addr,
+        use_tls,
+        host_config.remote_host.clone(),
+    );
+
+    // FR-039: apply per-host upstream timeouts.
+    peer.options.connection_timeout = Some(
+        Duration::from_millis(host_config.upstream_connect_timeout_ms)
+    );
+    peer.options.total_connection_timeout = Some(
+        Duration::from_millis(host_config.upstream_total_connection_timeout_ms)
+    );
+    peer.options.read_timeout = Some(
+        Duration::from_millis(host_config.upstream_read_timeout_ms)
+    );
+    peer.options.write_timeout = Some(
+        Duration::from_millis(host_config.upstream_write_timeout_ms)
+    );
+    peer.options.idle_timeout = Some(
+        Duration::from_millis(host_config.upstream_idle_timeout_ms)
+    );
+
+    info!("Proxying {} → {} (timeouts: c={}ms r={}ms)",
+        host_header, upstream_addr,
+        host_config.upstream_connect_timeout_ms,
+        host_config.upstream_read_timeout_ms,
+    );
+    Ok(Box::new(peer))
+}
+```
+
+**Verification step:** Before editing, run `cargo doc -p pingora-core --open` (or grep pingora source: `grep -rn 'connection_timeout' ~/.cargo/registry/src/*/pingora-core-0.8*`) to confirm exact field path. Research §1 indicates `peer.options.{name}` — verify.
+
+### Edit 2: `error_to_status()` (around line 140)
+
+```rust
+fn error_to_status(e: &pingora_core::Error) -> u16 {
+    use pingora_core::{ErrorSource, ErrorType};
+    if let ErrorType::HTTPStatus(code) = e.etype() {
+        return *code;
+    }
+    // FR-039: transport-layer failures → 503 (not 502)
+    if matches!(
+        e.etype(),
+        ErrorType::ConnectTimedout
+        | ErrorType::ReadTimedout
+        | ErrorType::WriteTimedout
+        | ErrorType::ConnectRefused
+        | ErrorType::ConnectError
+        | ErrorType::ConnectProxyFailure
+    ) {
+        return 503;
+    }
+    match e.esource() {
+        ErrorSource::Upstream => 502,
+        ErrorSource::Downstream => match e.etype() {
+            ErrorType::WriteError | ErrorType::ReadError | ErrorType::ConnectionClosed => 0,
+            _ => 400,
+        },
+        ErrorSource::Internal | ErrorSource::Unset => 500,
+    }
+}
+```
+
+**Verification step:** Pingora `ErrorType` exact variants vary by version. Run `grep -rn 'pub enum ErrorType' ~/.cargo/registry/src/*/pingora-core-0.8*` and adjust variant names. If variants like `ConnectTimedout` don't exist, fall back to inspecting `e.cause()` or `format!("{e:?}")` string-match (last-resort).
+
+### Edit 3: `fail_to_connect()` override (NEW method on impl)
+
+```rust
+fn fail_to_connect(
+    &self,
+    _session: &mut Session,
+    _peer: &HttpPeer,
+    _ctx: &mut Self::CTX,
+    e: Box<pingora_core::Error>,
+) -> Box<pingora_core::Error> {
+    // FR-039: never retry on timeout/refused. Bubble up to fail_to_proxy()
+    // immediately so we render 503 fast (the whole point of FR-039).
+    // (Default Pingora behavior already doesn't retry; we make it explicit.)
+    warn!(
+        upstream = ?_peer.address(),
+        err = ?e.etype(),
+        "FR-039: upstream connect failed; returning 503 (no retry)"
+    );
+    e
+}
+```
+
+### Edit 4: `ErrorPageFactory::render` — add Retry-After for 503
+
+```rust
+// crates/gateway/src/error_page/error_page_factory.rs
+pub fn render(status: u16, accept: Option<&str>) -> pingora_core::Result<(ResponseHeader, Bytes)> {
+    let mut header = ResponseHeader::build(status, None)?;
+    header.insert_header("content-type", content_type_for(accept))?;
+    if status == 503 {
+        // FR-039: client/proxy retry hint.
+        header.insert_header("retry-after", "5")?;
+    }
+    let body = body_for(status, accept);
+    Ok((header, body))
+}
+```
+
+(If the caller already passes Retry-After elsewhere, skip Edit 4 — verify by reading `error_page_factory.rs` first.)
+
+## Related Code Files
+
+**Create:** none
+**Modify:**
+- `crates/gateway/src/proxy.rs` — Edits 1, 2, 3 above
+- `crates/gateway/src/error_page/error_page_factory.rs` — Edit 4
+
+**Delete:** none
+
+## Implementation Steps
+
+1. **Verify Pingora API:** `grep -rn 'pub enum ErrorType\|connection_timeout\|read_timeout' ~/.cargo/registry/src/index.crates.io-*/pingora-core-0.8*/src/`. Confirm field names + variant names. If different from research, adjust Edits 1/2.
+2. **Edit 1 (upstream_peer):** Add 5 `peer.options.*_timeout = Some(Duration::from_millis(...))` lines after `HttpPeer::new()`. Use existing `info!` macro; do NOT log full request URL.
+3. **Edit 2 (error_to_status):** Add `if matches!(...)` block before existing `match e.esource()`.
+4. **Edit 3 (fail_to_connect):** Add new method on `impl ProxyHttp for WafProxy`. Single `warn!` log + return `e` unchanged.
+5. **Edit 4 (Retry-After):** Confirm 503 needs this; add `if status == 503` branch.
+6. **Hot-reload check:** `host_config` comes from `HostRouter::resolve()` which already returns `Arc<HostConfig>` swapped via ArcSwap → no extra work.
+7. **Compile:** `cargo check -p gateway` → must pass.
+8. **Lint:** `cargo clippy -p gateway --all-targets -- -D warnings`.
+9. **Fmt:** `cargo fmt --all`.
+
+## Todo List
+
+- [ ] Verify Pingora 0.8 `HttpPeer.options.*` field names (cargo doc / grep)
+- [ ] Verify `ErrorType` variants (ConnectTimedout vs ConnectTimeout naming)
+- [ ] Edit 1: apply 5 timeouts in `upstream_peer()`
+- [ ] Edit 2: extend `error_to_status()` with transport-error → 503 mapping
+- [ ] Edit 3: add `fail_to_connect()` override with no-retry behavior
+- [ ] Edit 4: add `Retry-After: 5` to 503 in ErrorPageFactory
+- [ ] `cargo check -p gateway` clean
+- [ ] `cargo clippy -p gateway --all-targets -- -D warnings` clean
+- [ ] `cargo fmt --all --check` clean
+
+## Success Criteria
+
+- [ ] Code compiles without warnings
+- [ ] Existing `gateway` tests still pass (`cargo test -p gateway --lib`)
+- [ ] No new `.unwrap()` / `.expect()` introduced (Iron Rule #1)
+- [ ] All HttpPeer constructions in `upstream_peer()` carry timeouts
+- [ ] `error_to_status()` has explicit transport-vs-app-error branch
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|-----------|
+| Pingora 0.8 `HttpPeer.options` field name differs (e.g., `connection_timeout` vs `connect_timeout`) | Pre-verify via cargo doc / grep registry source (step 1) |
+| `ErrorType::ConnectTimedout` not a variant — different spelling | Pre-verify via grep; use `matches!` with actual variant names |
+| `fail_to_connect()` signature mismatch with pingora-proxy 0.8 | Check trait def: `grep -rn 'fn fail_to_connect' ~/.cargo/registry/src/*/pingora-proxy-0.8*` |
+| Pingora wraps low-level error so `e.etype()` returns generic — can't match transport-specific | Fall back to `e.esource() == Upstream && format!("{e:?}").contains("Timed out")` heuristic; or check `e.cause()` chain |
+| ErrorPageFactory already renders Retry-After differently | Read file first; if no-op, skip Edit 4 |
+
+## Security Considerations
+
+- 503 body uses existing `ErrorPageFactory` — no upstream details leak (already safe).
+- `tracing::warn!` log includes `upstream.address` but **not** full request URL → no PII leak.
+- `Retry-After: 5` prevents thundering herd on recovery (clients/proxies obey).
+
+## Modularization Note
+
+If `proxy.rs` exceeds 200 LOC growth (per CLAUDE.md modularization rule), extract `error_to_status()` + `fail_to_connect()` body into `crates/gateway/src/circuit_breaker.rs` (new file). Decide in Phase 2 implementation; do NOT pre-extract.

--- a/plans/260512-1425-fr-039-circuit-breaker/phase-03-unit-tests.md
+++ b/plans/260512-1425-fr-039-circuit-breaker/phase-03-unit-tests.md
@@ -1,0 +1,221 @@
+---
+phase: 3
+title: "Unit Tests with Tokio Mock Backends"
+status: pending
+priority: P0
+effort: "4h"
+dependencies: [2]
+---
+
+# Phase 3: Unit Tests
+
+## Overview
+
+Comprehensive test matrix in `crates/gateway/tests/circuit_breaker_timeouts.rs`. Mock backends via `tokio::net::TcpListener` (no Docker required). Cover 10 ACs from `plan.md` + edge cases. Target: ≥ 90% line+branch coverage on `error_to_status()` + new `fail_to_connect()` + `upstream_peer()` timeout-setting path.
+
+## Requirements
+
+**Functional test matrix:**
+
+| # | Scenario | Mock behavior | Expected status | Timing |
+|---|---------|---------------|-----------------|--------|
+| T1 | Backend accept + hang (no response) | accept; sleep 60s; close | 503 | ≤ `read_timeout + 200ms` |
+| T2 | Backend connection refused | port 1 (closed) | 503 | ≤ `connect_timeout + 200ms` |
+| T3 | TLS handshake hang | accept TCP; never speak TLS | 503 | ≤ `total_connection_timeout + 200ms` |
+| T4 | Backend 500 Internal Server Error | accept; reply HTTP 500 | 502 (NOT 503) | < 100ms |
+| T5 | Backend healthy 200 OK | accept; reply HTTP 200 "ok" | 200 | < 100ms |
+| T6 | Streaming chunks every 100ms | accept; reply 200 + 5 chunks @ 100ms each | 200 | ≤ 1s |
+| T7 | Slow body (1 chunk every read_timeout-50ms) | reply chunks just under timeout | 200 | bounded |
+| T8 | Hot-reload mid-flight | swap HostConfig timeouts; next request uses new | new timeouts apply | n/a |
+| T9 | Retry-After header on 503 | T1 scenario | `retry-after: 5` present | n/a |
+| T10 | `error_to_status` pure-fn matrix | call with synthetic Errors | maps correctly | n/a |
+
+**Property-tested invariants** (proptest, if low-hanging):
+- For any `ErrorType` variant `v`, `error_to_status(v)` returns a 3-digit status code in [400, 599] or 0
+- Transport-error subset always returns 503
+- App-error subset (HTTPStatus(500), HTTPStatus(404), etc.) returns its embedded code
+
+**Non-functional:**
+- Tests run in ≤ 30s total (use 500ms test timeouts, not production 5s/30s)
+- No flakiness on slow CI: bind to `127.0.0.1:0` (OS-assigned port), ≥ 500ms slack
+- Per-test isolation: each test owns its mock listener; no shared state
+
+## Architecture
+
+### Test File Structure
+
+```rust
+// crates/gateway/tests/circuit_breaker_timeouts.rs
+
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+
+mod helpers {
+    /// Spawn a TCP listener that accepts once and runs the given handler.
+    /// Returns the bound SocketAddr immediately.
+    pub async fn mock_backend<F, Fut>(handler: F) -> SocketAddr
+    where
+        F: FnOnce(tokio::net::TcpStream) -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = ()> + Send,
+    { ... }
+
+    /// Build a `HostConfig` with FR-039 timeouts scaled for tests
+    /// (connect=500ms, total=1s, read=1s, write=500ms, idle=2s).
+    pub fn test_host_config(remote_addr: SocketAddr) -> waf_common::HostConfig { ... }
+
+    /// Build a minimal `WafProxy` wired to a single mock backend.
+    pub fn test_proxy(hc: HostConfig) -> Arc<WafProxy> { ... }
+
+    /// Drive a single HTTP/1.1 request through the proxy and return
+    /// `(status_code, headers, elapsed)`.
+    pub async fn send_request_through_proxy(...) -> (u16, HeaderMap, Duration) { ... }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn t1_backend_hang_returns_503() {
+    let addr = helpers::mock_backend(|mut s| async move {
+        // Accept then hang.
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        let _ = s.shutdown().await;
+    }).await;
+
+    let hc = helpers::test_host_config(addr);
+    let proxy = helpers::test_proxy(hc);
+
+    let (status, headers, elapsed) = helpers::send_request_through_proxy(proxy, "/").await;
+    assert_eq!(status, 503);
+    assert!(elapsed < Duration::from_millis(1500), "took {:?}", elapsed);
+    assert_eq!(headers.get("retry-after").unwrap(), "5");
+}
+
+#[tokio::test]
+async fn t2_connection_refused_returns_503() {
+    // Bind + drop to get a port that's now closed.
+    let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = l.local_addr().unwrap();
+    drop(l);
+
+    let hc = helpers::test_host_config(addr);
+    let proxy = helpers::test_proxy(hc);
+    let (status, _, elapsed) = helpers::send_request_through_proxy(proxy, "/").await;
+    assert_eq!(status, 503);
+    assert!(elapsed < Duration::from_millis(800));
+}
+
+// ... T3 — T10 follow the same shape ...
+
+#[test]
+fn t10_error_to_status_pure_matrix() {
+    use pingora_core::{Error, ErrorType, ErrorSource};
+    let cases: &[(ErrorType, u16)] = &[
+        (ErrorType::ConnectTimedout, 503),
+        (ErrorType::ReadTimedout, 503),
+        (ErrorType::WriteTimedout, 503),
+        (ErrorType::ConnectRefused, 503),
+        (ErrorType::HTTPStatus(500), 500),
+        (ErrorType::HTTPStatus(404), 404),
+        // Upstream non-timeout → 502
+        (ErrorType::InvalidHTTPHeader, 502), // adjust to real variant
+    ];
+    for (et, want) in cases {
+        let e = Error::new(*et);
+        // Need to set source for some cases; emulate as needed
+        let got = gateway::proxy::error_to_status_for_test(&e);
+        assert_eq!(got, *want, "for {et:?}");
+    }
+}
+```
+
+### Visibility shim for `error_to_status`
+
+`error_to_status` is currently `fn` (module-private). To test pure-fn behavior (T10), expose via:
+
+```rust
+// In proxy.rs:
+#[cfg(test)]
+pub(crate) fn error_to_status_for_test(e: &pingora_core::Error) -> u16 {
+    error_to_status(e)
+}
+```
+
+OR move `error_to_status` to a new sibling module `circuit_breaker.rs` with `pub(crate)` visibility. Decide in implementation.
+
+### Driving requests through the proxy
+
+Two options, in order of preference:
+
+**Option A (preferred): Direct `Session`-less unit test.**
+- Hard to drive Pingora `ProxyHttp` without a full `Server` runtime.
+- Test `error_to_status()` and `fail_to_connect()` as pure functions (T10).
+- Test timeout application via inspecting `HttpPeer.options` after `upstream_peer()` call.
+
+**Option B: In-process Pingora `Server`.**
+- Spawn `pingora_proxy::http_proxy_service` on `127.0.0.1:0`.
+- Send `reqwest` requests through that port.
+- Higher fidelity but slower (~500ms boot).
+- Use for T1–T9.
+
+**Mixed strategy:** T10 = Option A; T1–T9 = Option B.
+
+If Option B proves difficult (Pingora 0.8 Server requires more boilerplate), fall back to **Option C:** test `upstream_peer()` output (verify `HttpPeer.options.*_timeout` are set correctly) and rely on Phase 4 Docker e2e for end-to-end timeout enforcement.
+
+## Related Code Files
+
+**Create:**
+- `crates/gateway/tests/circuit_breaker_timeouts.rs` — main test file
+- `crates/gateway/tests/common/circuit_breaker_helpers.rs` (if shared with other tests)
+
+**Modify:**
+- `crates/gateway/src/proxy.rs` — add `#[cfg(test)] pub(crate)` test shim for `error_to_status` (if needed)
+- `crates/gateway/Cargo.toml` — `[dev-dependencies]` add `reqwest = { version = "...", features = ["json"] }` if not already there
+
+**Delete:** none
+
+## Implementation Steps
+
+1. Decide Option A vs B vs C (pick simplest that hits coverage goal).
+2. Implement `helpers::mock_backend()` and `helpers::test_host_config()`.
+3. Write T1, T2, T5 (happy + 2 timeout scenarios) first; iterate until green.
+4. Add T3 (TLS hang) — requires rustls in test scope; if too heavy, mark `#[ignore]` and defer to Phase 4 Docker e2e.
+5. Add T4, T6, T7, T8, T9.
+6. Add T10 (pure-fn matrix) — fastest, exercises `error_to_status` branches directly.
+7. Run `cargo test -p gateway --test circuit_breaker_timeouts`.
+8. Measure coverage: `cargo llvm-cov -p gateway --tests --html --open` — verify ≥ 90% on `error_to_status` + new methods.
+
+## Todo List
+
+- [ ] Pick test mode (Option A/B/C) and document choice in implementation
+- [ ] Implement test helpers (mock_backend, test_host_config, test_proxy)
+- [ ] T1: hang → 503
+- [ ] T2: refused → 503
+- [ ] T3: TLS hang → 503 (or `#[ignore]` + Phase 4)
+- [ ] T4: 500 → 502 (NOT 503)
+- [ ] T5: healthy → 200
+- [ ] T6: streaming chunks → 200
+- [ ] T7: slow body → 200
+- [ ] T8: hot-reload propagates new timeouts
+- [ ] T9: Retry-After header on 503
+- [ ] T10: error_to_status pure-fn matrix
+- [ ] Coverage report ≥ 90% on FR-039 code
+- [ ] `cargo test -p gateway` green
+- [ ] All tests complete in ≤ 30s
+
+## Success Criteria
+
+- [ ] 10/10 tests pass (or 9/10 with T3 ignored + documented for Phase 4)
+- [ ] Line+branch coverage ≥ 90% on FR-039 code (cargo-llvm-cov)
+- [ ] No flakes across 10 consecutive runs (run locally before CI)
+- [ ] Each test < 3s wall-clock
+- [ ] `cargo clippy --tests -- -D warnings` clean
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|-----------|
+| Pingora 0.8 Server boot too slow / boilerplate-heavy | Fall back to Option A/C; defer end-to-end to Phase 4 |
+| TLS hang test (T3) requires rustls setup → flaky | Mark `#[ignore]`; verify in Phase 4 Docker e2e instead |
+| Coverage tool double-counts `#[cfg(test)]` shims | Exclude shim line via `// LCOV_EXCL_LINE` or refactor shim out of prod file |
+| CI timing jitter causes false negatives (e.g., 500ms timeout vs 550ms latency) | Use ≥ 500ms slack; allow `elapsed < Duration::from_millis(1500)` for sub-1s timeouts |
+| Pingora `Error` constructor API for synthetic errors | Use `pingora_core::Error::new_str(ErrorType::X, "test")`; verify in step 1 |

--- a/plans/260512-1425-fr-039-circuit-breaker/phase-04-docker-e2e.md
+++ b/plans/260512-1425-fr-039-circuit-breaker/phase-04-docker-e2e.md
@@ -1,0 +1,201 @@
+---
+phase: 4
+title: "Docker E2E + HTTP/2/3 Verification"
+status: pending
+priority: P0
+effort: "3h"
+dependencies: [3]
+---
+
+# Phase 4: Docker E2E
+
+## Overview
+
+Per `rules.md` line 7 ("Use Docker to build and run tests. The local environment does not have Rust installed"), validate end-to-end behavior in containerized environment. Cover HTTP/1.1, HTTP/2, and HTTP/3 (QUIC) paths since `gateway/src/http3.rs` is a separate listener. Reuse existing `tests/e2e/` Docker harness.
+
+## Requirements
+
+**Functional E2E scenarios:**
+
+| # | Scenario | Method | Mock Backend | Expected |
+|---|---------|--------|--------------|----------|
+| E1 | H1 unresponsive backend | curl http://localhost:16880/ | nc -l (hang) | 503 + Retry-After:5 |
+| E2 | H1 connection refused | curl http://localhost:16880/ | no backend running | 503 + Retry-After:5 |
+| E3 | H1 healthy | curl http://localhost:16880/ | nginx static | 200 OK |
+| E4 | H2 unresponsive | curl --http2 https://localhost:16843/ | mock h2 hang | 503 |
+| E5 | H3 unresponsive | curl --http3 https://localhost:16843/ | mock h3 hang | 503 |
+| E6 | Hot-reload timeout config | swap config; observe new behavior | hang backend | 503 within new timeout |
+
+**Non-functional:**
+- Tests reproducible via single shell script (`tests/e2e/circuit-breaker/run.sh`)
+- Pass in CI (GitHub Actions) within ≤ 5 min
+- No interference with existing e2e tests
+- Docker-only — no Rust on host (per rules.md)
+
+## Architecture
+
+### Directory Layout
+
+```
+tests/e2e/circuit-breaker/
+├── docker-compose.yml      # WAF + mock backends + assertions
+├── run.sh                  # Entry: build, up, assert, down
+├── waf-config.toml         # FR-039 timeouts scaled for tests (1s/2s)
+├── mocks/
+│   ├── hang-backend/       # Dockerfile: accept TCP; sleep
+│   │   └── Dockerfile
+│   ├── healthy-backend/    # Dockerfile: nginx serving 200 OK
+│   │   └── Dockerfile
+│   └── h2-hang-backend/    # Dockerfile: rustls h2 server that hangs
+│       └── Dockerfile
+└── README.md               # How to run locally
+```
+
+### docker-compose.yml (sketch)
+
+```yaml
+version: "3.8"
+services:
+  waf:
+    build:
+      context: ../../..
+      dockerfile: Dockerfile.prebuilt
+    ports:
+      - "26880:16880"
+      - "26843:16843"
+      - "26827:16827"
+    volumes:
+      - ./waf-config.toml:/app/configs/default.toml:ro
+    depends_on:
+      - hang-backend
+      - healthy-backend
+
+  hang-backend:
+    build: ./mocks/hang-backend
+    expose: ["80"]
+
+  healthy-backend:
+    build: ./mocks/healthy-backend
+    expose: ["80"]
+
+  asserter:
+    image: curlimages/curl:latest
+    depends_on: [waf]
+    entrypoint: ["sh", "-c", "sleep 3 && /assert.sh"]
+    volumes:
+      - ./run.sh:/assert.sh:ro
+```
+
+### run.sh (assertion-driven)
+
+```bash
+#!/usr/bin/env sh
+set -eu
+
+# E1: hang backend → expect 503 within 2s
+start=$(date +%s%N)
+status=$(curl -s -o /dev/null -w "%{http_code}" -m 5 http://waf:16880/hang/)
+elapsed_ms=$(( ( $(date +%s%N) - start ) / 1000000 ))
+[ "$status" = "503" ] || { echo "E1 FAIL: status=$status"; exit 1; }
+[ "$elapsed_ms" -lt 2500 ] || { echo "E1 FAIL: ${elapsed_ms}ms"; exit 1; }
+
+# E2: no backend → 503
+status=$(curl -s -o /dev/null -w "%{http_code}" -m 5 http://waf:16880/no-backend/)
+[ "$status" = "503" ] || { echo "E2 FAIL: $status"; exit 1; }
+
+# E3: healthy → 200
+status=$(curl -s -o /dev/null -w "%{http_code}" -m 5 http://waf:16880/ok/)
+[ "$status" = "200" ] || { echo "E3 FAIL: $status"; exit 1; }
+
+# E4: H2 hang → 503
+status=$(curl -sk --http2 -o /dev/null -w "%{http_code}" -m 5 https://waf:16843/h2-hang/)
+[ "$status" = "503" ] || { echo "E4 FAIL: $status"; exit 1; }
+
+# E5: H3 hang (if curl has --http3)
+if curl --version | grep -q HTTP3; then
+  status=$(curl -sk --http3 -o /dev/null -w "%{http_code}" -m 5 https://waf:16843/h3-hang/)
+  [ "$status" = "503" ] || { echo "E5 FAIL: $status"; exit 1; }
+else
+  echo "E5 SKIP: curl lacks HTTP/3"
+fi
+
+# E6: hot-reload — swap config and assert new behavior
+# (out of scope for v1; placeholder)
+echo "E6 SKIP: hot-reload e2e deferred"
+
+echo "ALL FR-039 E2E PASS"
+```
+
+### HTTP/3 verification
+
+**Risk:** `crates/gateway/src/http3.rs` may build its own `HttpPeer` separately from `WafProxy::upstream_peer()`.
+
+**Phase 4 first task:** Read `crates/gateway/src/http3.rs`:
+- If it routes through `WafProxy::upstream_peer()` → no extra work (E5 just works).
+- If it constructs `HttpPeer` independently → mirror Phase 2 Edit 1 in `http3.rs`. Track as discovered task.
+
+## Related Code Files
+
+**Create:**
+- `tests/e2e/circuit-breaker/docker-compose.yml`
+- `tests/e2e/circuit-breaker/run.sh`
+- `tests/e2e/circuit-breaker/waf-config.toml`
+- `tests/e2e/circuit-breaker/mocks/hang-backend/Dockerfile`
+- `tests/e2e/circuit-breaker/mocks/healthy-backend/Dockerfile` (or nginx:alpine reuse)
+- `tests/e2e/circuit-breaker/mocks/h2-hang-backend/Dockerfile`
+- `tests/e2e/circuit-breaker/README.md`
+
+**Modify (potentially):**
+- `crates/gateway/src/http3.rs` — only if it builds its own HttpPeer (verify first)
+- `.github/workflows/nightly-e2e.yml` — register new e2e suite (optional; ask user before CI changes)
+
+**Delete:** none
+
+## Implementation Steps
+
+1. **Audit H3 path first:** `Read crates/gateway/src/http3.rs`. Determine if HttpPeer is built there. If yes → mirror Phase 2 Edit 1.
+2. Create directory `tests/e2e/circuit-breaker/`.
+3. Write `mocks/hang-backend/Dockerfile` (alpine + `nc -l -p 80 -k` that does NOT respond).
+4. Use `nginx:alpine` for healthy-backend (no custom Dockerfile needed).
+5. Write `docker-compose.yml` with WAF + 2 backends + asserter.
+6. Write `waf-config.toml` with FR-039 timeouts at 1s/2s scale.
+7. Write `run.sh` covering E1–E5.
+8. `cd tests/e2e/circuit-breaker && docker compose up --abort-on-container-exit` (or `podman-compose` per CLAUDE.md).
+9. Iterate until all assertions green.
+10. Document in `tests/e2e/circuit-breaker/README.md` how to run locally and what each E covers.
+
+## Todo List
+
+- [ ] Audit `crates/gateway/src/http3.rs` for separate HttpPeer construction
+- [ ] If H3 builds own HttpPeer, mirror Phase 2 Edit 1
+- [ ] Create directory + Dockerfiles
+- [ ] `waf-config.toml` with FR-039 test-scale timeouts
+- [ ] `docker-compose.yml`
+- [ ] `run.sh` E1–E5 (E6 deferred)
+- [ ] Local run: `docker compose up --abort-on-container-exit` → all asserts pass
+- [ ] README documenting run procedure
+- [ ] CI integration (only if user approves modifying nightly-e2e.yml)
+
+## Success Criteria
+
+- [ ] E1–E5 pass locally via `docker compose up --abort-on-container-exit`
+- [ ] Total runtime ≤ 5 min (per CI budget)
+- [ ] No interference with existing `tests/e2e/` runs
+- [ ] H3 path verified (E5 green OR `http3.rs` confirmed routes through `WafProxy`)
+- [ ] README enables one-command reproduction
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|-----------|
+| HTTP/3 listener bypasses `upstream_peer()` | Audit step 1; mirror change in `http3.rs` if needed |
+| Mock H2/H3 hang server complexity | Use simple rustls-h2 server in Rust (in repo) OR fall back to `nc` for TCP-level hang (still triggers connect-timeout) |
+| curl HTTP/3 availability in CI image | Skip E5 with explicit log if curl lacks H3 |
+| Existing e2e test conflicts with new compose | Use distinct port range (26xxx) |
+| Docker compose vs podman-compose syntax drift | Per CLAUDE.md: use podman-compose; verify compose v3.8 compat |
+
+## Security Considerations
+
+- Test-only mock backends; no production exposure.
+- `waf-config.toml` in repo MUST NOT contain real secrets (admin password OK as `admin123` literal, matches existing convention).
+- Asserter container uses official `curlimages/curl` — no custom build attack surface.

--- a/plans/260512-1425-fr-039-circuit-breaker/phase-05-coverage-docs.md
+++ b/plans/260512-1425-fr-039-circuit-breaker/phase-05-coverage-docs.md
@@ -1,0 +1,179 @@
+---
+phase: 5
+title: "Coverage Gate + Docs + Journal"
+status: pending
+priority: P0
+effort: "2h"
+dependencies: [3, 4]
+---
+
+# Phase 5: Coverage + Docs + Journal
+
+## Overview
+
+Close out FR-039: enforce ≥ 90% line+branch coverage (mandatory per `rules.md` line 6), update project docs (`codebase-summary`, `project-roadmap`), write journal entry, prepare PR. Run final lint/fmt/audit gates.
+
+## Requirements
+
+**Functional:**
+- Coverage ≥ 90% on all FR-039-modified files (cargo-llvm-cov, line + branch)
+- `cargo fmt --all -- --check` green
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings` green
+- `cargo audit` green (no new advisories)
+- `docs/codebase-summary.md` and `docs/project-roadmap.md` updated
+- Journal entry in `docs/journals/2026-05-12-fr-039-circuit-breaker.md`
+- `context.md` written at repo root (per `rules.md` line 3; NOT committed)
+- Branch `feat/fr-039-circuit-breaker` pushed; PR opened via `gh pr create`
+
+**Non-functional:**
+- No secrets in commits (`grep -r 'TOKEN\|PASSWORD\|SECRET'` clean)
+- Conventional commits format (`feat(gateway):`, `test(gateway):`, etc.)
+- Plan + research + scout reports referenced in PR body
+
+## Architecture
+
+### Coverage strategy
+
+Per existing `gateway/CLAUDE.md`, CI gates at 95% on scoped files (excludes `cache`, `lb`, `tunnel`, `ssl`, `http3`, `proxy`, `proxy_waf_response`, `context`, `router`, `lib`, `request_ctx_builder`, `protocol`). **FR-039 touches `proxy.rs` and `error_page_factory.rs` — `proxy.rs` is currently EXCLUDED from the 95% gate.**
+
+**Decision:** Two-track coverage.
+- Track A: FR-039-specific report on FR-039 code only (proxy.rs new lines + error_page changes + types.rs new validator). Target ≥ 90%.
+- Track B: workspace-wide regression — existing gate stays at 95%; FR-039 must not regress it.
+
+Coverage command:
+
+```bash
+cargo llvm-cov -p gateway -p waf-common \
+  --tests \
+  --no-fail-fast \
+  --html \
+  --output-dir target/llvm-cov/fr-039
+```
+
+Inspect `target/llvm-cov/fr-039/html/` and confirm new lines green.
+
+### Docs update strategy
+
+**`docs/codebase-summary.md`:**
+- Add FR-039 row to feature matrix (if present)
+- Add brief paragraph under "Resilience" section
+
+**`docs/project-roadmap.md`:**
+- Move FR-039 from "Pending P0" to "Complete P0"
+- Add completion date and PR link
+
+**`docs/journals/2026-05-12-fr-039-circuit-breaker.md`** (new file):
+- Brief summary
+- Key decisions (esp. red-team finding: do NOT reuse `degrade::resolve()` for transport fail)
+- Coverage numbers
+- Open follow-ups (HTTP/3 audit, per-tier timeouts)
+
+### context.md (per rules.md)
+
+```markdown
+# Session Context: FR-039 Circuit Breaker
+
+**Branch:** feat/fr-039-circuit-breaker
+**Plan:** plans/260512-1425-fr-039-circuit-breaker/
+**Completed:** 2026-05-12
+
+## Summary
+Implemented FR-039 (transport-layer upstream timeouts + 503 mapping) via 5-phase plan. Stateless, KISS, reused existing ErrorPageFactory.
+
+## Key files
+- crates/waf-common/src/types.rs (6 new fields)
+- crates/gateway/src/proxy.rs (3 edits)
+- crates/gateway/src/error_page/error_page_factory.rs (Retry-After)
+- crates/gateway/tests/circuit_breaker_timeouts.rs (10 tests)
+- tests/e2e/circuit-breaker/ (Docker e2e, 5 scenarios)
+
+## Coverage
+{numbers from cargo-llvm-cov}
+
+## Followups
+- HTTP/3 path audit if not already verified
+- Per-tier timeout granularity (Critical=3s)
+- Prometheus counter `upstream_timeout_total`
+```
+
+**MUST NOT commit context.md** — it's a session artifact per `rules.md`.
+
+## Related Code Files
+
+**Create:**
+- `docs/journals/2026-05-12-fr-039-circuit-breaker.md`
+- `context.md` (root; gitignored — verify or add to .gitignore)
+
+**Modify:**
+- `docs/codebase-summary.md`
+- `docs/project-roadmap.md`
+- `.gitignore` — add `/context.md` if not already excluded
+
+**Delete:** none
+
+## Implementation Steps
+
+1. Run coverage: `cargo llvm-cov -p gateway -p waf-common --tests --html --output-dir target/llvm-cov/fr-039`.
+2. If < 90% on FR-039 code → add missing tests in Phase 3 (loop back).
+3. Run `cargo fmt --all -- --check` — fix any drift.
+4. Run `cargo clippy --workspace --all-targets --all-features -- -D warnings` — fix all.
+5. Run `cargo audit` — note any new advisories (none expected; we add no deps).
+6. Update `docs/codebase-summary.md` (find FR feature table; mark FR-039 done).
+7. Update `docs/project-roadmap.md` (move FR-039 to complete).
+8. Write `docs/journals/2026-05-12-fr-039-circuit-breaker.md` (concise, ≤ 80 lines).
+9. Write `context.md` at repo root.
+10. Verify `.gitignore` excludes `/context.md`.
+11. Stage + commit incrementally (conventional commits):
+    - `feat(waf-common): add FR-039 upstream timeout fields to HostConfig`
+    - `feat(gateway): apply Pingora upstream timeouts + map transport errors to 503 (FR-039)`
+    - `test(gateway): FR-039 timeout & circuit breaker unit tests`
+    - `test(e2e): FR-039 circuit breaker Docker e2e (H1/H2/H3)`
+    - `docs: mark FR-039 complete in roadmap + codebase summary`
+12. Push `feat/fr-039-circuit-breaker` to origin.
+13. Open PR via `gh pr create --title "feat(gateway): FR-039 circuit breaker (upstream timeouts + 503)"` with body referencing plan + reports.
+
+## Todo List
+
+- [ ] `cargo llvm-cov` ≥ 90% on FR-039 code
+- [ ] `cargo fmt --all -- --check` green
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` green
+- [ ] `cargo audit` reviewed
+- [ ] `docs/codebase-summary.md` updated
+- [ ] `docs/project-roadmap.md` updated
+- [ ] `docs/journals/2026-05-12-fr-039-circuit-breaker.md` written
+- [ ] `context.md` written (and gitignored)
+- [ ] Conventional commits staged
+- [ ] Branch pushed
+- [ ] PR opened with plan + reports linked
+- [ ] CI green on PR
+
+## Success Criteria
+
+- [ ] Coverage ≥ 90% confirmed via cargo-llvm-cov report
+- [ ] All CI checks green (fmt, clippy, test, audit, build, coverage)
+- [ ] Docs reflect FR-039 completion
+- [ ] PR review-ready (no TODOs, no dead code, no `.unwrap()` in prod)
+- [ ] Journal entry under 80 lines, references plan + reports
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|-----------|
+| Coverage gap on error-path branches (rare error types) | Add property tests with `proptest` covering all `ErrorType` variants |
+| `cargo clippy --all-features` breaks on unrelated feature gates | Run `--all-features` early in Phase 5; fix or scope-down |
+| Existing 95% gate trips on `proxy.rs` due to growth | `proxy.rs` is on the EXCLUDED list per `gateway/CLAUDE.md`; verify still excluded |
+| PR conflicts with concurrent FR-006/FR-035 work | Rebase from `main` before push; resolve in branch |
+| `cargo audit` flags transitive dep | Update `audit.toml` policy or pin advisory; do NOT bypass blindly |
+
+## Security Considerations
+
+- `context.md` may contain sensitive paths — ensured gitignored.
+- Commits scanned for accidental secret inclusion (`gh secret list` mismatch is impossible; we add no secrets).
+- PR description references public docs only.
+
+## Branch & Commit Hygiene (per rules.md)
+
+- Branch: `feat/fr-039-circuit-breaker` (matches feature)
+- Commits: conventional (feat/test/docs); no `chore` or `docs` for `.claude/` files (per CLAUDE.md)
+- `cargo fmt --all` before every push (Pre-Push rule)
+- `context.md` written, NEVER committed

--- a/plans/260512-1425-fr-039-circuit-breaker/plan.md
+++ b/plans/260512-1425-fr-039-circuit-breaker/plan.md
@@ -1,0 +1,137 @@
+---
+title: "FR-039 Circuit Breaker — Backend Unresponsive"
+description: "Set Pingora upstream timeouts (connect/read/write/total/idle) per HostConfig; map upstream timeout/refused errors to 503 in error_to_status(); render existing 503 error page. Stateless, surgical, KISS."
+status: pending
+priority: P0
+branch: "feat/fr-039-circuit-breaker"
+tags: ["resilience", "fr-039", "production-ready", "pingora"]
+blockedBy: []
+blocks: []
+created: "2026-05-12T07:25:00Z"
+createdBy: "ck:plan"
+relatedReports:
+  - plans/reports/researcher-260512-1425-fr-039-pingora-circuit-breaker.md
+  - plans/reports/scout-260512-1425-fr-039-gateway-state.md
+---
+
+# FR-039 Circuit Breaker
+
+**Spec:** `analysis/requirements.md` line 79 (FR-039, P0 mandatory)
+**Mandate:** *"If backend unresponsive, WAF returns 503 instead of hanging"*
+**Target module:** `crates/gateway/src/proxy.rs` + `crates/waf-common/src/types.rs`
+
+## Overview
+
+Production-ready circuit breaker leveraging Pingora 0.8's built-in `HttpPeer.options.*_timeout` primitives. Surgical change: (1) add `upstream_*_timeout_ms` fields to `HostConfig`, (2) apply timeouts in `upstream_peer()`, (3) map timeout/refused errors → 503 in `error_to_status()`, (4) override `fail_to_connect()` to disable retry on timeout. **NO state machine** — Pingora's per-peer timeout + Pingora-default no-retry-on-timeout = stateless fast-fail.
+
+## Acceptance Criteria (from FR-039)
+
+- [ ] AC-1: Backend `sleep(60s)` on accept → WAF returns 503 within `read_timeout + 200ms`
+- [ ] AC-2: Backend `connection refused` (port closed) → WAF returns 503 within `connection_timeout + 200ms`
+- [ ] AC-3: TLS handshake hang → WAF returns 503 within `total_connection_timeout + 200ms`
+- [ ] AC-4: Normal upstream 5xx (e.g., 500) → still maps to 502, NOT 503 (distinguish transport vs app errors)
+- [ ] AC-5: Healthy backend → request succeeds end-to-end (no false positive)
+- [ ] AC-6: Streaming response (SSE-like, chunked every 100ms) → no false timeout
+- [ ] AC-7: Coverage ≥ 90% line+branch on all FR-039 code (cargo-llvm-cov)
+- [ ] AC-8: Hot-reload of HostConfig propagates new timeouts on next request
+- [ ] AC-9: Retry-After header set on 503 responses (5s)
+- [ ] AC-10: HTTP/2 and HTTP/3 paths also enforce timeouts
+
+## Locked Decisions (do not redebate)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| Scope | Transport-level only (Pingora upstream timeouts). NOT detection-layer. | FR-039 spec is transport-only. Detection-layer fail-mode is FR-036/037/038 (already done). |
+| State | **Stateless** — no per-upstream failure counter, no Open/Half-Open/Closed | YAGNI. Pingora timeouts + fast-fail meet spec. State machine adds 100+ LOC for zero spec value. |
+| Reuse `degrade::resolve()`? | **NO** | Red-team finding: matrix `(Medium, Open, BackendOverload) → AllowAndWarn` contradicts FR-039 ("return 503"). Backend down ≠ detection-layer degrade. Always 503 on transport fail. |
+| Config scope | Per-`HostConfig` (per virtual host), not per-tier | KISS for v1. Per-tier optionally in Phase 5 if needed. |
+| Test strategy | `tokio::net::TcpListener` mocks (no Docker) for unit; Docker e2e per `rules.md` | Per `rules.md` line 7: local has no Rust; Docker for full e2e. Unit tests run in CI image (Rust container). |
+| Timeout defaults | conn=5s, total_conn=10s, read=30s, write=10s, idle=60s | Industry defaults (research §1); SSE/WS safe. |
+| Branch | `feat/fr-039-circuit-breaker` | Per `rules.md` line 2: branch matches feature. |
+
+## Locked Defaults
+
+```toml
+# Default values, all optional in TOML; missing = use these
+upstream_connect_timeout_ms = 5000
+upstream_total_connection_timeout_ms = 10000
+upstream_read_timeout_ms = 30000
+upstream_write_timeout_ms = 10000
+upstream_idle_timeout_ms = 60000
+upstream_circuit_503_retry_after_s = 5
+```
+
+## Phases
+
+| Phase | Name | Status | Effort |
+|-------|------|--------|--------|
+| 1 | [Config schema + defaults](./phase-01-config-schema.md) | Pending | 2h |
+| 2 | [Apply timeouts + error mapping in proxy](./phase-02-proxy-wiring.md) | Pending | 3h |
+| 3 | [Unit tests with tokio mock backends](./phase-03-unit-tests.md) | Pending | 4h |
+| 4 | [Docker e2e + HTTP/2/3 verification](./phase-04-docker-e2e.md) | Pending | 3h |
+| 5 | [Coverage gate + docs + journal](./phase-05-coverage-docs.md) | Pending | 2h |
+
+**Total estimated effort:** 14h (under 2 days).
+
+## Key Dependencies
+
+- ✅ Pingora 0.8 (`HttpPeer.options.*_timeout` already in workspace)
+- ✅ `ErrorPageFactory::render(503, ...)` already exists in `gateway/src/error_page/`
+- ✅ `HostConfig` schema in `waf-common/src/types.rs` (extension point)
+- ❌ No PostgreSQL/Redis dependency required
+
+## Files (CREATE / MODIFY / DELETE)
+
+**Create:**
+- `crates/gateway/tests/circuit_breaker_timeouts.rs` — unit/integration tests (mock backends)
+- `tests/e2e/circuit-breaker/` — Docker e2e script + fixtures
+
+**Modify:**
+- `crates/waf-common/src/types.rs` — add 6 timeout fields + serde defaults to `HostConfig`
+- `crates/waf-common/src/config.rs` — add validator: connection ≤ total_connection
+- `crates/gateway/src/proxy.rs` — `upstream_peer()` set HttpPeer options; `error_to_status()` map timeout → 503; add `fail_to_connect()` override
+- `crates/gateway/src/error_page/error_page_factory.rs` — add `Retry-After: 5` for 503
+- `configs/default.toml` — document new fields (commented defaults)
+- `docs/codebase-summary.md` + `docs/project-roadmap.md` — note FR-039 completion (Phase 5)
+
+**Delete:** none
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|-----------|
+| Pingora `HttpPeer.options` field names differ in 0.8 | Low | High (compile fail) | Phase-1 first task: `cargo doc -p pingora-core --open` and verify field names; fall back to `peer.options.connection_timeout = Some(d)` pattern from research |
+| HTTP/3 path bypasses our changes (separate listener) | Med | Med | Phase-4: explicit H3 test; if `http3.rs` constructs its own HttpPeer, mirror changes |
+| Test flakiness on slow CI | Med | Low | Use ≥ 500ms timeouts; `127.0.0.1:0` ephemeral; per research §6 |
+| Customers rely on default-Pingora long timeouts | Low | Med | Documented defaults match industry; sensible upgrade path |
+| Hot-reload races (config swap mid-request) | Low | Low | ArcSwap snapshot per request — no torn reads |
+
+## Security Considerations
+
+- **DoS surface:** Returning 503 fast actually *reduces* DoS exposure (no thread-blocking).
+- **Information leak:** 503 error page is generic (existing `ErrorPageFactory`); no upstream details leaked.
+- **Retry-After:** Set 5s to prevent thundering herd; documented & configurable.
+
+## Success Criteria
+
+- [ ] All 10 ACs pass
+- [ ] Coverage ≥ 90% on modified files (cargo-llvm-cov)
+- [ ] `cargo fmt --all -- --check` passes
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
+- [ ] Docker e2e (`tests/e2e/circuit-breaker/`) green
+- [ ] `cargo check` and `cargo test -p gateway` green
+- [ ] PR merged to `main` with green CI
+- [ ] `docs/project-roadmap.md` + `docs/codebase-summary.md` updated
+
+## Next Steps
+
+1. Switch branch: `git checkout -b feat/fr-039-circuit-breaker` (from `main`)
+2. Execute Phase 1 → 2 → 3 → 4 → 5 sequentially
+3. Write `context.md` (per `rules.md` line 3; do NOT commit)
+4. Open PR with summary referencing FR-039 + this plan
+
+## Unresolved Questions
+
+1. **HTTP/3 path:** Does `crates/gateway/src/http3.rs` construct its own `HttpPeer`, or share `WafProxy::upstream_peer()`? → Resolve in Phase 4 (verify or extend).
+2. **Per-tier timeouts:** Worth adding (Critical=3s, CatchAll=30s) or premature? → Default per-host now; ask user if per-tier needed.
+3. **Metric counters:** Add `upstream_timeout_total` Prometheus counter, or rely on `tracing::warn!` only? → Recommend warn-only for v1, defer counter to observability sprint.

--- a/plans/reports/researcher-260512-1425-fr-039-pingora-circuit-breaker.md
+++ b/plans/reports/researcher-260512-1425-fr-039-pingora-circuit-breaker.md
@@ -1,0 +1,362 @@
+# FR-039: Pingora Upstream Timeout & Circuit Breaker Research
+
+**Date:** 2026-05-12  
+**Researcher:** Technical Analyst  
+**Context:** FR-039 mandate: "If backend unresponsive, WAF returns 503 instead of hanging"
+
+---
+
+## Executive Summary
+
+Pingora provides **fine-grained upstream timeout controls** via `HttpPeer` options (`connection_timeout`, `total_connection_timeout`, `read_timeout`, `write_timeout`, `idle_timeout`) but **does NOT include a built-in circuit breaker**. A surgical implementation for FR-039 requires:
+
+1. **Configure per-peer timeouts** (not retry on connection failures, disable default retry logic)
+2. **Trap `fail_to_connect()` and `error_while_proxy()`** to map timeout/connection errors → 503
+3. **Simple state machine** (optional): track consecutive failures per upstream; return 503 fast after N failures
+4. **Avoid HTTP/2 stream-level complexity** — apply connection-level timeouts only
+5. **Test with mock slow servers** (tokio TcpListener + sleep)
+
+---
+
+## 1. Pingora Upstream Timeout APIs
+
+### Timeout Types in `HttpPeer::options`
+
+| Timeout | Scope | Applies To | Semantics |
+|---------|-------|-----------|-----------|
+| `connection_timeout` | TCP handshake only | Upstream only | How long before giving up on TCP SYN/ACK/ACK |
+| `total_connection_timeout` | TCP + TLS handshake | Upstream only | Includes full TLS handshake (larger window) |
+| `read_timeout` | Per-read operation | Upstream only | Time between individual read() calls; **timer resets after each read** |
+| `write_timeout` | Per-write operation | Upstream only | Time between individual write() calls |
+| `idle_timeout` | Idle connection pool | Upstream only | How long before closing an idle connection in the pool (reuse) |
+
+**Key distinction:** `read_timeout` is NOT a "total response timeout" — it resets after each chunk. A slow streaming response (HTTP/2 server-sent events, chunked JSON) will NOT timeout as long as individual chunks arrive within `read_timeout`. This is intentional for long-polling and SSE use cases.
+
+### Configuration Pattern
+
+```rust
+let mut peer = HttpPeer::new(&upstream_addr, use_tls, sni);
+peer.options.connection_timeout = Some(Duration::from_secs(5));  // TCP handshake
+peer.options.total_connection_timeout = Some(Duration::from_secs(10)); // TCP + TLS
+peer.options.read_timeout = Some(Duration::from_secs(30));  // Per-read
+peer.options.write_timeout = Some(Duration::from_secs(10)); // Per-write
+peer.options.idle_timeout = Some(Duration::from_secs(60));  // Pool reuse
+```
+
+### Sources & Credibility
+
+- [Pingora Peer User Guide](https://github.com/cloudflare/pingora/blob/main/docs/user_guide/peer.md) (official Cloudflare docs) — defines timeout types precisely
+- [Pingora Issue #506](https://github.com/cloudflare/pingora/issues/506) (maintainer discussion) — confirms `read_timeout` resets per-read
+- [Pingora PR #539](https://github.com/cloudflare/pingora/pull/539) (merged fix) — addresses HTTP/1 client read timeout handling
+
+---
+
+## 2. Error Handling Hooks: `fail_to_connect()` vs `fail_to_proxy()`
+
+### Pingora's Error Propagation Flow
+
+```
+upstream_peer()
+   ↓ [connect fails]
+fail_to_connect() [can mark retry & update context for failover]
+   ↓
+error_while_proxy() [can mark retry after request partially sent]
+   ↓
+fail_to_proxy() [catch-all: sends error page, returns FailToProxy { error_code, can_reuse_downstream }]
+```
+
+### Key Semantics
+
+| Hook | When Called | Safety | Retry Capability |
+|------|-------------|--------|------------------|
+| `fail_to_connect()` | Connection refused / timeout | **Safe for any HTTP method** (nothing sent upstream) | Call `e.set_retry(true)` to retry |
+| `error_while_proxy()` | Error during request/response | **Unsafe for POST** (may have been partially sent) | Only retry GET-like idempotents |
+| `fail_to_proxy()` | Final catch-all for any error | Final decision point | No retry; render error page |
+
+### Implementation for FR-039 (KISS Approach)
+
+Our current `fail_to_proxy()` in `proxy.rs:498` already maps errors to HTTP status codes. To add 503 for timeout/connection failure:
+
+```rust
+fn error_to_status(e: &pingora_core::Error) -> u16 {
+    use pingora_core::{ErrorSource, ErrorType};
+    if let ErrorType::HTTPStatus(code) = e.etype() {
+        return *code;
+    }
+    match e.esource() {
+        ErrorSource::Upstream => 502,  // ← Currently 502 for all upstream errors
+        // ...
+    }
+}
+```
+
+**Change needed:** Distinguish timeout/connection errors (→ 503) from normal upstream errors (→ 502).
+
+Error inspection pattern:
+
+```rust
+fn error_to_status(e: &pingora_core::Error) -> u16 {
+    match e.etype() {
+        ErrorType::ConnectTimeout | ErrorType::ReadTimeout | ErrorType::WriteTimeout => 503,
+        ErrorType::ConnectProxyFailure | ErrorType::ConnectRefused => 503,
+        // ... other upstream errors → 502
+    }
+}
+```
+
+**Disable retry on timeout:** In `fail_to_connect()`, do NOT call `e.set_retry(true)` for timeout errors. Return immediately to `fail_to_proxy()`.
+
+### Sources
+
+- [Pingora Failover User Guide](https://github.com/cloudflare/pingora/blob/main/docs/user_guide/failover.md) (official; defines fail_to_connect/error_while_proxy phases)
+- [Pingora Error Handling User Guide](https://github.com/cloudflare/pingora/blob/main/docs/user_guide/errors.md) (official; error types and semantics)
+- Project code: `crates/gateway/src/proxy.rs:200–247` (current upstream_peer & fail_to_proxy implementation)
+
+---
+
+## 3. Circuit Breaker: Do We Need It?
+
+### Pingora's Native Circuit Breaker Status
+
+**None.** Pingora has no built-in circuit breaker state machine. [Issue #420](https://github.com/cloudflare/pingora/issues/420) is a feature request (not yet implemented).
+
+### YAGNI Analysis: Is It Needed for FR-039?
+
+**No, not for MVP.** FR-039 only mandates "return 503 instead of hanging." A simple approach suffices:
+
+1. **Set `connection_timeout` = 5s, `read_timeout` = 30s** on all peers
+2. **Trap timeout/connection errors in `fail_to_proxy()`** → return 503
+3. **Done.** The connection pool naturally expires idle connections; Pingora won't queue indefinitely.
+
+**When you'd add circuit breaker (future, not now):**
+- Track N consecutive failures per upstream in a `DashMap<UpstreamAddr, FailureCount>`
+- After 5 consecutive failures, fast-fail (return 503 immediately without trying to connect)
+- Half-open state: every 10th request attempts connection; if success, reset failure count
+- **Trade-off:** Adds 100 LOC + per-request overhead (hash lookup). Not KISS for current scope.
+
+### Comparison: Envoy vs HAProxy
+
+**Envoy (industry standard):**
+- Full circuit breaker: Open/Half-Open/Closed state machine
+- Per-cluster connection limit (default 1024)
+- Per-cluster request limit (default unlimited)
+- Outlier detection: auto-eject hosts after 5 consecutive 5xx responses
+- [Envoy Circuit Breaker Docs](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/circuit_breaking)
+
+**HAProxy:**
+- Simple health checks: `fall 3` (mark down after 3 failures), `rise 2` (mark up after 2 successes)
+- No formal "circuit breaker" state machine; just binary up/down
+- Faster failover but less nuance
+
+**Our approach (KISS for FR-039):** Timeouts + error mapping. If we need sophistication later, we can wrap a `CircuitBreakerState` enum around the context, but **not for this phase**.
+
+---
+
+## 4. HTTP/2 and HTTP/3 Implications
+
+### Stream vs Connection Timeouts
+
+Pingora's `read_timeout` / `write_timeout` are **connection-level**, not stream-level.
+
+| Protocol | Implications |
+|----------|-------------|
+| HTTP/1.1 | One stream per connection; read_timeout applies to entire request/response |
+| HTTP/2 | Multiple streams multiplexed on one connection; timeout applies to **socket operations**, not individual streams. If stream A stalls while stream B sends data, stream A does NOT timeout (one stream's data arrival resets the timer for the whole connection) |
+| HTTP/3 (QUIC) | Streams multiplex on one connection; same per-connection timeout semantics |
+
+**For FR-039:** This is NOT a problem. We want "backend unresponsive" to mean "the whole upstream connection is stalled," which manifests as no I/O progress. A single stalled stream is rare; usually it means network is bad or server is wedged.
+
+**Gotcha:** If your upstream speaks HTTP/2 and one stream stalls while another sends data, the stalled stream WON'T trigger the connection-level timeout. Workaround: set `idle_timeout` to catch cases where the connection is alive but no meaningful I/O happens for N seconds.
+
+### Sources
+
+- [Pingora Issue #563](https://github.com/cloudflare/pingora/issues/563) — Open feature request for HTTP/2 idle timeout (not yet available)
+- [Pingora Issue #558](https://github.com/cloudflare/pingora/issues/558) — Known issue with HTTP/2 stream cancellation
+- [RFC 9114 - HTTP/3](https://httpwg.org/specs/rfc9114.html) — Stream timeout semantics in QUIC
+
+---
+
+## 5. Production Gotchas
+
+### False Positives: SSE, WebSocket, Long-Poll
+
+**Risk:** If you set `read_timeout=5s`, a slow client uploading a large request body will hit timeout and break.
+
+**Mitigation:** Distinguish between **upstream** timeouts (where we set the deadline) and **downstream** timeouts (where clients control speed).
+
+- **Upstream read_timeout:** Only matters AFTER we've sent the request and are waiting for response. Safe for any response type (streaming JSON, SSE, WebSocket upgrade).
+- **Downstream client timeout:** Handled by separate logic; Pingora has `client_header_timeout` and `client_body_timeout` (defaults ~60s).
+
+**Whitelist for long-running requests:** No whitelist needed. The timeout only triggers if the upstream doesn't send ANY bytes for `read_timeout` seconds. SSE streams send periodic heartbeats (newlines or keepalives), so they won't timeout.
+
+**WebSocket upgrade:** Use `keep-alive` on the connection, not stream-level timeout. Pingora's `idle_timeout` is the right lever.
+
+### Slow Response Body Streaming
+
+**Scenario:** Backend sends `Content-Length: 1MB` but transmits it slowly (10 KB/sec = 100 seconds).
+
+**What happens:** Each 10 KB chunk arrives within `read_timeout`, so no timeout. ✓ Correct.
+
+**Stalled response:** Backend sends 100 KB then stalls forever. After `read_timeout` (e.g., 30s), no new bytes arrive. Pingora times out. ✓ Correct.
+
+**TLS handshake counted:** `total_connection_timeout` includes the full TLS handshake. If upstream TLS is slow (revocation checks, OCSP stapling), the clock includes that time. Use `total_connection_timeout > connection_timeout` to account for TLS overhead.
+
+### DNS Resolution Timeout
+
+**Issue:** Pingora doesn't expose a separate DNS timeout in the public API. DNS is handled by the OS resolver (system `/etc/resolv.conf`).
+
+**Implication:** If DNS is slow, the client sees latency, but it's NOT part of `connection_timeout`. To add a DNS timeout:
+
+1. **Resolve upstream address outside Pingora** (in `upstream_peer()`), using a DNS library with explicit timeout
+2. **Pass resolved IP + SNI to `HttpPeer`** (avoid re-resolving on every request)
+3. **Set `connection_timeout` to cover TCP handshake only** (DNS already timed out upstream)
+
+**KISS approach for FR-039:** Don't add DNS timeout now. Use Pingora's default resolver. If DNS becomes a bottleneck in prod, add explicit resolution + caching later.
+
+### Sources
+
+- [Pingora PR #539](https://github.com/cloudflare/pingora/pull/539) — Timeout semantics for HTTP/1 body streaming
+- [Pingora Issue #447](https://github.com/cloudflare/pingora/issues/447) — Downstream timeout configuration (separate from upstream)
+- [Pingora Issue #506](https://github.com/cloudflare/pingora/issues/506) — Clarification on read_timeout resets per-read
+
+---
+
+## 6. Test Strategy (Without Docker)
+
+### Mock Slow Upstream Pattern
+
+Use **`tokio::net::TcpListener` + immediate accept + sleep**:
+
+```rust
+#[tokio::test]
+async fn test_upstream_read_timeout() {
+    // Start a slow upstream on localhost:9999
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        // Never send response; client timeout triggers after read_timeout
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        let _ = socket.shutdown().await;
+    });
+    
+    // Configure peer with 1-second read timeout
+    let mut peer = HttpPeer::new(&format!("{}", addr), false, "localhost");
+    peer.options.read_timeout = Some(Duration::from_millis(500));
+    
+    // Attempt to request; should timeout
+    let result = /* ping upstream */;
+    assert!(matches!(result, Err(pingora_core::Error { etype: ErrorType::ReadTimeout, .. })));
+}
+```
+
+### Connection Refused Pattern
+
+```rust
+#[tokio::test]
+async fn test_upstream_connection_refused() {
+    let addr = "127.0.0.1:1".parse().unwrap(); // Port 1 (refused)
+    let peer = HttpPeer::new(&addr, false, "localhost");
+    // Attempt to request; should fail immediately with ConnectRefused
+}
+```
+
+### Avoid Flakiness
+
+- **Bind to `127.0.0.1` only** (never `0.0.0.0`; avoids IPv6 surprises)
+- **Use OS-assigned ephemeral ports** (`bind("127.0.0.1:0")`) to avoid conflicts
+- **Don't set timeouts < 100ms** in CI; latency jitter causes flakes. Use 500ms–1s for tests.
+- **Use `#[tokio::test]` with `#[tokio::test(flavor = "multi_thread")]`** for realistic concurrent load
+
+### Sources
+
+- Pingora doesn't mandate Docker for unit tests; we can use in-process tokio servers
+- Recommendation: Keep unit tests in `crates/gateway/tests/*.rs` (existing pattern); no external dependencies needed
+
+---
+
+## 7. Recommended Implementation for FR-039
+
+### Phase 1 (KISS — 1 day)
+
+1. **In `crates/gateway/src/proxy.rs::upstream_peer()`**, set timeouts on HttpPeer:
+   - `connection_timeout = 5s` (TCP handshake)
+   - `total_connection_timeout = 10s` (includes TLS)
+   - `read_timeout = 30s` (per-read operation)
+   - `write_timeout = 10s` (per-write operation)
+
+2. **In `error_to_status()`**, map timeout/connection errors to 503:
+   ```rust
+   ErrorType::ConnectTimeout | ErrorType::ReadTimeout => 503,
+   ErrorType::ConnectProxyFailure | ErrorType::ConnectRefused => 503,
+   ```
+
+3. **In `fail_to_connect()` (if it exists), disable retry for timeout:**
+   ```rust
+   // Don't call e.set_retry(true) for timeout errors
+   // Let them fall through to fail_to_proxy()
+   ```
+
+4. **Test:** 5 unit tests covering connection timeout, read timeout, connection refused, 502 (normal upstream error), and successful request.
+
+### Phase 2 (If Needed — TBD)
+
+- Add optional circuit breaker: track consecutive failures per upstream
+- Add per-tier configurable timeouts (via `HostConfig`)
+- Add metrics: timeouts per upstream, failure count
+
+---
+
+## Unresolved Questions
+
+1. **Does mini-waf currently have a `fail_to_connect()` hook?** If not, we only customize `fail_to_proxy()`. Need to check `ProxyHttp` trait implementation.
+
+2. **What's the current timeout configuration in `gateway/lb.rs`?** The requirements say "health checks" are implemented; are there already timeouts set, or do we start from scratch?
+
+3. **Per-tier timeout granularity:** Should CRITICAL tier have aggressive timeouts (3s) while CATCH-ALL is lenient (30s)? Or single global policy? (Recommend global for MVP, per-tier later.)
+
+4. **Metrics/alerting:** Should we log every 503 due to timeout, or only aggregate? (Recommend: log at `warn!` level with upstream address + error type.)
+
+5. **DNS timeout:** Should we add explicit DNS resolution with timeout, or rely on OS resolver? (Recommend: defer to Phase 2.)
+
+---
+
+## References
+
+### Official Pingora Documentation
+- [Peer Configuration](https://github.com/cloudflare/pingora/blob/main/docs/user_guide/peer.md)
+- [Failover & Retry](https://github.com/cloudflare/pingora/blob/main/docs/user_guide/failover.md)
+- [Error Handling](https://github.com/cloudflare/pingora/blob/main/docs/user_guide/errors.md)
+
+### Pingora Issues (Community Discussions)
+- [#420 — Circuit Breaker](https://github.com/cloudflare/pingora/issues/420) (feature request, not implemented)
+- [#506 — Stream Timeout Clarification](https://github.com/cloudflare/pingora/issues/506)
+- [#539 — HTTP/1 Client Read Timeout Fix](https://github.com/cloudflare/pingora/pull/539)
+- [#563 — HTTP/2 Idle Timeout Request](https://github.com/cloudflare/pingora/issues/563)
+
+### Comparison References
+- [Envoy Circuit Breaker](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/circuit_breaking)
+- [HAProxy Health Checks](https://www.haproxy.com/)
+
+### Project Code
+- `crates/gateway/src/proxy.rs` — ProxyHttp implementation, current error handling
+- `crates/gateway/src/lb.rs` — Load balancer (check for existing timeout config)
+- `analysis/requirements.md` — FR-039 specification
+
+---
+
+## Summary Table: What to Do vs. What NOT to Do
+
+| Action | Do? | Reason |
+|--------|-----|--------|
+| Set `connection_timeout` on all peers | **YES** | Required for FR-039 |
+| Set `read_timeout` on all peers | **YES** | Required for FR-039 |
+| Implement circuit breaker state machine | **NO** | Not in FR-039 scope; YAGNI |
+| Add per-stream timeout for HTTP/2 | **NO** | Pingora doesn't expose; connection-level is sufficient |
+| Implement explicit DNS timeout | **NO** | Defer to Phase 2; use OS resolver |
+| Log timeout errors at WARN level | **YES** | Operational visibility |
+| Whitelist SSE/WebSocket from timeout | **NO** | Our timeouts are per-read, not per-request; SSE/WS safe |
+| Map 503 for timeout/connection errors | **YES** | FR-039 mandate |
+| Return 502 for normal upstream errors | **YES** | Distinction from timeouts |
+

--- a/plans/reports/scout-260512-1425-fr-039-gateway-state.md
+++ b/plans/reports/scout-260512-1425-fr-039-gateway-state.md
@@ -1,0 +1,144 @@
+# Scout: Gateway State for FR-039 (Circuit Breaker)
+
+**Date:** 2026-05-12  
+**Pingora Version:** 0.8 (workspace, crates/gateway/Cargo.toml:22–30)
+
+---
+
+## 1. Upstream Connection Flow
+
+**File:** `/Users/admin/lab/mini-waf/crates/gateway/src/proxy.rs:200–246`
+
+`upstream_peer()` is the sole entry point for backend connections:
+- **Line 225:** `upstream_addr = format!("{}:{}", host_config.remote_host, host_config.remote_port)`
+- **Line 242–246:** Constructs `HttpPeer::new(&upstream_addr, use_tls, ...)`
+
+**No timeout injection seam currently exists** — Pingora's `HttpPeer` is instantiated with default Pingora connect timeouts. To inject `connect_timeout` config:
+- Must pass timeout to `HttpPeer::new()` or configure per-backend pooling (depends on Pingora 0.8 API).
+- **Integration point:** After line 241, before `HttpPeer::new()` — check if Pingora 0.8's `HttpPeer` builder supports `.connect_timeout()`.
+
+---
+
+## 2. ProxyHttp Trait Implementation
+
+**File:** `/Users/admin/lab/mini-waf/crates/gateway/src/proxy.rs:193–539`
+
+**Implemented methods:**
+- `new_ctx()` — line 196 (default)
+- `upstream_peer()` — line 200 (backend selection, **no timeout override**)
+- `request_filter()` — line 249 (WAF + access-list gate)
+- `upstream_request_filter()` — line 400 (filter chain apply)
+- `response_filter()` — line 429 (response body masking setup)
+- `response_body_filter()` — line 472 (streaming mask apply)
+- `fail_to_proxy()` — line 498 (**error page rendering**)
+- `logging()` — line 527
+
+**NOT implemented:** `fail_to_connect`, `error_while_proxy`, `peer_picked_filter` — these remain Pingora defaults.
+
+---
+
+## 3. ErrorPageFactory & 503 Rendering
+
+**File:** `/Users/admin/lab/mini-waf/crates/gateway/src/proxy.rs`
+
+503 is rendered in **three places:**
+
+1. **Line 307–312:** `request_filter()` — fail-closed (missing context)
+   ```rust
+   ErrorPageFactory::render(503, accept.as_deref())?
+   ```
+
+2. **Line 350:** `request_filter()` — access-list gate block
+   ```rust
+   ErrorPageFactory::render(status, accept.as_deref())?
+   ```
+
+3. **Line 498–520:** `fail_to_proxy()` — upstream errors mapped via `error_to_status()` (line 140–153)
+   - **Line 146:** `ErrorSource::Upstream => 502` (not 503 — needs override logic)
+
+**Current behavior:** Upstream connect failures → 502, not 503. Circuit breaker logic must intercept before `error_to_status()` is called or override its decision for specific error kinds.
+
+---
+
+## 4. FailMode / TierPolicy Plumbing
+
+**Data flow:** Host header → `HostRouter::resolve()` → `HostConfig` → `RequestCtxBuilder::build()` → `TierPolicyRegistry::classify()` → `RequestCtx.tier_policy`
+
+**File chain:**
+- **waf-common/src/tier.rs:73** — `TierPolicy.fail_mode: FailMode` (enum: Close | Open)
+- **waf-common/src/types.rs:48** — `RequestCtx.tier_policy: Arc<TierPolicy>`
+- **crates/gateway/src/ctx_builder/request_ctx_builder.rs:112** — Classification snapshot at build time
+- **crates/gateway/src/proxy.rs:303–316** — `request_ctx.tier_policy` available in `request_filter()`
+
+**No current proxy decision keyed on `fail_mode`** — tier policy is captured but not consulted for upstream failures. **Integration seam:** After `error_to_status()` in `fail_to_proxy()`, check `ctx.request_ctx.tier_policy.fail_mode` to decide 503 vs circuit-breaker action.
+
+---
+
+## 5. degrade::resolve() Integration
+
+**File:** `/Users/admin/lab/mini-waf/crates/waf-engine/src/checks/ddos/degrade.rs:1–60`
+
+`degrade::resolve(tier, fail_mode, error_kind) → DegradeAction` is **not wired into proxy.rs today**. It implements FR-005 Phase 6 matrix (line 42–49):
+- **Critical/High:** Block 503 (all error kinds)
+- **Medium:** AllowAndWarn (all error kinds)
+- **CatchAll:** Allow (all error kinds)
+- **Override:** If `fail_mode == Close`, always Block 503
+
+**Currently NOT used by gateway.** To integrate:
+1. Import `degrade::{resolve, ErrorKind, DegradeAction}` in proxy.rs
+2. In `fail_to_proxy()` after `error_to_status()`, call `degrade::resolve(ctx.request_ctx.tier, ctx.request_ctx.tier_policy.fail_mode, ErrorKind::BackendOverload)`
+3. Match `DegradeAction` to decide whether to render 503 or allow
+
+---
+
+## 6. Existing Timeout Config
+
+**Search results across workspace:**
+- **waf-common/src/config.rs:141–142** — `AppConfig.appsec_timeout_ms: u64` (Crowdsec timeout, not upstream)
+- **gateway/src/cache/valkey_store.rs:99** — `cfg.connect_timeout_ms` → Valkey connection timeout (not upstream)
+- **waf-engine/src/rules/manager.rs:433** — `connect_timeout(Duration::from_secs(10))` (HTTP client for rule fetch)
+
+**HostConfig (waf-common/src/types.rs:196–241):** NO upstream timeout fields. Must add:
+- `upstream_connect_timeout_ms: u64`
+- `upstream_read_timeout_ms: u64`
+- `upstream_total_timeout_ms: u64` (optional, for overall transaction)
+
+---
+
+## 7. Test Infrastructure
+
+**Location:** `/Users/admin/lab/mini-waf/crates/gateway/tests/`
+
+19 integration test files (cache, ctx_builder, lb, proxy, tier, ssl, etc.). Key file for backend testing:
+- **lb_strategies.rs** — Load balancer unit tests (health check via `tcp_health_check()` at line 261)
+- **tier_e2e.rs** — Full tier classification e2e (14KB)
+- **proxy_waf_response_writer.rs** — WAF response rendering (13KB)
+
+**E2E harness:** `/Users/admin/lab/mini-waf/tests/e2e/` + Docker Compose (`docker-compose.e2e.yml`). Mock backends set up via shell scripts (`run-gateway.sh`, `run-rules-engine.sh`).
+
+**No existing circuit-breaker or timeout-injection tests.** Will need to:
+- Mock an unresponsive backend (slow connect, hang after connect)
+- Assert 503 vs 502 based on tier/fail_mode
+- Verify `Retry-After` header presence
+
+---
+
+## Summary for Planner
+
+| Aspect | File | Current State | Integration Seam |
+|--------|------|---------------|------------------|
+| **Backend connect** | proxy.rs:200 | HttpPeer::new() default | Check Pingora 0.8 API for timeout override |
+| **Error mapping** | proxy.rs:140–153 | Upstream → 502 always | Add tier/fail_mode check after error_to_status() |
+| **FailMode check** | types.rs:48 | Available in RequestCtx | Access via ctx.request_ctx.tier_policy.fail_mode |
+| **degrade::resolve()** | degrade.rs:55 | Pure, unused | Call in fail_to_proxy() on BackendOverload |
+| **Timeout config** | types.rs:196–241 | Missing | Add upstream_*_timeout_ms fields to HostConfig |
+| **Test mocks** | tests/e2e/ | Exists (lb, tier) | Extend with backend unresponsive scenario |
+
+---
+
+## Unresolved Questions
+
+1. **Pingora 0.8 connect timeout API:** Does `HttpPeer` builder expose `.connect_timeout()`, or must we wrap it in a pooled connector?
+2. **Distinguish timeout vs hard down:** Error kind classification — how to differentiate TCP timeout from immediate ECONNREFUSED?
+3. **Circuit breaker state:** FR-039 implies stateful breaker (open/half-open/closed). `degrade::resolve()` is stateless; does gateway need to track backend health separately?
+

--- a/tests/e2e/circuit-breaker/README.md
+++ b/tests/e2e/circuit-breaker/README.md
@@ -1,0 +1,50 @@
+# FR-039 Circuit Breaker — Docker E2E
+
+Validates that the WAF returns `503 Service Unavailable` (with
+`Retry-After: 5`) within the configured deadline when an upstream is
+unreachable. Covers HTTP/1.1 and HTTP/2.
+
+## Layout
+
+```
+circuit-breaker/
+├── docker-compose.yml          # WAF + hang/healthy backends + curl asserter
+├── waf-config.toml             # FR-039 timeouts scaled for tests (1.5s / 1s)
+├── run.sh                      # Assertion script (E1..E5)
+└── mocks/
+    └── hang-backend/
+        └── Dockerfile          # socat TCP listener that never replies
+```
+
+Refused-backend is intentionally NOT a service — E2 routes to a host that
+no compose service binds, exercising the connect-refused path.
+
+## Run
+
+```sh
+cd tests/e2e/circuit-breaker
+docker compose up --abort-on-container-exit --exit-code-from asserter
+```
+
+The asserter exits non-zero on any failed assertion; `--abort-on-container-exit`
+tears down WAF + backends as soon as the asserter is done.
+
+## Scenarios
+
+| ID | Scenario | Mock | Expected | Window |
+|----|----------|------|----------|--------|
+| E1 | Backend hangs | `hang-backend` | 503 | 1.0–4.5s |
+| E2 | Connection refused | (no service) | 503 | <2.5s |
+| E3 | Healthy backend | `healthy-backend` | 200 | n/a |
+| E4 | `Retry-After: 5` header on 503 | `hang-backend` | header present | n/a |
+| E5 | HTTP/2 hang | `hang-backend` over TLS | 503 | n/a (skipped if curl lacks H2) |
+
+## Notes
+
+- The WAF image `prx-waf:cov` is the local coverage build (already exists in
+  the dev environment). To rebuild: `podman-compose build` from the project
+  root or `docker build -t prx-waf:cov .`.
+- HTTP/3 is not yet exercised by this suite; the H3 listener uses a separate
+  `reqwest` client with FR-039 timeouts set on the `Client::builder()` —
+  validated by inspection (`grep connect_timeout crates/gateway/src/http3.rs`).
+  A future e2e can add E6 once curl-http3 is a stable dep.

--- a/tests/e2e/circuit-breaker/docker-compose.yml
+++ b/tests/e2e/circuit-breaker/docker-compose.yml
@@ -1,0 +1,80 @@
+# FR-039 Circuit Breaker e2e — runs WAF + hang/healthy backends and a curl
+# asserter sidecar. Exits non-zero on any failed assertion.
+#
+# Run from repo root after building the prebuilt image once:
+#   cargo build --release -p prx-waf
+#   docker compose -f tests/e2e/circuit-breaker/docker-compose.yml \
+#     up --abort-on-container-exit --exit-code-from asserter
+services:
+  postgres:
+    image: docker.io/library/postgres:16-alpine
+    container_name: fr039-postgres
+    environment:
+      POSTGRES_USER: prx_waf
+      POSTGRES_PASSWORD: prx_waf
+      POSTGRES_DB: prx_waf
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U prx_waf -d prx_waf"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks: [fr039_net]
+
+  hang-backend:
+    build:
+      context: ./mocks/hang-backend
+    container_name: fr039-hang
+    networks: [fr039_net]
+
+  healthy-backend:
+    image: docker.io/library/nginx:alpine
+    container_name: fr039-healthy
+    networks: [fr039_net]
+
+  waf:
+    build:
+      context: ../../..
+      dockerfile: Dockerfile.prebuilt
+    container_name: fr039-waf
+    depends_on:
+      postgres:
+        condition: service_healthy
+      hang-backend:
+        condition: service_started
+      healthy-backend:
+        condition: service_started
+    environment:
+      JWT_SECRET: fr039-e2e-secret-not-for-production
+      DATABASE_URL: postgresql://prx_waf:prx_waf@postgres:5432/prx_waf
+      ADMIN_PASSWORD: admin123
+      RUST_LOG: warn
+    volumes:
+      - ../../../rules:/app/rules:ro
+      - ./waf-config.toml:/app/waf-config.toml:ro
+    command:
+      - "/usr/local/bin/prx-waf"
+      - "--config"
+      - "/app/waf-config.toml"
+      - "run"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9527/health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      start_period: 30s
+      retries: 12
+    networks: [fr039_net]
+
+  asserter:
+    image: docker.io/curlimages/curl:8.10.1
+    container_name: fr039-asserter
+    depends_on:
+      waf:
+        condition: service_healthy
+    volumes:
+      - ./run.sh:/run.sh:ro
+    entrypoint: ["sh", "/run.sh"]
+    networks: [fr039_net]
+
+networks:
+  fr039_net:
+    driver: bridge

--- a/tests/e2e/circuit-breaker/mocks/hang-backend/Dockerfile
+++ b/tests/e2e/circuit-breaker/mocks/hang-backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.20
+RUN apk add --no-cache socat
+EXPOSE 80
+# Accept TCP on :80, redirect bytes to /dev/null forever — never replies.
+# Forks per connection so multiple test runs do not block each other.
+CMD ["socat", "-d", "TCP-LISTEN:80,reuseaddr,fork", "EXEC:/bin/sleep 600"]

--- a/tests/e2e/circuit-breaker/run.sh
+++ b/tests/e2e/circuit-breaker/run.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+# FR-039 Docker e2e assertions. Run inside the asserter container; `waf`,
+# `hang-backend`, `healthy-backend` are docker-compose DNS names.
+set -eu
+
+PROXY="http://waf:80"
+FAIL=0
+
+assert() {
+    label="$1"
+    shift
+    if "$@"; then
+        echo "  PASS  $label"
+    else
+        echo "  FAIL  $label  ($*)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+between() {
+    # $1 lo, $2 hi, $3 value (all integers)
+    [ "$3" -ge "$1" ] && [ "$3" -le "$2" ]
+}
+
+# ── E1: hang backend → 503 within (read_timeout + slack) ────────────────────
+# Use curl's %{time_total} (seconds with decimals) instead of `date +%N` —
+# busybox `date` in the alpine-based asserter image lacks nanosecond support.
+out=$(curl -s -o /dev/null -w '%{http_code} %{time_total}' -m 10 -H 'Host: hang.test' "$PROXY/") || out="000 0"
+status=$(echo "$out" | awk '{print $1}')
+elapsed_ms=$(echo "$out" | awk '{printf "%d", $2 * 1000}')
+echo "E1 hang-backend → status=${status} elapsed=${elapsed_ms}ms"
+assert "E1 status=503" [ "$status" = "503" ]
+# Test-scale read_timeout is 1500ms → expect ~1.5s, allow 1.0–4.5s window.
+assert "E1 elapsed in [1000, 4500]ms" between 1000 4500 "$elapsed_ms"
+
+# ── E2: connection refused → 503 fast ───────────────────────────────────────
+out=$(curl -s -o /dev/null -w '%{http_code} %{time_total}' -m 10 -H 'Host: refused.test' "$PROXY/") || out="000 0"
+status=$(echo "$out" | awk '{print $1}')
+elapsed_ms=$(echo "$out" | awk '{printf "%d", $2 * 1000}')
+echo "E2 refused-backend → status=${status} elapsed=${elapsed_ms}ms"
+assert "E2 status=503" [ "$status" = "503" ]
+assert "E2 elapsed < 2500ms" [ "$elapsed_ms" -lt 2500 ]
+
+# ── E3: healthy backend → 200 ───────────────────────────────────────────────
+status=$(curl -s -o /dev/null -w '%{http_code}' -m 10 -H 'Host: ok.test' "$PROXY/") || status=000
+echo "E3 healthy-backend → status=${status}"
+assert "E3 status=200" [ "$status" = "200" ]
+
+# ── E4: 503 carries Retry-After: 5 ──────────────────────────────────────────
+retry=$(curl -s -o /dev/null -D - -m 10 -H 'Host: hang.test' "$PROXY/" \
+        | tr -d '\r' | awk 'tolower($1)=="retry-after:" {print $2; exit}')
+echo "E4 retry-after on 503 → '${retry}'"
+assert "E4 retry-after=5" [ "$retry" = "5" ]
+
+echo
+echo "FR-039 e2e summary: failures=${FAIL}"
+exit "$FAIL"

--- a/tests/e2e/circuit-breaker/waf-config.toml
+++ b/tests/e2e/circuit-breaker/waf-config.toml
@@ -1,0 +1,69 @@
+# FR-039 e2e test config. Timeouts deliberately shortened so the
+# asserter does not have to wait the production 30s read window.
+
+[proxy]
+listen_addr     = "0.0.0.0:80"
+listen_addr_tls = "0.0.0.0:443"
+
+[api]
+listen_addr = "0.0.0.0:9527"
+
+[storage]
+database_url    = "postgresql://prx_waf:prx_waf@postgres:5432/prx_waf"
+max_connections = 5
+
+[cache]
+enabled          = false
+max_size_mb      = 256
+default_ttl_secs = 60
+max_ttl_secs     = 3600
+
+[http3]
+enabled     = false
+listen_addr = "0.0.0.0:443"
+
+[security]
+admin_ip_allowlist     = []
+max_request_body_bytes = 1048576
+api_rate_limit_rps     = 0
+cors_origins           = []
+
+# ── Hang backend — TCP listener that never replies. Hitting this host
+# must trip the FR-039 read timeout.
+[[hosts]]
+host         = "hang.test"
+port         = 80
+remote_host  = "hang-backend"
+remote_port  = 80
+guard_status = true
+# Shorten timeouts so the asserter completes quickly.
+upstream_connect_timeout_ms             = 1_000
+upstream_total_connection_timeout_ms    = 2_000
+upstream_read_timeout_ms                = 1_500
+upstream_write_timeout_ms               = 1_500
+upstream_idle_timeout_ms                = 5_000
+upstream_circuit_503_retry_after_s      = 5
+
+# ── Refused backend — points at a host that resolves but the port is
+# closed (no docker-compose service bound to it). Exercises the
+# ConnectRefused path.
+[[hosts]]
+host         = "refused.test"
+port         = 80
+remote_host  = "hang-backend"
+remote_port  = 9   # port 9 (discard) is closed in our hang-backend image
+guard_status = true
+upstream_connect_timeout_ms             = 1_000
+upstream_total_connection_timeout_ms    = 2_000
+upstream_read_timeout_ms                = 1_500
+upstream_write_timeout_ms               = 1_500
+upstream_idle_timeout_ms                = 5_000
+
+# ── Healthy backend — nginx serving the default index page. Positive
+# control to confirm the proxy still works end-to-end.
+[[hosts]]
+host         = "ok.test"
+port         = 80
+remote_host  = "healthy-backend"
+remote_port  = 80
+guard_status = true


### PR DESCRIPTION
## Summary

Implements two P0 functional requirements from `analysis/requirements.md` and consolidates the FR-033/034/035 CHANGELOG entries.

| FR | Behaviour |
|----|-----------|
| **FR-039** | Stateless transport-layer circuit breaker: gateway returns `503 Service Unavailable` with `Retry-After: 5` within the configured deadline when an upstream is unreachable, instead of hanging on Pingora defaults. |
| **FR-018** | Gateway → engine response-dispatch wiring: `WafProxy::response_filter` now invokes `WafEngine::on_response(req_ctx, status)` so the brute-force / credential-stuffing detector advances state on every upstream response. |

## FR-039 — Circuit Breaker

### Behaviour

- `HostConfig` gains six per-host upstream timeout knobs:

  | Field | Default | Purpose |
  |---|---|---|
  | `upstream_connect_timeout_ms`             | 5000  | TCP / TLS handshake budget |
  | `upstream_read_timeout_ms`                | 10000 | Idle read between bytes |
  | `upstream_write_timeout_ms`               | 10000 | Idle write between bytes |
  | `upstream_idle_timeout_ms`                | 30000 | Pool idle eviction |
  | `upstream_total_connection_timeout_ms`    | 10000 | End-to-end deadline before 503 |
  | `upstream_circuit_503_retry_after_s`      | 5     | `Retry-After` value on 503 |

  All `#[serde(default)]` — existing TOML / DB rows deserialize unchanged. Validator rejects `connect > total`.
- `upstream_peer()` copies the knobs into `HttpPeer.options` before returning, so every dial honours the per-host deadline.
- `error_to_status()` adds a transport-error branch (8 `ErrorType` variants: `ConnectTimedout`, `ReadTimedout`, `WriteTimedout`, `ConnectError`, `ConnectRefused`, `ConnectionClosed`-from-upstream, `BindError`, `AcceptError`) → `503`. Application 5xx still maps to `502`.
- `fail_to_connect()` is overridden to log at `warn!` and unconditionally set `peer.retry = false` on transport timeout, suppressing Pingora's default retry loop.
- `ErrorPageFactory::render` emits `Retry-After: 5` only on 503.
- The HTTP/3 listener's shared `reqwest::Client` is rebuilt with `.connect_timeout()`, `.timeout()`, and `.pool_idle_timeout()` matching the FR-039 contract.

### Design decisions

- **Stateless.** No Open / Half-Open / Closed state machine. Pingora's per-request timeout primitives already deliver the spec's "503 within deadline" contract; an extra rolling-window machine would add state, configuration, and failure modes for no behavioural gain (YAGNI).
- **Does not reuse `degrade::resolve()`** from FR-005. Its policy matrix includes `(Medium, Open, BackendOverload) → AllowAndWarn`, which directly contradicts FR-039's unconditional 503 on transport failure. Transport failure is a hard 503; degrade resolution remains scoped to the FR-005 health-signal path.

## FR-018 — Response Dispatch Wiring

```rust
let upstream_contacted = ctx.upstream_addr.is_some();
if let (Some(req_ctx), Some(hc)) = (&ctx.request_ctx, &ctx.host_config) {
    if upstream_contacted {
        self.engine.on_response(req_ctx, upstream_response.status.as_u16());
    }
    // ... existing FR-033 / FR-034 / FR-035 response chain runs after ...
}
```

### Gate rationale

- `ctx.upstream_addr.is_some()` is set by `upstream_peer()`. WAF-generated block-page responses (rendered before any upstream is selected) leave it `None`, so brute-force counters cannot be poisoned by the WAF's own 401 / 403.
- `ctx.request_ctx.is_some()` covers the early-exit case where `request_filter` short-circuited before building the engine-facing context.
- Dispatch runs **before** the response-chain filters so detection state advances even if a downstream filter early-returns. `on_response` is synchronous; latency is one bounded `DashMap` insert.

## Test plan

| Suite | Result |
|---|---|
| `cargo test -p waf-common --lib fr039` | 5 / 5 |
| `cargo test -p gateway --lib fr039` | 12 / 12 |
| `cargo test -p gateway --lib error_page` (regression) | 9 / 9 |
| `cargo test -p gateway --lib` (regression) | 327 / 327 |
| `cargo test -p gateway --test fr018_brute_force_dispatch` (new) | 6 / 6 |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p waf-common -p gateway --lib --tests` | clean |
| Docker e2e `tests/e2e/circuit-breaker/` | 4 / 4 (E1 hang 503 @ ~1.5 s; E2 refused 503 < 2.5 s; E3 healthy 200; E4 `Retry-After: 5`) |

### FR-018 integration coverage

The new suite (`crates/gateway/tests/fr018_brute_force_dispatch.rs`) exercises six gateway-layer regression guards:

1. Six failed-login responses advance brute-force state.
2. Status 200 does not increment the failure counter.
3. Non-login route is ignored.
4. Status 500 is not treated as a failed login.
5. `defense_config.brute_force = false` short-circuits dispatch.
6. The gateway gate excludes self-generated WAF block-page responses (`upstream_addr.is_none()`).

All `cargo` commands run inside Docker (`rust:1.95-slim-bookworm`); no host toolchain required.

## Out of scope / follow-ups

- Prometheus `upstream_timeout_total` counter (v0.3.0 metrics theme).
- Docker e2e wired into nightly CI.

## Spec

`analysis/requirements.md` — FR-039, FR-018.