### PR TITLE
fix(router): case-fold Host header for resolve / register / unregister (#87)

### DIFF
--- a/crates/gateway/src/router.rs
+++ b/crates/gateway/src/router.rs
@@ -26,7 +26,7 @@ impl HostRouter {
     /// that lookups remain case-insensitive (RFC 9110 §5.4 — host names are
     /// case-insensitive). Without this a client sending `Host: Example.COM`
     /// against a registered `example.com` would miss the route and the
-    /// router would return 502, which an attacker can weaponise into a DoS
+    /// router would return 502, which an attacker can weaponise into a `DoS`
     /// by spraying random-case Host headers.
     pub fn register(&self, config: &Arc<HostConfig>) {
         let host_lc = config.host.to_ascii_lowercase();

--- a/crates/gateway/src/router.rs
+++ b/crates/gateway/src/router.rs
@@ -20,37 +20,57 @@ impl HostRouter {
         Self::default()
     }
 
-    /// Register a host configuration
+    /// Register a host configuration.
+    ///
+    /// The host name is normalised to ASCII lowercase before insertion so
+    /// that lookups remain case-insensitive (RFC 9110 §5.4 — host names are
+    /// case-insensitive). Without this a client sending `Host: Example.COM`
+    /// against a registered `example.com` would miss the route and the
+    /// router would return 502, which an attacker can weaponise into a DoS
+    /// by spraying random-case Host headers.
     pub fn register(&self, config: &Arc<HostConfig>) {
+        let host_lc = config.host.to_ascii_lowercase();
+
         // Register by "host:port"
-        let key = format!("{}:{}", config.host, config.port);
+        let key = format!("{}:{}", host_lc, config.port);
         self.routes.insert(key, Arc::clone(config));
 
         // Also register by bare hostname for default ports (80/443)
         if config.port == 80 || config.port == 443 {
-            self.routes.insert(config.host.clone(), Arc::clone(config));
+            self.routes.insert(host_lc, Arc::clone(config));
         }
     }
 
-    /// Remove a host configuration
+    /// Remove a host configuration.
+    ///
+    /// Case is normalised symmetrically with [`Self::register`] so that
+    /// `unregister("Example.com", 80)` removes what `register` stored as
+    /// `"example.com"`.
     pub fn unregister(&self, host: &str, port: u16) {
-        let key = format!("{host}:{port}");
+        let host_lc = host.to_ascii_lowercase();
+        let key = format!("{host_lc}:{port}");
         self.routes.remove(&key);
         if port == 80 || port == 443 {
-            self.routes.remove(host);
+            self.routes.remove(&host_lc);
         }
     }
 
-    /// Resolve a request to a host config using the Host header value
+    /// Resolve a request to a host config using the Host header value.
+    ///
+    /// Lookup is case-insensitive — the incoming header is folded to
+    /// ASCII lowercase to match the normalised keys produced by
+    /// [`Self::register`].
     pub fn resolve(&self, host_header: &str) -> Option<Arc<HostConfig>> {
+        let host_lc = host_header.to_ascii_lowercase();
+
         // Try exact match first
-        if let Some(entry) = self.routes.get(host_header) {
+        if let Some(entry) = self.routes.get(&host_lc) {
             let cfg: Arc<HostConfig> = Arc::clone(&*entry);
             return Some(cfg);
         }
 
         // Try stripping default port if present
-        if let Some(bare_host) = host_header.split(':').next()
+        if let Some(bare_host) = host_lc.split(':').next()
             && let Some(entry) = self.routes.get(bare_host)
         {
             let cfg: Arc<HostConfig> = Arc::clone(&*entry);

--- a/crates/gateway/tests/router_vhost_resolution.rs
+++ b/crates/gateway/tests/router_vhost_resolution.rs
@@ -162,7 +162,10 @@ fn register_uppercase_host_resolves_via_lowercase_header() {
     // Admin / DB may have stored the host with mixed case — registration
     // must normalise so canonical lowercase headers still hit the route.
     r.register(&make_host("c", "Example.COM", 80));
-    assert!(r.resolve("example.com").is_some(), "lowercase header on uppercase registration");
+    assert!(
+        r.resolve("example.com").is_some(),
+        "lowercase header on uppercase registration"
+    );
     assert!(r.resolve("example.com:80").is_some());
 }
 

--- a/crates/gateway/tests/router_vhost_resolution.rs
+++ b/crates/gateway/tests/router_vhost_resolution.rs
@@ -129,3 +129,49 @@ fn non_default_port_does_not_register_bare_host() {
     // to splitting host_header by ':'. Check missing host header instead.
     assert!(r.resolve("other.com").is_none());
 }
+
+// ── Case-fold (#87) ─────────────────────────────────────────────────────────
+//
+// DashMap lookup is byte-exact. Without ASCII case-folding the Host header
+// `Example.COM` would miss a route registered as `example.com` and the
+// proxy would 502 — weaponisable as a DoS by spraying random-case Host
+// headers. RFC 9110 §5.4 mandates case-insensitive host comparison; the
+// router now lowercases on both register and resolve so the lookup is
+// symmetric end-to-end.
+
+#[test]
+fn resolve_is_case_insensitive_on_bare_host() {
+    let r = HostRouter::new();
+    r.register(&make_host("c", "example.com", 80));
+    assert!(r.resolve("EXAMPLE.COM").is_some(), "uppercase host header");
+    assert!(r.resolve("Example.com").is_some(), "mixed-case host header");
+    assert!(r.resolve("ExAmPlE.cOm").is_some(), "tordured-case host header");
+}
+
+#[test]
+fn resolve_is_case_insensitive_on_host_with_port() {
+    let r = HostRouter::new();
+    r.register(&make_host("c", "example.com", 8080));
+    assert!(r.resolve("Example.COM:8080").is_some());
+    assert!(r.resolve("EXAMPLE.com:8080").is_some());
+}
+
+#[test]
+fn register_uppercase_host_resolves_via_lowercase_header() {
+    let r = HostRouter::new();
+    // Admin / DB may have stored the host with mixed case — registration
+    // must normalise so canonical lowercase headers still hit the route.
+    r.register(&make_host("c", "Example.COM", 80));
+    assert!(r.resolve("example.com").is_some(), "lowercase header on uppercase registration");
+    assert!(r.resolve("example.com:80").is_some());
+}
+
+#[test]
+fn unregister_is_case_insensitive() {
+    let r = HostRouter::new();
+    r.register(&make_host("c", "example.com", 80));
+    // Caller passes mixed case — must still find and remove the lowercase entry.
+    r.unregister("Example.COM", 80);
+    assert!(r.resolve("example.com").is_none());
+    assert!(r.resolve("Example.com").is_none());
+}


### PR DESCRIPTION
## Summary

Closes #87 — HostRouter byte-exact Host header lookup → DoS via random-case Host headers.

`HostRouter` stored DashMap keys verbatim (`config.host` straight from DB) and looked them up byte-exact, so `Host: Example.COM` against a registered `example.com` missed the route and returned 502. An attacker can spray random-case Host headers across a botnet and force legitimate traffic into the no-route error pipeline.

RFC 9110 §5.4 mandates case-insensitive host comparison. The downstream tier classifier already lowercases (`host_for_classify`), but the router runs first — so the bypass is real even though the classifier is correct.

## Fix

Symmetric ASCII lowercase normalisation on all three sides of the DashMap so the key space is canonical regardless of casing at the admin / DB / header layers:

- `register` lowercases `config.host` before the `host:port` and bare-host inserts.
- `unregister` lowercases its `host` argument so callers may pass any casing without leaving dead keys behind.
- `resolve` folds the incoming `host_header` once at entry and reuses the folded form for both the exact-match lookup and the port-stripped fallback lookup.

`to_ascii_lowercase` allocates one short string per call — negligible on the proxy hot path compared with the DashMap lookup.

## Test coverage

Four new tests in `tests/router_vhost_resolution.rs`:

- `resolve_is_case_insensitive_on_bare_host` — `EXAMPLE.COM`, `Example.com`, `ExAmPlE.cOm` all resolve against `example.com`.
- `resolve_is_case_insensitive_on_host_with_port` — same for `Example.COM:8080` form.
- `register_uppercase_host_resolves_via_lowercase_header` — a stale `Example.COM` row in the DB still produces a canonical key.
- `unregister_is_case_insensitive` — symmetric removal so dead keys cannot accumulate.

## Scope

- Files touched: 2 (`router.rs`, `router_vhost_resolution.rs`)
- LOC delta: +75 / -9
- Targets `release/stg`. Pure-fn change; no async, no I/O, no DB.

## Test plan

- [x] 4 deterministic unit tests covering forward, port-stripped, registration-side, and unregister paths.
- [ ] CI: full pipeline — Lint (`cargo fmt --check`, clippy `-D warnings`, machete), Test, Build, per-crate Coverage matrix, sec-audit if dependency files moved (they did not).

## Out of scope — surfaced as follow-up

- IPv6 literal port-stripping via `host_header.split(':').next()` still mis-handles `[::1]:8080` (returns `"["`). Separate bug, not addressed here.
- Admin API `host` field normalisation (`crates/waf-api/src/handlers.rs` host CRUD) — the question raised in the issue body. Defence-in-depth at the router means the bug is already neutralised even if the admin layer accepts mixed case, but normalising at write-time is still worth a follow-up issue.