### PR TITLE
fix(identity): amortize MemoryIdentityStore cap eviction (#86)

### DIFF
--- a/crates/waf-engine/src/device_fp/identity/memory.rs
+++ b/crates/waf-engine/src/device_fp/identity/memory.rs
@@ -373,8 +373,9 @@ mod tests {
         // one eviction tick fires. Each observe carries a monotonically
         // increasing `ts` so the oldest entries are the smallest-numbered ones.
         let total = max + EVICT_INTERVAL + 100;
-        for i in 0..total as i64 {
-            store.observe(&k(&format!("fp-{i}")), ip, "ua", i).await.unwrap();
+        for i in 0..total {
+            let ts = i64::try_from(i).unwrap_or(i64::MAX);
+            store.observe(&k(&format!("fp-{i}")), ip, "ua", ts).await.unwrap();
         }
 
         // Cap drift is bounded by `EVICT_INTERVAL` — the ticker fires once

--- a/crates/waf-engine/src/device_fp/identity/memory.rs
+++ b/crates/waf-engine/src/device_fp/identity/memory.rs
@@ -8,6 +8,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::net::IpAddr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use ahash::RandomState;
@@ -16,6 +17,13 @@ use dashmap::DashMap;
 
 use crate::device_fp::identity::identity_trait::IdentityStore;
 use crate::device_fp::types::{FpKey, IdentityRecord, Observation};
+
+/// How many `observe` calls past `max_entries` must happen before an
+/// eviction sweep runs. Amortizes the O(N) full-map scan so that an
+/// attacker rotating JA3 / UA values one-per-request cannot turn cap
+/// enforcement itself into a CPU-`DoS` primitive. Mirrors the
+/// `scanner_state::EVICT_INTERVAL` pattern.
+const EVICT_INTERVAL: usize = 1024;
 
 #[derive(Clone, Copy, Debug)]
 pub struct MemoryConfig {
@@ -119,6 +127,10 @@ pub struct MemoryIdentityStore {
     map: DashMap<FpKey, Entry, RandomState>,
     cfg: MemoryConfig,
     hasher_state: RandomState,
+    /// Counts `observe` calls that find the map already over `max_entries`.
+    /// Only every `EVICT_INTERVAL`-th such call pays the eviction scan, so
+    /// the per-request cost amortizes to O(N / `EVICT_INTERVAL`).
+    evict_ticker: AtomicUsize,
 }
 
 impl Default for MemoryIdentityStore {
@@ -141,6 +153,7 @@ impl MemoryIdentityStore {
             map: DashMap::with_capacity_and_hasher_and_shard_amount(0, RandomState::new(), shards),
             cfg,
             hasher_state: RandomState::new(),
+            evict_ticker: AtomicUsize::new(0),
         }
     }
 
@@ -163,22 +176,41 @@ impl MemoryIdentityStore {
         self.hasher_state.hash_one(ua)
     }
 
-    /// Best-effort eviction of the entry with the smallest `last_seen`
-    /// while size exceeds `max_entries`. O(N) per pass — runs only on
-    /// overflow, which the cap is meant to make rare.
+    /// Drop the oldest entries (by `last_seen`) — but only once every
+    /// [`EVICT_INTERVAL`] over-cap calls. Each sweep is a single
+    /// partial-sort pass (O(N) average via `select_nth_unstable_by_key`)
+    /// rather than the previous `while len > max { iter().min_by_key() }`
+    /// loop which was O(N²) per pass under sustained overflow.
+    ///
+    /// Drops at least the current overflow but no fewer than 10 % of the
+    /// map so a single sweep buys a meaningful runway before the next
+    /// one is needed; otherwise an attacker rotating JA3 values could
+    /// keep us at `max_entries + 1` and pay the O(N) cost every
+    /// `EVICT_INTERVAL` requests.
     fn enforce_cap(&self) {
-        while self.map.len() > self.cfg.max_entries {
-            let victim = self
-                .map
-                .iter()
-                .min_by_key(|r| r.value().last_seen)
-                .map(|r| r.key().clone());
-            match victim {
-                Some(k) => {
-                    self.map.remove(&k);
-                }
-                None => break,
-            }
+        if self.map.len() <= self.cfg.max_entries {
+            return;
+        }
+        let tick = self.evict_ticker.fetch_add(1, Ordering::Relaxed);
+        if !tick.is_multiple_of(EVICT_INTERVAL) {
+            return;
+        }
+        let mut ages: Vec<(FpKey, i64)> = self
+            .map
+            .iter()
+            .map(|kv| (kv.key().clone(), kv.value().last_seen))
+            .collect();
+        let over = self.map.len().saturating_sub(self.cfg.max_entries);
+        let drop_n = over.max(ages.len() / 10).min(ages.len());
+        if drop_n == 0 {
+            return;
+        }
+        if drop_n < ages.len() {
+            // O(N) average — partial sort, not a full O(N log N) sort.
+            ages.select_nth_unstable_by_key(drop_n - 1, |(_, t)| *t);
+        }
+        for (k, _) in ages.into_iter().take(drop_n) {
+            self.map.remove(&k);
         }
     }
 }
@@ -211,9 +243,7 @@ impl IdentityStore for MemoryIdentityStore {
             snap
         };
 
-        if self.map.len() > self.cfg.max_entries {
-            self.enforce_cap();
-        }
+        self.enforce_cap();
         Ok(obs)
     }
 
@@ -299,5 +329,69 @@ mod tests {
         let handle = spawn_janitor(Arc::clone(&store));
         tokio::time::sleep(Duration::from_millis(50)).await;
         handle.abort();
+    }
+
+    // ── Amortized cap eviction (#86) ─────────────────────────────────────────
+    //
+    // Old `enforce_cap` ran a full O(N) `min_by_key` scan after every observe
+    // once size exceeded `max_entries`. An attacker rotating JA3 / UA values
+    // one-per-request kept the map at `max+1` so every request paid the
+    // O(N) tax → CPU amplification under sustained traffic.
+    //
+    // New behaviour mirrors `scanner_state::evict_if_over_cap`: an
+    // `AtomicUsize` ticker counts over-cap observes; only every
+    // `EVICT_INTERVAL`-th call pays the eviction scan, and that scan uses
+    // `select_nth_unstable_by_key` to drop at least 10 % of entries in a
+    // single O(N)-average pass — buying a runway so the next sweep is far
+    // off rather than the immediate-next request.
+
+    #[tokio::test]
+    async fn enforce_cap_skips_eviction_when_under_cap() {
+        let store = MemoryIdentityStore::with_config(MemoryConfig {
+            ttl_secs: 3600,
+            window_secs: 600,
+            max_entries: 1000,
+        });
+        let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+        for i in 0..500_i64 {
+            store.observe(&k(&format!("fp-{i}")), ip, "ua", i).await.unwrap();
+        }
+        assert_eq!(store.len(), 500, "no eviction while under cap");
+    }
+
+    #[tokio::test]
+    async fn enforce_cap_drops_oldest_after_eviction_interval() {
+        let max = 50;
+        let store = MemoryIdentityStore::with_config(MemoryConfig {
+            ttl_secs: 3600,
+            window_secs: 600,
+            max_entries: max,
+        });
+        let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+        // Burst enough unique fingerprints past the cap to guarantee at least
+        // one eviction tick fires. Each observe carries a monotonically
+        // increasing `ts` so the oldest entries are the smallest-numbered ones.
+        let total = max + EVICT_INTERVAL + 100;
+        for i in 0..total as i64 {
+            store.observe(&k(&format!("fp-{i}")), ip, "ua", i).await.unwrap();
+        }
+
+        // Cap drift is bounded by `EVICT_INTERVAL` — the ticker fires once
+        // per `EVICT_INTERVAL` over-cap calls, so by the time we add another
+        // `EVICT_INTERVAL` entries the next sweep has already run.
+        assert!(
+            store.len() <= max + EVICT_INTERVAL,
+            "len {} must stay bounded by max + EVICT_INTERVAL ({})",
+            store.len(),
+            max + EVICT_INTERVAL,
+        );
+        // The very first inserted fingerprint must be among the evicted —
+        // proves the partial-sort actually targets the oldest `last_seen`,
+        // not arbitrary entries.
+        assert!(
+            store.lookup(&k("fp-0")).await.unwrap().is_none(),
+            "oldest fingerprint must be evicted",
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #86 — `MemoryIdentityStore::enforce_cap` is O(N) per request under cap overflow.

The old `enforce_cap` ran a full O(N) `min_by_key` scan inside a `while` loop after every observe once `map.len() > max_entries`. With the default 1 M cap, an attacker rotating JA3 / User-Agent values one per request keeps the map at `max + 1` permanently — so every request pays the O(N²)-per-pass eviction tax. Pure CPU amplification: the cap is supposed to *defend* against memory exhaustion, instead it becomes the DoS amplifier.

## Fix

Mirror `scanner_state::evict_if_over_cap` (`crates/waf-engine/src/checks/scanner_state.rs:182-211`) which already solved this exact problem on the per-IP scanner path:

- New `AtomicUsize` `evict_ticker` counts only calls that find the map over `max_entries`.
- Only every `EVICT_INTERVAL` (1024) over-cap call pays the eviction scan; everything in between exits after a cheap `len` comparison.
- The eviction sweep itself becomes a single `select_nth_unstable_by_key` partial-sort — O(N) average, never the old O(N²) `while min_by_key` ramp.
- Each sweep drops at least the current overflow but no fewer than 10 % of entries, so a single sweep buys a meaningful runway before the next tick.

Per-request cost under sustained rotation drops from O(N) to O(N / EVICT_INTERVAL) amortised — roughly 1000× at the 1 M-entry default cap.

## Test coverage

Two new tests in the existing inline `mod tests`:

- `enforce_cap_skips_eviction_when_under_cap` — 500 unique observes into a 1000-cap store retain all entries; ticker must stay idle.
- `enforce_cap_drops_oldest_after_eviction_interval` — burst of `max + EVICT_INTERVAL + 100` unique fingerprints with strictly increasing `ts` into a 50-cap store. Asserts (a) `len` stays bounded by `max + EVICT_INTERVAL`, and (b) the first fingerprint inserted is evicted — proving the partial-sort targets oldest `last_seen` rather than arbitrary entries.

## Scope

- Files touched: 1 (`crates/waf-engine/src/device_fp/identity/memory.rs`)
- LOC delta: +112 / -18
- Targets `release/stg`. Single crate, single module — no external API change.

## Test plan

- [x] Under-cap path: no eviction ever runs.
- [x] Over-cap burst: ticker fires once per `EVICT_INTERVAL`, oldest entries go first.
- [ ] CI: full pipeline — Lint (`fmt --check` + clippy `-D warnings`), Test, Build, all 7 Coverage matrix entries, sec-audit if dependency files moved (they did not).

## Out of scope

- Option B from the issue body (secondary `BTreeMap<Instant, FpKey>` for O(log N) eviction) is the asymptotically correct fix but requires a concurrent-sorted-map (DashMap + Mutex<BTreeMap> serializes everything, killing the win). Option A here is the 1000× improvement at zero refactor cost.
- Redis-backed store (`identity::redis`) is untouched — it has different overflow semantics (Redis-side eviction policy).