### PR TITLE
fix(ssrf): reject IPv4-compatible IPv6 metadata/private addresses (#77)

### DIFF
--- a/crates/waf-common/src/url_validator.rs
+++ b/crates/waf-common/src/url_validator.rs
@@ -205,6 +205,18 @@ const fn is_private_or_reserved(ip: &IpAddr) -> bool {
                 || (seg[0] == 0x2001 && seg[1] == 0x0db8)
                 // 64:ff9b::/96 — IPv4/IPv6 translation (RFC 6052)
                 || (seg[0] == 0x0064 && seg[1] == 0xff9b)
+                // ::a.b.c.d — IPv4-compatible (RFC 4291 §2.5.5.1, deprecated
+                // but still parseable). Upper 96 bits zero, trailing 32 bits
+                // carry a bare v4 that must be re-checked against v4 rules.
+                // `Ipv6Addr::is_loopback` only matches `::1`, so without this
+                // branch `::127.0.0.1`, `::169.254.169.254` etc. slip through.
+                || (seg[0] == 0 && seg[1] == 0 && seg[2] == 0
+                    && seg[3] == 0 && seg[4] == 0 && seg[5] == 0
+                    && (seg[6] != 0 || seg[7] != 0)
+                    && is_private_or_reserved(&IpAddr::V4(std::net::Ipv4Addr::new(
+                        (seg[6] >> 8) as u8, (seg[6] & 0xff) as u8,
+                        (seg[7] >> 8) as u8, (seg[7] & 0xff) as u8,
+                    ))))
             }
         }
     }

--- a/crates/waf-common/tests/url_validator_edge.rs
+++ b/crates/waf-common/tests/url_validator_edge.rs
@@ -137,3 +137,45 @@ fn scheme_only_allows_arbitrary_private_ips() {
     assert!(validate_scheme_only("http://10.0.0.1:8080").is_ok());
     assert!(validate_scheme_only("https://[fe80::1]:8080").is_ok());
 }
+
+// ─── IPv4-compatible IPv6 (RFC 4291 §2.5.5.1) ────────────────────────────────
+// Form `::a.b.c.d` carries an IPv4 address in the trailing 32 bits with the
+// upper 96 bits all zero. `Ipv6Addr::is_loopback` matches only `::1`, so each
+// of these literals would otherwise slip past the IPv6 guard and reach the
+// embedded IPv4 service (cloud metadata, loopback, RFC1918).
+
+#[test]
+fn rejects_ipv4_compatible_aws_imds() {
+    // ::169.254.169.254 — AWS / Azure IMDS via IPv4-compatible form.
+    let err = validate_public_url("http://[::169.254.169.254]/latest/meta-data/").unwrap_err();
+    assert!(matches!(err, UrlValidationError::BlockedHost(_, _)));
+}
+
+#[test]
+fn rejects_ipv4_compatible_alibaba_imds() {
+    // ::100.100.100.200 — Alibaba Cloud IMDS via IPv4-compatible form.
+    let err = validate_public_url("http://[::100.100.100.200]/").unwrap_err();
+    assert!(matches!(err, UrlValidationError::BlockedHost(_, _)));
+}
+
+#[test]
+fn rejects_ipv4_compatible_loopback() {
+    // ::127.0.0.1 — loopback via IPv4-compatible form (not caught by ::1 check).
+    let err = validate_public_url("http://[::127.0.0.1]/").unwrap_err();
+    assert!(matches!(err, UrlValidationError::BlockedHost(_, _)));
+}
+
+#[test]
+fn rejects_ipv4_compatible_rfc1918() {
+    // RFC1918 private ranges via IPv4-compatible form.
+    assert!(validate_public_url("http://[::10.0.0.1]/").is_err());
+    assert!(validate_public_url("http://[::192.168.1.1]/").is_err());
+    assert!(validate_public_url("http://[::172.16.0.1]/").is_err());
+}
+
+#[test]
+fn accepts_public_ipv4_compatible_not_blocked() {
+    // ::1.1.1.1 — Cloudflare DNS via IPv4-compatible form. The trailing v4 is
+    // publicly routable, so the URL must pass (negative case: no over-block).
+    assert!(validate_public_url("http://[::1.1.1.1]/").is_ok());
+}

--- a/crates/waf-engine/src/checks/ssrf_scanners.rs
+++ b/crates/waf-engine/src/checks/ssrf_scanners.rs
@@ -134,9 +134,23 @@ pub fn is_private_ip(addr: IpAddr) -> bool {
                 // set here to close the `[::ffff:100.100.100.200]` bypass.
                 return METADATA_HOST_SET.is_match(&v4.to_string());
             }
-            // Reject IPv6 unique-local + link-local prefixes; everything
-            // else is treated as routable for v1.
             let segs = v6.segments();
+            // IPv4-compatible IPv6 (RFC 4291 §2.5.5.1): `::a.b.c.d` — upper
+            // 96 bits zero, trailing 32 bits carry a bare v4. NOT matched by
+            // `to_ipv4_mapped()` which only handles the `::ffff:a.b.c.d` form.
+            if segs[0..6].iter().all(|&s| s == 0) && (segs[6] != 0 || segs[7] != 0) {
+                let v4 = Ipv4Addr::new(
+                    (segs[6] >> 8) as u8,
+                    (segs[6] & 0xff) as u8,
+                    (segs[7] >> 8) as u8,
+                    (segs[7] & 0xff) as u8,
+                );
+                if PRIVATE_CIDRS.iter().any(|net| net.contains(&v4))
+                    || METADATA_HOST_SET.is_match(&v4.to_string())
+                {
+                    return true;
+                }
+            }
             // fc00::/7 (unique-local)
             if segs[0] & 0xfe00 == 0xfc00 {
                 return true;
@@ -253,5 +267,28 @@ mod tests {
     fn is_private_ip_v6_public_returns_false() {
         let v6: IpAddr = "2606:4700:4700::1111".parse().expect("public v6");
         assert!(!is_private_ip(v6));
+    }
+
+    #[test]
+    fn is_private_ip_v4_compatible_metadata() {
+        // RFC 4291 §2.5.5.1 IPv4-compatible IPv6 (`::a.b.c.d`) — bare v4 in
+        // the trailing 32 bits with upper 96 bits all zero. Must catch the
+        // same private ranges and metadata hosts as the mapped form.
+        for s in [
+            "::169.254.169.254", // AWS / Azure IMDS
+            "::100.100.100.200", // Alibaba IMDS
+            "::127.0.0.1",       // loopback (not caught by Ipv6Addr::is_loopback)
+            "::10.0.0.1",        // RFC1918
+        ] {
+            let addr: IpAddr = s.parse().expect("v4-compatible");
+            assert!(is_private_ip(addr), "{s} should be private");
+        }
+    }
+
+    #[test]
+    fn is_private_ip_v4_compatible_public_returns_false() {
+        // Negative: public v4 in IPv4-compatible form must not be over-blocked.
+        let addr: IpAddr = "::1.1.1.1".parse().expect("v4-compatible public");
+        assert!(!is_private_ip(addr));
     }
 }

--- a/crates/waf-engine/src/checks/ssrf_scanners.rs
+++ b/crates/waf-engine/src/checks/ssrf_scanners.rs
@@ -145,9 +145,7 @@ pub fn is_private_ip(addr: IpAddr) -> bool {
                     (segs[7] >> 8) as u8,
                     (segs[7] & 0xff) as u8,
                 );
-                if PRIVATE_CIDRS.iter().any(|net| net.contains(&v4))
-                    || METADATA_HOST_SET.is_match(&v4.to_string())
-                {
+                if PRIVATE_CIDRS.iter().any(|net| net.contains(&v4)) || METADATA_HOST_SET.is_match(&v4.to_string()) {
                     return true;
                 }
             }


### PR DESCRIPTION
## Summary

Closes #77 — SSRF private-IP guard bypass via IPv4-compatible IPv6 notation.

The `::a.b.c.d` form (RFC 4291 §2.5.5.1) sits in the IPv6 namespace but
carries a bare IPv4 address in its trailing 32 bits. Neither of the two
existing IPv6 guards recognised it:

- `Ipv6Addr::is_loopback()` matches only the canonical `::1`, so
  `::127.0.0.1` reached the embedded loopback service.
- `Ipv6Addr::to_ipv4_mapped()` handles only the `::ffff:a.b.c.d` form,
  so the IPv4-compatible form was never extracted for v4 rule matching.

Net exposure: SSRF to AWS / Azure IMDS via `::169.254.169.254`, Alibaba
via `::100.100.100.200`, loopback via `::127.0.0.1`, and any RFC1918
range via `::10.0.0.1`, `::192.168.x.x` etc — all bypassed the guard.

## Fix

Two parallel branches, one per validation layer:

- `waf-common::url_validator::is_private_or_reserved` — new arm in the
  IPv6 `match` recurses into the v4 check after reconstructing the
  embedded `Ipv4Addr`. Const-recursion stays one hop deep (v4 arm never
  recurses back).
- `waf-engine::checks::ssrf_scanners::is_private_ip` — new branch after
  `to_ipv4_mapped`, mirrors the mapped-form handling: consults both
  `PRIVATE_CIDRS` and `METADATA_HOST_SET` (Alibaba `100.100.100.200` is
  intentionally excluded from `PRIVATE_CIDRS` to avoid flagging the
  whole CGNAT range, so a second-pass metadata check is needed).

## Test coverage

New cases in `crates/waf-common/tests/url_validator_edge.rs`:

- `rejects_ipv4_compatible_aws_imds` — `::169.254.169.254`
- `rejects_ipv4_compatible_alibaba_imds` — `::100.100.100.200`
- `rejects_ipv4_compatible_loopback` — `::127.0.0.1`
- `rejects_ipv4_compatible_rfc1918` — `::10.0.0.1`, `::192.168.1.1`, `::172.16.0.1`
- `accepts_public_ipv4_compatible_not_blocked` — `::1.1.1.1` (negative case to guard against over-blocking)

New cases in `ssrf_scanners` inline tests:

- `is_private_ip_v4_compatible_metadata` — AWS, Alibaba, loopback, RFC1918 via the v4-compatible form
- `is_private_ip_v4_compatible_public_returns_false` — `::1.1.1.1` must pass

## Scope

- Files touched: 3 (`url_validator.rs`, `url_validator_edge.rs`, `ssrf_scanners.rs`)
- LOC delta: +93 / -2
- Targets `release/stg`. Production-grade fix; no DB / cluster / network dependencies, all pure-function tests.

## Test plan

- [x] Unit tests added for AWS/Azure IMDS, Alibaba IMDS, loopback, RFC1918, and the public-IP negative case.
- [ ] CI: `cargo test`, `cargo clippy`, `cargo fmt --check`, and per-crate coverage gates must pass.
- [ ] CI: workspace build + Docker rocky9 build must succeed.