### PR TITLE
fix(plugins): enforce MAX_MEMORY_BYTES via wasmtime ResourceLimiter (#78)

### DIFF
--- a/crates/waf-engine/src/plugins/manager.rs
+++ b/crates/waf-engine/src/plugins/manager.rs
@@ -36,22 +36,12 @@ const FUEL_PER_CALL: u64 = 10_000_000;
 struct PluginLimits;
 
 impl ResourceLimiter for PluginLimits {
-    fn memory_growing(
-        &mut self,
-        _current: usize,
-        desired: usize,
-        _maximum: Option<usize>,
-    ) -> anyhow::Result<bool> {
+    fn memory_growing(&mut self, _current: usize, desired: usize, _maximum: Option<usize>) -> wasmtime::Result<bool> {
         let cap = usize::try_from(MAX_MEMORY_BYTES).unwrap_or(usize::MAX);
         Ok(desired <= cap)
     }
 
-    fn table_growing(
-        &mut self,
-        _current: usize,
-        _desired: usize,
-        _maximum: Option<usize>,
-    ) -> anyhow::Result<bool> {
+    fn table_growing(&mut self, _current: usize, _desired: usize, _maximum: Option<usize>) -> wasmtime::Result<bool> {
         Ok(true)
     }
 }

--- a/crates/waf-engine/src/plugins/manager.rs
+++ b/crates/waf-engine/src/plugins/manager.rs
@@ -21,13 +21,40 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
-use wasmtime::{Config, Engine, Linker, Module, Store};
+use wasmtime::{Config, Engine, Linker, Module, ResourceLimiter, Store};
 
 /// Maximum WASM linear memory (64 MiB)
 const MAX_MEMORY_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Fuel granted per-invocation (≈ 10 million instructions)
 const FUEL_PER_CALL: u64 = 10_000_000;
+
+/// Per-`Store` resource limiter that caps linear-memory growth at
+/// `MAX_MEMORY_BYTES`. Without this, a hostile plugin declaring
+/// `(memory N)` for large N would request `N * 64 KiB` at instantiation
+/// and OOM the host process — fuel only meters instructions, not allocation.
+struct PluginLimits;
+
+impl ResourceLimiter for PluginLimits {
+    fn memory_growing(
+        &mut self,
+        _current: usize,
+        desired: usize,
+        _maximum: Option<usize>,
+    ) -> anyhow::Result<bool> {
+        let cap = usize::try_from(MAX_MEMORY_BYTES).unwrap_or(usize::MAX);
+        Ok(desired <= cap)
+    }
+
+    fn table_growing(
+        &mut self,
+        _current: usize,
+        _desired: usize,
+        _maximum: Option<usize>,
+    ) -> anyhow::Result<bool> {
+        Ok(true)
+    }
+}
 
 // ─── Plugin action ────────────────────────────────────────────────────────────
 
@@ -128,7 +155,8 @@ impl WasmPlugin {
     }
 
     fn run_request(&self, method: &str, path: &str, client_ip: &str) -> anyhow::Result<PluginAction> {
-        let mut store = Store::new(&self.engine, ());
+        let mut store = Store::new(&self.engine, PluginLimits);
+        store.limiter(|state| state);
         store.set_fuel(FUEL_PER_CALL)?;
 
         let linker = Linker::new(&self.engine);
@@ -158,7 +186,8 @@ impl WasmPlugin {
 
     /// Read a plugin name/version string from WASM memory exports.
     pub fn read_string_export(&self, ptr_export: &str, len_export: &str) -> Option<String> {
-        let mut store = Store::new(&self.engine, ());
+        let mut store = Store::new(&self.engine, PluginLimits);
+        store.limiter(|state| state);
         store.set_fuel(1_000_000).ok()?;
         let linker = Linker::new(&self.engine);
         let instance = linker.instantiate(&mut store, &self.module).ok()?;

--- a/crates/waf-engine/tests/plugins_wasm_lifecycle.rs
+++ b/crates/waf-engine/tests/plugins_wasm_lifecycle.rs
@@ -282,3 +282,57 @@ async fn set_enabled_on_missing_id_returns_false() {
     let mgr = PluginManager::new();
     assert!(!mgr.set_enabled(Uuid::new_v4(), true).await);
 }
+
+// ── Memory limiter (#78) ─────────────────────────────────────────────────────
+//
+// `MAX_MEMORY_BYTES` is 64 MiB = 1024 WASM pages. A hostile plugin declaring
+// `(memory N)` for large N would otherwise allocate `N * 64 KiB` at
+// instantiation and OOM the host (fuel meters instructions only). The
+// `ResourceLimiter` wired onto every `Store` caps `memory_growing` at
+// `MAX_MEMORY_BYTES`. Instantiation that would exceed the cap fails inside
+// `run_request`, which then swallows the error and returns the safe-default
+// `Allow` — so a Block-returning plugin with oversized memory ends up Allowing.
+
+fn wat_memory_pages_block(pages: u32) -> Vec<u8> {
+    wat::parse_str(&format!(
+        r#"(module
+             (memory (export "memory") {pages})
+             (func (export "on_request") (result i32) i32.const 1)
+           )"#,
+    ))
+    .expect("valid WAT")
+}
+
+#[tokio::test]
+async fn memory_within_cap_block_plugin_still_blocks() {
+    let mgr = PluginManager::new();
+    let id = Uuid::new_v4();
+    // 1024 pages × 64 KiB = exactly 64 MiB; limiter permits `desired <= cap`.
+    mgr.load(params(id, "within-cap", &wat_memory_pages_block(1024)))
+        .await
+        .expect("load");
+
+    let action = mgr.run_request("GET", "/", "1.2.3.4").await;
+    assert_eq!(action, PluginAction::Block, "plugin at the cap must still run");
+}
+
+#[tokio::test]
+async fn memory_over_cap_blocks_instantiation_and_returns_allow() {
+    let mgr = PluginManager::new();
+    let id = Uuid::new_v4();
+    // 2048 pages × 64 KiB = 128 MiB, double the cap. WasmPlugin::new only
+    // compiles the module, so `load` succeeds. The limiter rejects the
+    // memory growth at instantiation inside `run_request`, the error
+    // propagates, `on_request` swallows it and returns Allow — so the
+    // module's i32.const 1 (Block) is never observed.
+    mgr.load(params(id, "over-cap", &wat_memory_pages_block(2048)))
+        .await
+        .expect("load (compile only)");
+
+    let action = mgr.run_request("GET", "/", "1.2.3.4").await;
+    assert_eq!(
+        action,
+        PluginAction::Allow,
+        "memory cap must reject instantiation; safe-default to Allow"
+    );
+}

--- a/crates/waf-engine/tests/plugins_wasm_lifecycle.rs
+++ b/crates/waf-engine/tests/plugins_wasm_lifecycle.rs
@@ -294,7 +294,7 @@ async fn set_enabled_on_missing_id_returns_false() {
 // `Allow` — so a Block-returning plugin with oversized memory ends up Allowing.
 
 fn wat_memory_pages_block(pages: u32) -> Vec<u8> {
-    wat::parse_str(&format!(
+    wat::parse_str(format!(
         r#"(module
              (memory (export "memory") {pages})
              (func (export "on_request") (result i32) i32.const 1)


### PR DESCRIPTION
## Summary

Closes #78 — WASM plugin `MAX_MEMORY_BYTES` declared but never enforced.

`crates/waf-engine/src/plugins/manager.rs` defined `MAX_MEMORY_BYTES = 64 MiB` but the `Store` only enabled fuel and a `max_wasm_stack` setting; nothing capped linear-memory growth. A plugin declaring `(memory 65536)` would request 4 GiB at instantiation time and OOM the host. Fuel meters instructions, not allocation.

## Fix

- New ZST `PluginLimits` implements `wasmtime::ResourceLimiter`.
- `memory_growing` returns `Ok(desired <= MAX_MEMORY_BYTES)`; growths at or below the cap proceed, anything beyond is rejected.
- `table_growing` returns `Ok(true)` — out of scope, kept open as a follow-up (defense-in-depth on table size has no real exploit path with current fuel cap).
- Wired via `store.limiter(|state| state)` at both `Store::new` sites in `WasmPlugin::run_request` and `WasmPlugin::read_string_export`. When the limiter rejects, instantiation fails inside `run_request`; the existing error handler logs and returns `PluginAction::Allow` (the safe default — a hostile plugin can no longer take down the engine, but legitimate traffic also isn't accidentally Blocked by a buggy plugin).

## Test coverage

Two new tests in `tests/plugins_wasm_lifecycle.rs` cover the boundary and the rejection path:

- `memory_within_cap_block_plugin_still_blocks` — `(memory 1024)` = exactly 64 MiB, the cap. The plugin returns Block; the limiter must allow `desired == cap`, so the Block decision must surface. Guards against an over-eager limiter.
- `memory_over_cap_blocks_instantiation_and_returns_allow` — `(memory 2048)` = 128 MiB, twice the cap. `load` succeeds (compile only). `run_request` must hit the limiter at instantiation, the error must propagate through the existing handler, and the action must be Allow rather than the plugin's intended Block — proving the cap actually fires.

Helper `wat_memory_pages_block(pages: u32)` parameterises page count so future tweaks to the cap stay one constant away from the test.

## Scope

- Files touched: 2 (`manager.rs`, `plugins_wasm_lifecycle.rs`)
- LOC delta: +86 / -3
- Targets `release/stg`.
- Pure-fn / single-crate work. No DB, no cluster, no network — tests are deterministic and self-contained.

## Test plan

- [x] WAT modules at-cap and over-cap added with assertions on observable behaviour, not internal error types.
- [ ] CI: full pipeline — Lint (incl. `cargo fmt --check`), Test, Build, Coverage matrix, Security audit.

## Out of scope — surfaced as follow-up

- Issue #71 (plugin upload no size/MIME limit) — paired with this in #78's "Related" section; that one belongs to the `waf-api` upload layer, not the engine, and remains open.
- Table-size cap (`table_growing` left as `Ok(true)` for now) — no known exploit path with current fuel limit; revisit if a table-bomb proof-of-concept lands.