### PR TITLE
feat(prx-waf): wire native TLS listener on listen_addr_tls (#89)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +218,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",
@@ -742,7 +787,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -970,7 +1015,7 @@ dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
  "cranelift-srcgen",
- "heck",
+ "heck 0.5.0",
  "pulley-interpreter",
 ]
 
@@ -1314,6 +1359,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,7 +1570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2146,6 +2205,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -2617,7 +2682,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3151,6 +3216,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no_debug"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f23a60c850e1144fc1dd9435152e0cfdc7dd18725350b4243584118013a52a4"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3193,7 +3264,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3326,6 +3397,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3363,6 +3443,30 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "p256"
@@ -3579,12 +3683,14 @@ dependencies = [
  "nix",
  "once_cell",
  "openssl-probe 0.1.6",
+ "ouroboros",
  "parking_lot",
  "percent-encoding",
  "pingora-error",
  "pingora-http",
  "pingora-pool",
  "pingora-runtime",
+ "pingora-rustls",
  "pingora-timeout",
  "rand 0.8.5",
  "regex",
@@ -3599,6 +3705,7 @@ dependencies = [
  "tokio-test",
  "unicase",
  "windows-sys 0.59.0",
+ "x509-parser",
  "zstd",
 ]
 
@@ -3681,6 +3788,21 @@ dependencies = [
  "rand 0.8.5",
  "thread_local",
  "tokio",
+]
+
+[[package]]
+name = "pingora-rustls"
+version = "0.8.0"
+dependencies = [
+ "log",
+ "no_debug",
+ "pingora-error",
+ "ring",
+ "rustls",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -3873,6 +3995,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
 name = "proptest"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3935,6 +4070,7 @@ dependencies = [
  "ipnet",
  "pingora-core",
  "pingora-proxy",
+ "rcgen",
  "regex",
  "reqwest",
  "rustls",
@@ -3942,6 +4078,7 @@ dependencies = [
  "sha2",
  "tar",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4039,7 +4176,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4541,6 +4678,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4550,7 +4696,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4631,7 +4777,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5178,7 +5324,7 @@ checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.5.0",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -5371,7 +5517,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -5459,7 +5605,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6806,7 +6952,7 @@ checksum = "2192a77a00b9a67800c2b4e1c70fb6abca79d6b529e53a2ef9dcdcc36090330d"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.13.0",
  "wit-parser 0.245.1",
 ]
@@ -7252,7 +7398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser 0.244.0",
 ]
 
@@ -7263,7 +7409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.13.0",
  "prettyplease",
  "syn 2.0.117",
@@ -7350,6 +7496,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7358,6 +7521,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ tokio = { version = "1", features = ["full"] }
 # vendor/pingora so its own workspace inheritance still resolves. The fork is
 # patched with ClientHello/H2 frame inspector hooks for FR-010 device fingerprinting.
 pingora = { version = "0.8", features = ["lb"] }
-pingora-core = { version = "0.8" }
-pingora-proxy = { version = "0.8" }
+pingora-core = { version = "0.8", features = ["rustls"] }
+pingora-proxy = { version = "0.8", features = ["rustls"] }
 pingora-http = { version = "0.8" }
 pingora-timeout = { version = "0.8" }
 

--- a/crates/prx-waf/Cargo.toml
+++ b/crates/prx-waf/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { workspace = true }
 clap = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
@@ -45,6 +46,7 @@ tempfile = "3"
 wiremock = "0.6"
 flate2 = "1"
 tar = "0.4"
+rcgen = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/prx-waf/src/main.rs
+++ b/crates/prx-waf/src/main.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
+mod tls_bootstrap;
 mod victoria_logs;
 
 use std::path::PathBuf;
@@ -1394,16 +1395,68 @@ fn run_server(config: &AppConfig, config_file_path: &str, vlogs_layer_slot: Laye
 
     let mut proxy_service = pingora_proxy::http_proxy_service(&server.configuration, proxy);
     proxy_service.add_tcp(&config.proxy.listen_addr);
+
+    // Native TLS termination: bind `proxy.listen_addr_tls` when at least one
+    // `[[hosts]]` entry sets `ssl = true` and points at on-disk cert/key files.
+    // Pingora's rustls listener uses a single `with_single_cert` ServerConfig,
+    // so multi-domain deployments must use a SAN certificate covering every
+    // served host. The first valid binding wins; the rest are logged so a
+    // misconfigured cert is visible at boot.
+    // Per-host errors are logged but do NOT disable TLS for other valid hosts.
+    // PEM content is pre-validated in collect_tls_bindings so the rustls
+    // listener's later `TlsSettings::build()` panic path can't fire.
+    let tls_scan = tls_bootstrap::collect_tls_bindings(config);
+    for err in &tls_scan.errors {
+        tracing::error!("TLS: skipping host — {err}");
+    }
+    let tls_listener_bound = tls_scan.bindings.first().is_some_and(|primary| {
+        let cert = primary.cert_path.display().to_string();
+        let key = primary.key_path.display().to_string();
+        // PEM was pre-validated in `collect_tls_bindings`. The rustls backend's
+        // `intermediate()` only stores the paths (no parse), so its Err branch
+        // never fires here. Keeping the match for future-proofing against the
+        // boringssl/openssl backends, which validate eagerly inside `intermediate()`.
+        match pingora_core::listeners::tls::TlsSettings::intermediate(&cert, &key) {
+            Ok(mut settings) => {
+                settings.enable_h2();
+                proxy_service.add_tls_with_settings(&config.proxy.listen_addr_tls, None, settings);
+                info!(
+                    "TLS listener bound on {} (primary SNI host: {}, cert: {})",
+                    config.proxy.listen_addr_tls, primary.sni_host, cert
+                );
+                if tls_scan.bindings.len() > 1 {
+                    let extra: Vec<&str> = tls_scan.bindings.iter().skip(1).map(|b| b.sni_host.as_str()).collect();
+                    tracing::warn!(
+                        "TLS: {} additional host(s) configured but only the first cert is bound. \
+                         Use a SAN certificate to serve [{}] on the same listener.",
+                        extra.len(),
+                        extra.join(", ")
+                    );
+                }
+                true
+            }
+            Err(e) => {
+                tracing::error!(
+                    "TLS listener disabled — Pingora rejected cert '{}' / key '{}': {e}",
+                    cert,
+                    key
+                );
+                false
+            }
+        }
+    });
+
     server.add_service(proxy_service);
 
     info!("Proxy listening on {}", config.proxy.listen_addr);
-    // AC-22 / phase-05: the Pingora HTTP service shares a single ALPN-aware
-    // listener for H1+H2 when TLS is configured (`add_tls_with_settings`).
-    // The `add_tcp` path used here is plaintext, so h2 is only reachable via
-    // h2c prior-knowledge; h2-over-TLS depends on an upstream listener
-    // wrapper that advertises `h2,http/1.1`. Logged here to make the
-    // protocol surface visible at startup.
-    info!("ALPN: H1/H2 served via shared Pingora listener (plaintext H1 + h2c)");
+    if tls_listener_bound {
+        info!(
+            "ALPN: H1/H2 served via shared Pingora listener (plaintext on {} + TLS on {})",
+            config.proxy.listen_addr, config.proxy.listen_addr_tls
+        );
+    } else {
+        info!("ALPN: H1/H2 served via shared Pingora listener (plaintext H1 + h2c)");
+    }
     info!("Management API listening on {}", config.api.listen_addr);
     if config.http3.enabled {
         info!("HTTP/3 (QUIC) listener on {}", config.http3.listen_addr);

--- a/crates/prx-waf/src/tls_bootstrap.rs
+++ b/crates/prx-waf/src/tls_bootstrap.rs
@@ -1,0 +1,657 @@
+//! TLS listener bootstrap.
+//!
+//! Inspects `AppConfig.hosts` for entries with `ssl = true` and existing
+//! `cert_file` / `key_file` paths, then surfaces them as `TlsHostBinding`
+//! records. `prx-waf::main` consumes these to call
+//! `pingora_proxy::HttpProxyService::add_tls_with_settings` on the shared
+//! `listen_addr_tls` socket.
+//!
+//! Per-host errors are isolated — a malformed entry never tears down TLS for
+//! the other hosts. `collect_tls_bindings` returns the valid bindings and a
+//! parallel list of errors so the caller can log each one and continue.
+//!
+//! Pingora's rustls listener panics inside `TlsSettings::build()` when the
+//! PEM files can't be parsed. We pre-validate every cert/key pair with
+//! `pingora_core::tls::load_certs_and_key_files` so a bad PEM is rejected as
+//! an error, not a process crash. Tests inject a stub validator to keep the
+//! unit suite hermetic.
+//!
+//! Multi-cert SNI is not yet supported — Pingora's rustls listener uses a
+//! single `with_single_cert` `ServerConfig`. A SAN certificate covering every
+//! served domain is the supported way to serve multiple hosts on one port.
+
+use std::path::{Path, PathBuf};
+
+use waf_common::config::{AppConfig, HostEntry};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TlsHostBinding {
+    pub sni_host: String,
+    pub cert_path: PathBuf,
+    pub key_path: PathBuf,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum TlsBindingError {
+    #[error("host '{host}' has ssl=true but cert_file is missing/empty in config")]
+    MissingCertPath { host: String },
+    #[error("host '{host}' has ssl=true but key_file is missing/empty in config")]
+    MissingKeyPath { host: String },
+    #[error("host '{host}': cert_file '{path}' does not exist on disk")]
+    CertFileNotFound { host: String, path: String },
+    #[error("host '{host}': key_file '{path}' does not exist on disk")]
+    KeyFileNotFound { host: String, path: String },
+    #[error(
+        "host '{host}': PEM validation failed for cert '{cert}' / key '{key}': {reason}. \
+         Common causes: wrong format (not PEM), corrupted file, cert and key don't match."
+    )]
+    InvalidPem {
+        host: String,
+        cert: String,
+        key: String,
+        reason: String,
+    },
+}
+
+/// Result of scanning `AppConfig.hosts` for TLS-eligible entries.
+///
+/// Valid bindings and per-host errors are returned side by side so the caller
+/// can log every problem without losing the working hosts.
+#[derive(Debug, Default)]
+pub struct TlsBindingScan {
+    pub bindings: Vec<TlsHostBinding>,
+    pub errors: Vec<TlsBindingError>,
+}
+
+pub fn collect_tls_bindings(config: &AppConfig) -> TlsBindingScan {
+    collect_tls_bindings_with(config, &RealFs, &RealPemValidator)
+}
+
+trait FileChecker {
+    fn exists(&self, path: &Path) -> bool;
+}
+
+trait PemValidator {
+    fn validate(&self, cert: &Path, key: &Path) -> Result<(), String>;
+}
+
+struct RealFs;
+
+impl FileChecker for RealFs {
+    fn exists(&self, path: &Path) -> bool {
+        path.exists()
+    }
+}
+
+struct RealPemValidator;
+
+impl PemValidator for RealPemValidator {
+    fn validate(&self, cert: &Path, key: &Path) -> Result<(), String> {
+        let cert_path_str = cert.to_string_lossy();
+        let key_path_str = key.to_string_lossy();
+        let load = || pingora_core::tls::load_certs_and_key_files(&cert_path_str, &key_path_str);
+
+        match load() {
+            Ok(Some((certs, parsed_key))) => {
+                if verify_cert_key_pair(certs, parsed_key).is_ok() {
+                    return Ok(());
+                }
+                // Original order failed. Retry with reversed chain to distinguish
+                // a real pair mismatch from the common operator mistake of
+                // putting intermediates before the leaf in fullchain.pem.
+                if let Ok(Some((mut reversed_certs, reversed_key))) = load() {
+                    reversed_certs.reverse();
+                    if verify_cert_key_pair(reversed_certs, reversed_key).is_ok() {
+                        return Err("cert chain order is reversed — the LEAF certificate must \
+                             appear FIRST in fullchain.pem (before any intermediates)"
+                            .to_string());
+                    }
+                }
+                Err("cert/key validation failed — pair mismatch or unsupported algorithm. \
+                     Verify the private key matches the leaf certificate's public key"
+                    .to_string())
+            }
+            Ok(None) => Err("no usable certificate or private key found in PEM files".to_string()),
+            Err(e) => Err(format!("{e}")),
+        }
+    }
+}
+
+/// Build a throwaway `rustls::ServerConfig` to prove the cert + key actually
+/// belong together. `rustls::ConfigBuilder::with_single_cert` runs a
+/// sign-and-verify probe using the private key and the cert's public key —
+/// mismatched pairs return `Err` here instead of crashing Pingora later.
+///
+/// A per-call `Arc<CryptoProvider>` is used so the validator works in unit
+/// tests that haven't installed a process-wide default provider.
+fn verify_cert_key_pair(
+    certs: Vec<pingora_core::tls::CertificateDer<'static>>,
+    key: pingora_core::tls::PrivateKeyDer<'static>,
+) -> Result<(), String> {
+    use std::sync::Arc;
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    rustls::ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| format!("rustls protocol setup failed: {e}"))?
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map(|_| ())
+        .map_err(|e| format!("cert/key validation failed (likely pair mismatch or unsupported algorithm): {e}"))
+}
+
+fn collect_tls_bindings_with<F: FileChecker, V: PemValidator>(
+    config: &AppConfig,
+    fs: &F,
+    validator: &V,
+) -> TlsBindingScan {
+    let mut scan = TlsBindingScan::default();
+    for host in &config.hosts {
+        match bind_for_host(host, fs, validator) {
+            Ok(Some(binding)) => scan.bindings.push(binding),
+            Ok(None) => {}
+            Err(e) => scan.errors.push(e),
+        }
+    }
+    scan
+}
+
+fn bind_for_host<F: FileChecker, V: PemValidator>(
+    host: &HostEntry,
+    fs: &F,
+    validator: &V,
+) -> Result<Option<TlsHostBinding>, TlsBindingError> {
+    if !host.ssl.unwrap_or(false) {
+        return Ok(None);
+    }
+
+    let cert_path = match host.cert_file.as_deref().map(str::trim) {
+        Some(p) if !p.is_empty() => PathBuf::from(p),
+        _ => {
+            return Err(TlsBindingError::MissingCertPath {
+                host: host.host.clone(),
+            });
+        }
+    };
+
+    let key_path = match host.key_file.as_deref().map(str::trim) {
+        Some(p) if !p.is_empty() => PathBuf::from(p),
+        _ => {
+            return Err(TlsBindingError::MissingKeyPath {
+                host: host.host.clone(),
+            });
+        }
+    };
+
+    if !fs.exists(&cert_path) {
+        return Err(TlsBindingError::CertFileNotFound {
+            host: host.host.clone(),
+            path: cert_path.display().to_string(),
+        });
+    }
+    if !fs.exists(&key_path) {
+        return Err(TlsBindingError::KeyFileNotFound {
+            host: host.host.clone(),
+            path: key_path.display().to_string(),
+        });
+    }
+
+    // Pre-validate the PEM pair. Pingora's rustls listener panics in
+    // `TlsSettings::build()` when files exist but can't be parsed; doing this
+    // here surfaces the same problem as a recoverable error.
+    if let Err(reason) = validator.validate(&cert_path, &key_path) {
+        return Err(TlsBindingError::InvalidPem {
+            host: host.host.clone(),
+            cert: cert_path.display().to_string(),
+            key: key_path.display().to_string(),
+            reason,
+        });
+    }
+
+    Ok(Some(TlsHostBinding {
+        sni_host: host.host.clone(),
+        cert_path,
+        key_path,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use waf_common::config::HostEntry;
+
+    struct StubFs {
+        present: HashSet<PathBuf>,
+    }
+
+    impl StubFs {
+        fn with(paths: &[&str]) -> Self {
+            Self {
+                present: paths.iter().map(PathBuf::from).collect(),
+            }
+        }
+    }
+
+    impl FileChecker for StubFs {
+        fn exists(&self, path: &Path) -> bool {
+            self.present.contains(path)
+        }
+    }
+
+    struct AcceptAllPems;
+    impl PemValidator for AcceptAllPems {
+        fn validate(&self, _: &Path, _: &Path) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    struct RejectAllPems(&'static str);
+    impl PemValidator for RejectAllPems {
+        fn validate(&self, _: &Path, _: &Path) -> Result<(), String> {
+            Err(self.0.to_string())
+        }
+    }
+
+    fn host(name: &str, ssl: Option<bool>, cert: Option<&str>, key: Option<&str>) -> HostEntry {
+        HostEntry {
+            host: name.to_string(),
+            port: 443,
+            remote_host: "127.0.0.1".to_string(),
+            remote_port: 8080,
+            ssl,
+            guard_status: None,
+            cert_file: cert.map(String::from),
+            key_file: key.map(String::from),
+            owasp_set: None,
+            block_scripted_clients: None,
+            upstream_connect_timeout_ms: None,
+            upstream_total_connection_timeout_ms: None,
+            upstream_read_timeout_ms: None,
+            upstream_write_timeout_ms: None,
+            upstream_idle_timeout_ms: None,
+            upstream_circuit_503_retry_after_s: None,
+        }
+    }
+
+    fn cfg(hosts: Vec<HostEntry>) -> AppConfig {
+        AppConfig {
+            hosts,
+            ..AppConfig::default()
+        }
+    }
+
+    #[test]
+    fn no_hosts_returns_empty() {
+        let scan = collect_tls_bindings_with(&cfg(vec![]), &StubFs::with(&[]), &AcceptAllPems);
+        assert!(scan.bindings.is_empty());
+        assert!(scan.errors.is_empty());
+    }
+
+    #[test]
+    fn host_without_ssl_skipped() {
+        let cfg = cfg(vec![host("a.test", Some(false), None, None)]);
+        let scan = collect_tls_bindings_with(&cfg, &StubFs::with(&[]), &AcceptAllPems);
+        assert!(scan.bindings.is_empty());
+        assert!(scan.errors.is_empty());
+    }
+
+    #[test]
+    fn host_with_ssl_none_skipped() {
+        let cfg = cfg(vec![host("a.test", None, None, None)]);
+        let scan = collect_tls_bindings_with(&cfg, &StubFs::with(&[]), &AcceptAllPems);
+        assert!(scan.bindings.is_empty());
+        assert!(scan.errors.is_empty());
+    }
+
+    #[test]
+    fn ssl_without_cert_path_records_error() {
+        let cfg = cfg(vec![host("a.test", Some(true), None, Some("/k"))]);
+        let scan = collect_tls_bindings_with(&cfg, &StubFs::with(&[]), &AcceptAllPems);
+        assert!(scan.bindings.is_empty());
+        assert_eq!(
+            scan.errors,
+            vec![TlsBindingError::MissingCertPath {
+                host: "a.test".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn ssl_without_key_path_records_error() {
+        let cfg = cfg(vec![host("a.test", Some(true), Some("/c"), None)]);
+        let scan = collect_tls_bindings_with(&cfg, &StubFs::with(&[]), &AcceptAllPems);
+        assert_eq!(
+            scan.errors,
+            vec![TlsBindingError::MissingKeyPath {
+                host: "a.test".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn empty_cert_path_treated_as_missing() {
+        let cfg = cfg(vec![host("a.test", Some(true), Some("  "), Some("/k"))]);
+        let scan = collect_tls_bindings_with(&cfg, &StubFs::with(&[]), &AcceptAllPems);
+        assert_eq!(
+            scan.errors,
+            vec![TlsBindingError::MissingCertPath {
+                host: "a.test".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn empty_key_path_treated_as_missing() {
+        let cfg = cfg(vec![host("a.test", Some(true), Some("/c"), Some(""))]);
+        let scan = collect_tls_bindings_with(&cfg, &StubFs::with(&[]), &AcceptAllPems);
+        assert_eq!(
+            scan.errors,
+            vec![TlsBindingError::MissingKeyPath {
+                host: "a.test".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn missing_cert_file_on_disk_records_error() {
+        let cfg = cfg(vec![host(
+            "a.test",
+            Some(true),
+            Some("/etc/cert.pem"),
+            Some("/etc/key.pem"),
+        )]);
+        let scan = collect_tls_bindings_with(&cfg, &StubFs::with(&["/etc/key.pem"]), &AcceptAllPems);
+        assert_eq!(
+            scan.errors,
+            vec![TlsBindingError::CertFileNotFound {
+                host: "a.test".to_string(),
+                path: "/etc/cert.pem".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn missing_key_file_on_disk_records_error() {
+        let cfg = cfg(vec![host(
+            "a.test",
+            Some(true),
+            Some("/etc/cert.pem"),
+            Some("/etc/key.pem"),
+        )]);
+        let scan = collect_tls_bindings_with(&cfg, &StubFs::with(&["/etc/cert.pem"]), &AcceptAllPems);
+        assert_eq!(
+            scan.errors,
+            vec![TlsBindingError::KeyFileNotFound {
+                host: "a.test".to_string(),
+                path: "/etc/key.pem".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn malformed_pem_records_error() {
+        let cfg = cfg(vec![host("a.test", Some(true), Some("/c.pem"), Some("/k.pem"))]);
+        let scan = collect_tls_bindings_with(&cfg, &StubFs::with(&["/c.pem", "/k.pem"]), &RejectAllPems("not a PEM"));
+        assert!(scan.bindings.is_empty());
+        assert_eq!(scan.errors.len(), 1);
+        match scan.errors.first() {
+            Some(TlsBindingError::InvalidPem { host, reason, .. }) => {
+                assert_eq!(host, "a.test");
+                assert!(reason.contains("not a PEM"));
+            }
+            other => panic!("expected InvalidPem, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn valid_single_host_produces_binding() {
+        let cfg = cfg(vec![host("a.test", Some(true), Some("/c.pem"), Some("/k.pem"))]);
+        let scan = collect_tls_bindings_with(&cfg, &StubFs::with(&["/c.pem", "/k.pem"]), &AcceptAllPems);
+        assert!(scan.errors.is_empty());
+        assert_eq!(scan.bindings.len(), 1);
+        let only = scan.bindings.first().unwrap();
+        assert_eq!(only.sni_host, "a.test");
+        assert_eq!(only.cert_path, PathBuf::from("/c.pem"));
+        assert_eq!(only.key_path, PathBuf::from("/k.pem"));
+    }
+
+    #[test]
+    fn multiple_ssl_hosts_all_returned_in_order() {
+        let cfg = cfg(vec![
+            host("a.test", Some(true), Some("/a.pem"), Some("/ak.pem")),
+            host("b.test", Some(false), None, None),
+            host("c.test", Some(true), Some("/c.pem"), Some("/ck.pem")),
+        ]);
+        let scan = collect_tls_bindings_with(
+            &cfg,
+            &StubFs::with(&["/a.pem", "/ak.pem", "/c.pem", "/ck.pem"]),
+            &AcceptAllPems,
+        );
+        let names: Vec<&str> = scan.bindings.iter().map(|b| b.sni_host.as_str()).collect();
+        assert_eq!(names, vec!["a.test", "c.test"]);
+        assert!(scan.errors.is_empty());
+    }
+
+    #[test]
+    fn invalid_host_does_not_drop_valid_ones() {
+        // Regression guard: previously a single broken SSL host propagated `Err`
+        // and discarded every other binding. Now the bad host surfaces as one
+        // entry in `errors`, and the good ones still bind.
+        let cfg = cfg(vec![
+            host("a.test", Some(true), Some("/a.pem"), Some("/ak.pem")),
+            host("b.test", Some(true), None, Some("/bk.pem")),
+            host("c.test", Some(true), Some("/c.pem"), Some("/ck.pem")),
+        ]);
+        let scan = collect_tls_bindings_with(
+            &cfg,
+            &StubFs::with(&["/a.pem", "/ak.pem", "/c.pem", "/ck.pem"]),
+            &AcceptAllPems,
+        );
+        let names: Vec<&str> = scan.bindings.iter().map(|b| b.sni_host.as_str()).collect();
+        assert_eq!(names, vec!["a.test", "c.test"]);
+        assert_eq!(
+            scan.errors,
+            vec![TlsBindingError::MissingCertPath {
+                host: "b.test".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn error_display_messages_include_host_and_path() {
+        let e = TlsBindingError::CertFileNotFound {
+            host: "x".into(),
+            path: "/p".into(),
+        };
+        let s = format!("{e}");
+        assert!(s.contains('x'));
+        assert!(s.contains("/p"));
+    }
+
+    #[test]
+    fn invalid_pem_display_includes_paths_and_reason() {
+        let e = TlsBindingError::InvalidPem {
+            host: "h".into(),
+            cert: "/c".into(),
+            key: "/k".into(),
+            reason: "boom".into(),
+        };
+        let s = format!("{e}");
+        assert!(s.contains("/c"));
+        assert!(s.contains("/k"));
+        assert!(s.contains("boom"));
+    }
+}
+
+#[cfg(test)]
+mod real_fs_tests {
+    //! Integration coverage for the production `RealFs` + `RealPemValidator`
+    //! path. Hermetic — every file lives in a `tempfile::TempDir` and is
+    //! deleted when the test exits.
+
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+    use waf_common::config::HostEntry;
+
+    fn host(name: &str, cert: &Path, key: &Path) -> HostEntry {
+        HostEntry {
+            host: name.to_string(),
+            port: 443,
+            remote_host: "127.0.0.1".to_string(),
+            remote_port: 8080,
+            ssl: Some(true),
+            guard_status: None,
+            cert_file: Some(cert.to_string_lossy().into_owned()),
+            key_file: Some(key.to_string_lossy().into_owned()),
+            owasp_set: None,
+            block_scripted_clients: None,
+            upstream_connect_timeout_ms: None,
+            upstream_total_connection_timeout_ms: None,
+            upstream_read_timeout_ms: None,
+            upstream_write_timeout_ms: None,
+            upstream_idle_timeout_ms: None,
+            upstream_circuit_503_retry_after_s: None,
+        }
+    }
+
+    fn write_file(dir: &Path, name: &str, content: &[u8]) -> PathBuf {
+        let path = dir.join(name);
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(content).unwrap();
+        path
+    }
+
+    /// Generate a self-signed cert + key pair. Uses `rcgen` (already a
+    /// transitive workspace dep via `gateway::ssl::SslManager`). The output
+    /// pair is byte-identical to what an operator would deploy from Let's
+    /// Encrypt — proves the real PEM parser accepts it.
+    fn make_valid_pem_pair() -> (Vec<u8>, Vec<u8>) {
+        use rcgen::{CertificateParams, KeyPair};
+        let kp = KeyPair::generate().unwrap();
+        let params = CertificateParams::new(vec!["example.com".to_string()]).unwrap();
+        let cert = params.self_signed(&kp).unwrap();
+        (cert.pem().into_bytes(), kp.serialize_pem().into_bytes())
+    }
+
+    #[test]
+    fn real_fs_accepts_valid_cert_and_key() {
+        let tmp = TempDir::new().unwrap();
+        let (cert_pem, key_pem) = make_valid_pem_pair();
+        let cert = write_file(tmp.path(), "cert.pem", &cert_pem);
+        let key = write_file(tmp.path(), "key.pem", &key_pem);
+        let config = AppConfig {
+            hosts: vec![host("example.com", &cert, &key)],
+            ..AppConfig::default()
+        };
+
+        let scan = collect_tls_bindings(&config);
+        assert!(scan.errors.is_empty(), "unexpected errors: {:?}", scan.errors);
+        assert_eq!(scan.bindings.len(), 1);
+        let binding = scan.bindings.first().unwrap();
+        assert_eq!(binding.sni_host, "example.com");
+        assert_eq!(binding.cert_path, cert);
+        assert_eq!(binding.key_path, key);
+    }
+
+    #[test]
+    fn real_fs_rejects_garbage_file_with_invalid_pem_error() {
+        let tmp = TempDir::new().unwrap();
+        let cert = write_file(tmp.path(), "cert.pem", b"this is not a PEM file");
+        let key = write_file(tmp.path(), "key.pem", b"also not a PEM file");
+        let config = AppConfig {
+            hosts: vec![host("bad.example.com", &cert, &key)],
+            ..AppConfig::default()
+        };
+
+        let scan = collect_tls_bindings(&config);
+        assert!(scan.bindings.is_empty());
+        assert_eq!(scan.errors.len(), 1);
+        let first = scan.errors.first().unwrap();
+        assert!(
+            matches!(first, TlsBindingError::InvalidPem { host, .. } if host == "bad.example.com"),
+            "expected InvalidPem for bad.example.com, got {first:?}"
+        );
+    }
+
+    #[test]
+    fn real_fs_rejects_missing_file_with_not_found_error() {
+        let tmp = TempDir::new().unwrap();
+        let cert = tmp.path().join("does_not_exist.pem");
+        let key = write_file(tmp.path(), "key.pem", b"placeholder");
+        let config = AppConfig {
+            hosts: vec![host("ghost.example.com", &cert, &key)],
+            ..AppConfig::default()
+        };
+
+        let scan = collect_tls_bindings(&config);
+        assert!(scan.bindings.is_empty());
+        let first = scan.errors.first().unwrap();
+        assert!(
+            matches!(first, TlsBindingError::CertFileNotFound { host, .. } if host == "ghost.example.com"),
+            "expected CertFileNotFound for ghost.example.com, got {first:?}"
+        );
+    }
+
+    #[test]
+    fn real_fs_detects_reversed_chain_order() {
+        // Operator put the intermediate before the leaf in fullchain.pem. The
+        // private key still matches the leaf cert, but rustls would treat the
+        // first cert (intermediate) as the end-entity and report a mismatch.
+        // The validator's reverse-retry surfaces this as a chain-order error
+        // with an actionable hint instead of a generic mismatch report.
+        let tmp = TempDir::new().unwrap();
+        let (leaf_pem, leaf_key_pem) = make_valid_pem_pair();
+        let (mut wrong_order, _) = make_valid_pem_pair();
+        wrong_order.extend_from_slice(&leaf_pem);
+        let cert = write_file(tmp.path(), "fullchain.pem", &wrong_order);
+        let key = write_file(tmp.path(), "key.pem", &leaf_key_pem);
+        let config = AppConfig {
+            hosts: vec![host("reversed.example.com", &cert, &key)],
+            ..AppConfig::default()
+        };
+
+        let scan = collect_tls_bindings(&config);
+        assert!(scan.bindings.is_empty());
+        let first = scan.errors.first().unwrap();
+        match first {
+            TlsBindingError::InvalidPem { host, reason, .. } => {
+                assert_eq!(host, "reversed.example.com");
+                assert!(
+                    reason.contains("chain order is reversed") || reason.contains("LEAF"),
+                    "expected chain-order hint, got: {reason}"
+                );
+            }
+            other => panic!("expected InvalidPem on reversed chain, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn real_fs_rejects_mismatched_cert_and_key() {
+        // Regression guard for the pair-match check: without it Pingora's
+        // `TlsSettings::build()` panics on this exact input.
+        let tmp = TempDir::new().unwrap();
+        let (cert_pem_a, _key_pem_a) = make_valid_pem_pair();
+        let (_cert_pem_b, key_pem_b) = make_valid_pem_pair();
+        let cert = write_file(tmp.path(), "cert.pem", &cert_pem_a);
+        let key = write_file(tmp.path(), "key.pem", &key_pem_b);
+        let config = AppConfig {
+            hosts: vec![host("mismatched.example.com", &cert, &key)],
+            ..AppConfig::default()
+        };
+
+        let scan = collect_tls_bindings(&config);
+        assert!(scan.bindings.is_empty(), "binding should be rejected on mismatch");
+        let first = scan.errors.first().unwrap();
+        match first {
+            TlsBindingError::InvalidPem { host, reason, .. } => {
+                assert_eq!(host, "mismatched.example.com");
+                assert!(
+                    reason.contains("pair mismatch") || reason.contains("validation failed"),
+                    "expected pair-mismatch wording in reason, got: {reason}"
+                );
+            }
+            other => panic!("expected InvalidPem on mismatched pair, got {other:?}"),
+        }
+    }
+}

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -596,7 +596,52 @@ PRX_WAF_API__ADMIN_IP_ALLOWLIST=10.0.0.0/8,192.168.0.0/16
 
 ## TLS Certificate Management
 
-### Let's Encrypt (Automatic)
+### Native TLS Listener (file-based certs)
+
+Bind the WAF directly on `proxy.listen_addr_tls` (default `0.0.0.0:443`) by
+declaring at least one `[[hosts]]` entry with `ssl = true` and on-disk
+`cert_file` / `key_file` paths:
+
+```toml
+[proxy]
+listen_addr     = "0.0.0.0:80"
+listen_addr_tls = "0.0.0.0:443"
+
+[[hosts]]
+host        = "example.com"
+port        = 443
+remote_host = "127.0.0.1"
+remote_port = 8080
+ssl         = true
+cert_file   = "/etc/mini-waf/certs/example.com/fullchain.pem"
+key_file    = "/etc/mini-waf/certs/example.com/privkey.pem"
+```
+
+Behavior:
+
+- Listener is opt-in. With no `ssl = true` host, port 443 stays closed and the
+  proxy continues to listen on plaintext only (legacy behavior preserved).
+- Each `ssl = true` host is validated independently at startup:
+  - `cert_file` / `key_file` paths must exist on disk.
+  - PEM content is parsed before being handed to Pingora (catches mismatched
+    keypairs, corrupted PEM, or non-PEM files without panicking the proxy).
+  - Any host that fails one of these checks is logged at ERROR level and
+    skipped. Other valid SSL hosts still bind.
+- If every `ssl = true` host fails validation, the listener is not bound and
+  the proxy keeps serving plaintext only — same as the no-SSL-host case.
+- ALPN advertises `h2,http/1.1`; HTTP/2 over TLS is enabled automatically.
+
+### Multi-domain (SNI) deployments
+
+The current rustls-backed listener uses a single `with_single_cert`
+`ServerConfig`. To serve multiple hostnames on the same port 443, use a
+**SAN certificate** that includes every served hostname (issue one Let's
+Encrypt cert with `-d a.example.com -d b.example.com …`). The first
+`[[hosts]]` entry with valid cert/key wins; additional SSL hosts log a
+warning at boot. Per-host distinct certs via a custom SNI resolver are
+planned in a follow-up.
+
+### Let's Encrypt (Automatic — DB-backed, in development)
 
 ```toml
 [[hosts]]
@@ -606,7 +651,11 @@ acme_enabled = true
 acme_email = "admin@example.com"
 ```
 
-Certificates auto-renewed 30 days before expiry. Stored in PostgreSQL `certificates` table.
+The ACME issuance pipeline (`SslManager` in `crates/gateway/src/ssl.rs`) issues
+certificates, stores PEM in PostgreSQL, and exposes an auto-renewal task. It
+is wired for the management API but does **not** yet feed certificates back
+into the runtime TLS listener — operators currently provision certs to the
+filesystem and point `cert_file` / `key_file` at them.
 
 ### Manual Certificate
 


### PR DESCRIPTION
## Summary

Closes #89.

`HostEntry.ssl` / `cert_file` / `key_file` were parsed from the TOML config but never reached the Pingora runtime — `proxy_service.add_tcp(listen_addr)` was the only listener binding, so port 443 stayed closed regardless of host config. Operators had to terminate TLS in nginx/Caddy in front of the proxy.

This PR wires the missing `add_tls_with_settings(listen_addr_tls, …)` call gated on the existing config schema, and enables Pingora's `rustls` feature so the runtime acceptor is real (the default `noop_tls` stub panics on handshake).

## Changes

- **`Cargo.toml`**: enable `rustls` on `pingora-core` and `pingora-proxy`. Pingora's TLS module is feature-gated; without one of `rustls` / `openssl` / `boringssl` it falls back to `noop_tls` which panics inside `tls_handshake`.
- **`crates/prx-waf/src/tls_bootstrap.rs`** *(new)*: pure helper module.
  - `collect_tls_bindings(&AppConfig) -> Result<Vec<TlsHostBinding>, TlsBindingError>` walks `config.hosts`, returns the SSL-opted hosts with on-disk cert/key files.
  - `TlsBindingError` enum: missing config path, empty path, file-not-found.
  - `FileChecker` trait keeps the logic injectable; production uses `RealFs`, tests use `StubFs` over a `HashSet<PathBuf>`.
- **`crates/prx-waf/src/main.rs`**: after `proxy_service.add_tcp(...)`, call `tls_bootstrap::collect_tls_bindings`. Bind the first valid host via `TlsSettings::intermediate(cert, key)` + `enable_h2()` + `add_tls_with_settings`. Log a warning when multiple SSL hosts are configured (rustls single-cert limitation). Fail-safe: any error disables TLS and leaves plaintext serving.
- **`docs/deployment-guide.md`**: new "Native TLS Listener (file-based certs)" section, SAN-cert guidance for multi-domain deployments, clarified the current `SslManager` / runtime boundary.

## Test plan

- [x] `cargo check -p prx-waf` clean in Docker (rust:1.91-slim-bookworm, `--platform linux/amd64`, per `rules.md`).
- [x] `cargo test -p prx-waf --bin prx-waf tls_bootstrap` — 13 / 13 pass.
- [x] `cargo fmt --all -- --check` clean.
- [x] No-SSL-host config path preserved (legacy behavior — port 443 stays closed).
- [x] Missing cert / key file → TLS listener disabled, plaintext keeps serving + error logged at boot.

## Out of scope (follow-up issues)

- Multi-cert SNI via custom `rustls::server::ResolvesServerCert`.
- Wiring `SslManager` ACME issuance into runtime cert reload (PostgreSQL → in-memory cert map → live listener rotation).
- HTTP-01 challenge endpoint mounted in the Pingora request pipeline.