### PR TITLE
fix(prx-waf,gateway): separate TLS-terminate intent from upstream-TLS; H2 host routing

### DIFF
--- a/crates/gateway/src/proxy.rs
+++ b/crates/gateway/src/proxy.rs
@@ -298,6 +298,30 @@ const fn is_transport_unresponsive(et: &pingora_core::ErrorType) -> bool {
     )
 }
 
+/// Resolve the request's target host, supporting both HTTP/1.x (`Host` header)
+/// and HTTP/2 (where the host arrives in the `:authority` pseudo-header that
+/// Pingora exposes via the request URI). Returns an empty string when neither
+/// source is set — the caller treats that as "no route" and fails closed.
+///
+/// Pure on `(headers, uri)`; delegates to [`resolve_host_from_parts`] so unit
+/// tests cover the H1/H2/absolute-URI matrix without a live Pingora session.
+fn resolve_request_host(session: &Session) -> &str {
+    let req = session.req_header();
+    resolve_host_from_parts(&req.headers, &req.uri)
+}
+
+fn resolve_host_from_parts<'a>(headers: &'a http::HeaderMap, uri: &'a http::Uri) -> &'a str {
+    if let Some(host) = headers
+        .get(http::header::HOST)
+        .and_then(|v| std::str::from_utf8(v.as_bytes()).ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        return host;
+    }
+    uri.host().unwrap_or("")
+}
+
 /// FR-039: copy the per-host upstream timeouts into the Pingora [`HttpPeer`]
 /// options. Pulled out of `upstream_peer()` so unit tests can verify the
 /// mapping without spinning up a full Pingora `Server`.
@@ -381,11 +405,7 @@ impl ProxyHttp for WafProxy {
     async fn upstream_peer(&self, session: &mut Session, ctx: &mut GatewayCtx) -> pingora_core::Result<Box<HttpPeer>> {
         self.request_counter.fetch_add(1, Ordering::Relaxed);
 
-        let host_header = session
-            .get_header("host")
-            .and_then(|v| std::str::from_utf8(v.as_bytes()).ok())
-            .unwrap_or("")
-            .to_string();
+        let host_header = resolve_request_host(session).to_string();
 
         debug!("Routing request for host: {}", host_header);
 
@@ -474,11 +494,7 @@ impl ProxyHttp for WafProxy {
 
         // Build request context early so WAF runs before upstream_peer.
         if ctx.request_ctx.is_none() {
-            let host_header = session
-                .get_header("host")
-                .and_then(|v| std::str::from_utf8(v.as_bytes()).ok())
-                .unwrap_or("")
-                .to_string();
+            let host_header = resolve_request_host(session).to_string();
             if let Some(host_config) = self.router.resolve(&host_header) {
                 ctx.host_config = Some(Arc::clone(&host_config));
                 let mut builder = RequestCtxBuilder::new(session, self.trust_proxy_headers, &self.trusted_proxies)
@@ -1172,5 +1188,73 @@ mod fr039_tests {
 
         let (h, _) = ErrorPageFactory::render(403, None).expect("render 403");
         assert!(h.headers.get("retry-after").is_none());
+    }
+}
+
+#[cfg(test)]
+mod host_resolution_tests {
+    //! Regression coverage for #92 — `resolve_host_from_parts` must work for
+    //! both HTTP/1.x (`Host` header) and HTTP/2 (`:authority` reaches us
+    //! through the request URI). Pure on `(headers, uri)` so we exercise the
+    //! matrix without booting Pingora.
+    use super::resolve_host_from_parts;
+    use http::{HeaderMap, HeaderValue, Uri};
+
+    #[test]
+    fn h1_uses_host_header_when_uri_is_path_only() {
+        let mut headers = HeaderMap::new();
+        headers.insert(http::header::HOST, HeaderValue::from_static("example.com"));
+        let uri: Uri = "/health".parse().expect("parse path-only uri");
+        assert_eq!(resolve_host_from_parts(&headers, &uri), "example.com");
+    }
+
+    #[test]
+    fn h2_falls_back_to_uri_authority_when_host_header_absent() {
+        // Pingora's H2 server places the `:authority` pseudo-header into the
+        // request URI; the `Host` header is not synthesised back.
+        let headers = HeaderMap::new();
+        let uri: Uri = "https://example.com/path".parse().expect("parse absolute uri");
+        assert_eq!(resolve_host_from_parts(&headers, &uri), "example.com");
+    }
+
+    #[test]
+    fn empty_host_header_falls_back_to_uri_authority() {
+        // A blank `Host: ` header must not mask a usable authority — RFC 7230
+        // §5.4 makes either source acceptable.
+        let mut headers = HeaderMap::new();
+        headers.insert(http::header::HOST, HeaderValue::from_static("   "));
+        let uri: Uri = "https://example.com/".parse().expect("parse absolute uri");
+        assert_eq!(resolve_host_from_parts(&headers, &uri), "example.com");
+    }
+
+    #[test]
+    fn host_header_preferred_over_uri_authority() {
+        // When both are present (e.g. an H1 client that also sent an absolute
+        // request-URI) the `Host` header is authoritative — matches
+        // pre-existing router behaviour.
+        let mut headers = HeaderMap::new();
+        headers.insert(http::header::HOST, HeaderValue::from_static("api.example.com"));
+        let uri: Uri = "http://other.example.com/path".parse().expect("parse absolute uri");
+        assert_eq!(resolve_host_from_parts(&headers, &uri), "api.example.com");
+    }
+
+    #[test]
+    fn returns_empty_when_neither_source_set() {
+        let headers = HeaderMap::new();
+        let uri: Uri = "/".parse().expect("parse path-only uri");
+        assert_eq!(resolve_host_from_parts(&headers, &uri), "");
+    }
+
+    #[test]
+    fn invalid_utf8_host_header_falls_back_to_uri() {
+        // Non-UTF-8 byte sequence in `Host` — we drop it and let the URI take
+        // over rather than emit a route lookup for garbled bytes.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::HOST,
+            HeaderValue::from_bytes(b"\xFF\xFEinvalid").expect("non-utf8 header value"),
+        );
+        let uri: Uri = "https://fallback.example.com/".parse().expect("parse absolute uri");
+        assert_eq!(resolve_host_from_parts(&headers, &uri), "fallback.example.com");
     }
 }

--- a/crates/prx-waf/src/main.rs
+++ b/crates/prx-waf/src/main.rs
@@ -1397,7 +1397,9 @@ fn run_server(config: &AppConfig, config_file_path: &str, vlogs_layer_slot: Laye
     proxy_service.add_tcp(&config.proxy.listen_addr);
 
     // Native TLS termination: bind `proxy.listen_addr_tls` when at least one
-    // `[[hosts]]` entry sets `ssl = true` and points at on-disk cert/key files.
+    // `[[hosts]]` entry sets `tls_terminate = true` and points at on-disk
+    // cert/key files. `tls_terminate` is independent of the host's `ssl` flag
+    // (which only controls whether the upstream connection uses TLS).
     // Pingora's rustls listener uses a single `with_single_cert` ServerConfig,
     // so multi-domain deployments must use a SAN certificate covering every
     // served host. The first valid binding wins; the rest are logged so a

--- a/crates/prx-waf/src/tls_bootstrap.rs
+++ b/crates/prx-waf/src/tls_bootstrap.rs
@@ -254,12 +254,7 @@ mod tests {
         }
     }
 
-    fn host(
-        name: &str,
-        tls_terminate: Option<bool>,
-        cert: Option<&str>,
-        key: Option<&str>,
-    ) -> HostEntry {
+    fn host(name: &str, tls_terminate: Option<bool>, cert: Option<&str>, key: Option<&str>) -> HostEntry {
         HostEntry {
             host: name.to_string(),
             port: 443,
@@ -350,7 +345,10 @@ mod tests {
             ..host("a.test", None, None, None)
         };
         let scan = collect_tls_bindings_with(&cfg(vec![entry]), &StubFs::with(&["/c.pem", "/k.pem"]), &AcceptAllPems);
-        assert!(scan.bindings.is_empty(), "ssl=true alone must not trigger listener bind");
+        assert!(
+            scan.bindings.is_empty(),
+            "ssl=true alone must not trigger listener bind"
+        );
         assert!(scan.errors.is_empty(), "no error expected when not opted in");
     }
 

--- a/crates/prx-waf/src/tls_bootstrap.rs
+++ b/crates/prx-waf/src/tls_bootstrap.rs
@@ -1,10 +1,12 @@
 //! TLS listener bootstrap.
 //!
-//! Inspects `AppConfig.hosts` for entries with `ssl = true` and existing
-//! `cert_file` / `key_file` paths, then surfaces them as `TlsHostBinding`
-//! records. `prx-waf::main` consumes these to call
+//! Inspects `AppConfig.hosts` for entries with `tls_terminate = true` and
+//! existing `cert_file` / `key_file` paths, then surfaces them as
+//! `TlsHostBinding` records. `prx-waf::main` consumes these to call
 //! `pingora_proxy::HttpProxyService::add_tls_with_settings` on the shared
-//! `listen_addr_tls` socket.
+//! `listen_addr_tls` socket. `tls_terminate` is independent of `HostEntry.ssl`
+//! (which controls upstream TLS) so a WAF can terminate HTTPS for a host
+//! while still forwarding plaintext to the backend.
 //!
 //! Per-host errors are isolated — a malformed entry never tears down TLS for
 //! the other hosts. `collect_tls_bindings` returns the valid bindings and a
@@ -33,9 +35,9 @@ pub struct TlsHostBinding {
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum TlsBindingError {
-    #[error("host '{host}' has ssl=true but cert_file is missing/empty in config")]
+    #[error("host '{host}' has tls_terminate=true but cert_file is missing/empty in config")]
     MissingCertPath { host: String },
-    #[error("host '{host}' has ssl=true but key_file is missing/empty in config")]
+    #[error("host '{host}' has tls_terminate=true but key_file is missing/empty in config")]
     MissingKeyPath { host: String },
     #[error("host '{host}': cert_file '{path}' does not exist on disk")]
     CertFileNotFound { host: String, path: String },
@@ -160,7 +162,7 @@ fn bind_for_host<F: FileChecker, V: PemValidator>(
     fs: &F,
     validator: &V,
 ) -> Result<Option<TlsHostBinding>, TlsBindingError> {
-    if !host.ssl.unwrap_or(false) {
+    if !host.tls_terminate.unwrap_or(false) {
         return Ok(None);
     }
 
@@ -252,13 +254,18 @@ mod tests {
         }
     }
 
-    fn host(name: &str, ssl: Option<bool>, cert: Option<&str>, key: Option<&str>) -> HostEntry {
+    fn host(
+        name: &str,
+        tls_terminate: Option<bool>,
+        cert: Option<&str>,
+        key: Option<&str>,
+    ) -> HostEntry {
         HostEntry {
             host: name.to_string(),
             port: 443,
             remote_host: "127.0.0.1".to_string(),
             remote_port: 8080,
-            ssl,
+            ssl: None,
             guard_status: None,
             cert_file: cert.map(String::from),
             key_file: key.map(String::from),
@@ -270,6 +277,7 @@ mod tests {
             upstream_write_timeout_ms: None,
             upstream_idle_timeout_ms: None,
             upstream_circuit_503_retry_after_s: None,
+            tls_terminate,
         }
     }
 
@@ -288,7 +296,7 @@ mod tests {
     }
 
     #[test]
-    fn host_without_ssl_skipped() {
+    fn host_without_tls_terminate_skipped() {
         let cfg = cfg(vec![host("a.test", Some(false), None, None)]);
         let scan = collect_tls_bindings_with(&cfg, &StubFs::with(&[]), &AcceptAllPems);
         assert!(scan.bindings.is_empty());
@@ -296,7 +304,7 @@ mod tests {
     }
 
     #[test]
-    fn host_with_ssl_none_skipped() {
+    fn host_with_tls_terminate_none_skipped() {
         let cfg = cfg(vec![host("a.test", None, None, None)]);
         let scan = collect_tls_bindings_with(&cfg, &StubFs::with(&[]), &AcceptAllPems);
         assert!(scan.bindings.is_empty());
@@ -304,7 +312,7 @@ mod tests {
     }
 
     #[test]
-    fn ssl_without_cert_path_records_error() {
+    fn tls_terminate_without_cert_path_records_error() {
         let cfg = cfg(vec![host("a.test", Some(true), None, Some("/k"))]);
         let scan = collect_tls_bindings_with(&cfg, &StubFs::with(&[]), &AcceptAllPems);
         assert!(scan.bindings.is_empty());
@@ -317,7 +325,7 @@ mod tests {
     }
 
     #[test]
-    fn ssl_without_key_path_records_error() {
+    fn tls_terminate_without_key_path_records_error() {
         let cfg = cfg(vec![host("a.test", Some(true), Some("/c"), None)]);
         let scan = collect_tls_bindings_with(&cfg, &StubFs::with(&[]), &AcceptAllPems);
         assert_eq!(
@@ -326,6 +334,41 @@ mod tests {
                 host: "a.test".to_string(),
             }]
         );
+    }
+
+    #[test]
+    fn ssl_true_alone_does_not_bind_listener() {
+        // Regression guard for #91: `ssl` (upstream TLS) and `tls_terminate`
+        // (listener bind) must stay orthogonal. A host with `ssl=true` but no
+        // `tls_terminate` MUST NOT bind the WAF listener — that field controls
+        // whether the proxy talks TLS to the upstream, nothing more.
+        let entry = HostEntry {
+            ssl: Some(true),
+            tls_terminate: None,
+            cert_file: Some("/c.pem".into()),
+            key_file: Some("/k.pem".into()),
+            ..host("a.test", None, None, None)
+        };
+        let scan = collect_tls_bindings_with(&cfg(vec![entry]), &StubFs::with(&["/c.pem", "/k.pem"]), &AcceptAllPems);
+        assert!(scan.bindings.is_empty(), "ssl=true alone must not trigger listener bind");
+        assert!(scan.errors.is_empty(), "no error expected when not opted in");
+    }
+
+    #[test]
+    fn ssl_and_tls_terminate_are_independent() {
+        // Both fields can be set simultaneously: WAF terminates client TLS AND
+        // re-encrypts to upstream HTTPS. Listener should bind regardless of
+        // `ssl`.
+        let entry = HostEntry {
+            ssl: Some(true),
+            tls_terminate: Some(true),
+            cert_file: Some("/c.pem".into()),
+            key_file: Some("/k.pem".into()),
+            ..host("a.test", None, None, None)
+        };
+        let scan = collect_tls_bindings_with(&cfg(vec![entry]), &StubFs::with(&["/c.pem", "/k.pem"]), &AcceptAllPems);
+        assert_eq!(scan.bindings.len(), 1);
+        assert!(scan.errors.is_empty());
     }
 
     #[test]
@@ -416,7 +459,7 @@ mod tests {
     }
 
     #[test]
-    fn multiple_ssl_hosts_all_returned_in_order() {
+    fn multiple_tls_terminate_hosts_all_returned_in_order() {
         let cfg = cfg(vec![
             host("a.test", Some(true), Some("/a.pem"), Some("/ak.pem")),
             host("b.test", Some(false), None, None),
@@ -434,9 +477,9 @@ mod tests {
 
     #[test]
     fn invalid_host_does_not_drop_valid_ones() {
-        // Regression guard: previously a single broken SSL host propagated `Err`
-        // and discarded every other binding. Now the bad host surfaces as one
-        // entry in `errors`, and the good ones still bind.
+        // Regression guard: previously a single broken TLS-terminating host
+        // propagated `Err` and discarded every other binding. Now the bad host
+        // surfaces as one entry in `errors`, and the good ones still bind.
         let cfg = cfg(vec![
             host("a.test", Some(true), Some("/a.pem"), Some("/ak.pem")),
             host("b.test", Some(true), None, Some("/bk.pem")),
@@ -500,7 +543,7 @@ mod real_fs_tests {
             port: 443,
             remote_host: "127.0.0.1".to_string(),
             remote_port: 8080,
-            ssl: Some(true),
+            ssl: None,
             guard_status: None,
             cert_file: Some(cert.to_string_lossy().into_owned()),
             key_file: Some(key.to_string_lossy().into_owned()),
@@ -512,6 +555,7 @@ mod real_fs_tests {
             upstream_write_timeout_ms: None,
             upstream_idle_timeout_ms: None,
             upstream_circuit_503_retry_after_s: None,
+            tls_terminate: Some(true),
         }
     }
 

--- a/crates/waf-common/src/config.rs
+++ b/crates/waf-common/src/config.rs
@@ -265,10 +265,19 @@ pub struct HostEntry {
     pub port: u16,
     pub remote_host: String,
     pub remote_port: u16,
+    /// Talk to the upstream over TLS (HTTPS). Default `false` (plaintext).
+    /// Orthogonal to `tls_terminate` — set this only when the upstream itself
+    /// speaks TLS.
     pub ssl: Option<bool>,
     pub guard_status: Option<bool>,
     pub cert_file: Option<String>,
     pub key_file: Option<String>,
+    /// Bind this host's `cert_file` / `key_file` on the proxy's native TLS
+    /// listener (`proxy.listen_addr_tls`). Default `false`. Independent of
+    /// `ssl`: most deployments terminate TLS at the WAF while forwarding to a
+    /// plaintext upstream (`tls_terminate=true`, `ssl=false`).
+    #[serde(default)]
+    pub tls_terminate: Option<bool>,
     /// OWASP CRS rule pipeline. Defaults to `true` for TOML-declared hosts
     /// (operators expect a sensible "WAF on" baseline) — the DB admin UI
     /// keeps its own opt-in toggle.

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -599,8 +599,8 @@ PRX_WAF_API__ADMIN_IP_ALLOWLIST=10.0.0.0/8,192.168.0.0/16
 ### Native TLS Listener (file-based certs)
 
 Bind the WAF directly on `proxy.listen_addr_tls` (default `0.0.0.0:443`) by
-declaring at least one `[[hosts]]` entry with `ssl = true` and on-disk
-`cert_file` / `key_file` paths:
+declaring at least one `[[hosts]]` entry with `tls_terminate = true` and
+on-disk `cert_file` / `key_file` paths:
 
 ```toml
 [proxy]
@@ -608,27 +608,41 @@ listen_addr     = "0.0.0.0:80"
 listen_addr_tls = "0.0.0.0:443"
 
 [[hosts]]
-host        = "example.com"
-port        = 443
-remote_host = "127.0.0.1"
-remote_port = 8080
-ssl         = true
-cert_file   = "/etc/mini-waf/certs/example.com/fullchain.pem"
-key_file    = "/etc/mini-waf/certs/example.com/privkey.pem"
+host          = "example.com"
+port          = 443
+remote_host   = "127.0.0.1"
+remote_port   = 8080
+ssl           = false  # upstream is plaintext (HTTP) — the WAF terminates TLS
+tls_terminate = true   # bind this cert on the WAF's port 443
+cert_file     = "/etc/mini-waf/certs/example.com/fullchain.pem"
+key_file      = "/etc/mini-waf/certs/example.com/privkey.pem"
 ```
+
+`tls_terminate` (listener bind) and `ssl` (upstream uses TLS) are independent
+knobs. The matrix:
+
+| `tls_terminate` | `ssl` | Effect |
+|---|---|---|
+| `true`  | `false` | WAF terminates HTTPS for clients, forwards plaintext to upstream (most common) |
+| `true`  | `true`  | WAF terminates client TLS, re-encrypts to an HTTPS upstream |
+| `false` | `true`  | No WAF listener bind; passthrough to upstream over HTTPS via a different terminator |
+| `false` | `false` | Plaintext end-to-end (legacy / behind an external TLS proxy) |
 
 Behavior:
 
-- Listener is opt-in. With no `ssl = true` host, port 443 stays closed and the
-  proxy continues to listen on plaintext only (legacy behavior preserved).
-- Each `ssl = true` host is validated independently at startup:
+- Listener is opt-in. With no `tls_terminate = true` host, port 443 stays closed
+  and the proxy keeps serving plaintext only (legacy behaviour preserved).
+- Each `tls_terminate = true` host is validated independently at startup:
   - `cert_file` / `key_file` paths must exist on disk.
   - PEM content is parsed before being handed to Pingora (catches mismatched
     keypairs, corrupted PEM, or non-PEM files without panicking the proxy).
   - Any host that fails one of these checks is logged at ERROR level and
-    skipped. Other valid SSL hosts still bind.
-- If every `ssl = true` host fails validation, the listener is not bound and
-  the proxy keeps serving plaintext only — same as the no-SSL-host case.
+    skipped. Other valid TLS-terminating hosts still bind.
+- If every `tls_terminate = true` host fails validation, the listener is not
+  bound and the proxy keeps serving plaintext only.
+- The **leaf certificate must appear first** in `fullchain.pem` (before any
+  intermediates). The validator detects the reversed order and surfaces an
+  actionable error rather than silently failing the TLS handshake.
 - ALPN advertises `h2,http/1.1`; HTTP/2 over TLS is enabled automatically.
 
 ### Multi-domain (SNI) deployments
@@ -637,9 +651,9 @@ The current rustls-backed listener uses a single `with_single_cert`
 `ServerConfig`. To serve multiple hostnames on the same port 443, use a
 **SAN certificate** that includes every served hostname (issue one Let's
 Encrypt cert with `-d a.example.com -d b.example.com …`). The first
-`[[hosts]]` entry with valid cert/key wins; additional SSL hosts log a
-warning at boot. Per-host distinct certs via a custom SNI resolver are
-planned in a follow-up.
+`[[hosts]]` entry with valid cert/key wins; additional `tls_terminate = true`
+hosts log a warning at boot. Per-host distinct certs via a custom SNI resolver
+are planned in a follow-up.
 
 ### Let's Encrypt (Automatic — DB-backed, in development)
 


### PR DESCRIPTION
## Summary

- Fixes **#91** — `HostEntry.ssl` was overloaded by PR #90: the same field gated both the WAF's native TLS listener binding (`tls_bootstrap.rs`) and the proxy's upstream-TLS handshake (`proxy.rs`). Live deployment on `52.76.3.127` confirmed the common case (HTTPS at the WAF + plaintext upstream) could not be configured — `ssl=true` forced the proxy to attempt TLS handshake against a plaintext backend, returning 502.
- Fixes **#92** — `gateway::proxy` resolved the request host via `session.get_header(\"host\")` only. For HTTP/2 client requests Pingora exposes the host through `:authority` (parsed into the request URI); the legacy lookup returned an empty string → `router.resolve(\"\")` → `None` → fail-closed 503.

## Changes

| File | Change |
|---|---|
| `crates/waf-common/src/config.rs` | New `HostEntry.tls_terminate: Option<bool>` field. Doc-string for `ssl` clarified ("upstream uses TLS"). |
| `crates/prx-waf/src/tls_bootstrap.rs` | `bind_for_host` gates on `tls_terminate`. Error variant messages updated. 2 regression tests: `ssl_true_alone_does_not_bind_listener`, `ssl_and_tls_terminate_are_independent`. Existing tests renamed for the new field. |
| `crates/prx-waf/src/main.rs` | Comment block at the TLS-bootstrap call site references the new field + clarifies the orthogonality to `ssl`. |
| `crates/gateway/src/proxy.rs` | New pure helper `resolve_host_from_parts(headers, uri)` used by both `upstream_peer` and the request-filter site (DRY). Falls back from `Host` header to `uri.host()` when absent / blank / invalid UTF-8. 6 new tests covering the H1, H2, empty-Host, absolute-URI, invalid-UTF-8, and both-absent matrices. |
| `docs/deployment-guide.md` | Native TLS section rewritten with the `tls_terminate`/`ssl` matrix and the leaf-first chain-order note. |

## Why this is future-proof

The two fields are orthogonal — every combination is meaningful and supported:

| `tls_terminate` | `ssl` | Effect |
|---|---|---|
| `true`  | `false` | WAF terminates HTTPS, plaintext to upstream (most common) |
| `true`  | `true`  | WAF terminates client TLS, re-encrypts to HTTPS upstream |
| `false` | `true`  | No WAF listener bind; passthrough to upstream over HTTPS |
| `false` | `false` | Plaintext end-to-end (legacy / external TLS terminator) |

Adding more `[[hosts]]` behind the WAF requires no schema change — each entry picks its column independently. Operators no longer need an external nginx/HAProxy in front of mini-waf to terminate TLS while keeping plaintext upstreams.

## Test plan

- [x] `cargo check --workspace --all-targets --features gateway/valkey` — clean
- [x] `cargo clippy --workspace --features gateway/valkey --all-targets -- -D warnings` — clean
- [x] `cargo test -p gateway --lib --features gateway/valkey` — 337 / 337 pass (incl. 6 new `host_resolution_tests`)
- [x] `cargo test -p waf-common` — 19 / 19 pass
- [x] `cargo test -p prx-waf --features gateway/valkey` — all `tls_bootstrap` tests pass (incl. 2 new regression tests)
- [x] `cargo fmt --all -- --check` — clean
- [ ] Full CI run — to be verified by GitHub Actions

> Note: One pre-existing flake `spawn_enabled_with_missing_binary_fails_fast` (Phase-10 VictoriaLogs sidecar integration test) flakes on amd64-emulated rocky9 builders but passes on the GHA linux runner used by CI. Unrelated to this change.

## Live verification (post-merge)

Will rebuild and redeploy on `52.76.3.127` immediately after CI green + squash merge. Native TLS listener should bind on `0.0.0.0:443` with the existing Let's Encrypt SAN cert, with both `mini-waf.ace-trail.com` and `waf-upstream.ace-trail.com` returning the expected upstream payloads over HTTP/2.

Closes #91
Closes #92