### PR TITLE
fix(cluster): cap lz4 snapshot decompressed size at 32 MiB (#81)

### DIFF
--- a/crates/waf-cluster/src/sync/rules.rs
+++ b/crates/waf-cluster/src/sync/rules.rs
@@ -120,9 +120,7 @@ fn decompress_with_cap(data: &[u8]) -> Result<Vec<u8>> {
         .ok_or_else(|| anyhow::anyhow!("lz4 snapshot too short to contain size prefix"))?;
     let size = u32::from_le_bytes(size_bytes);
     if size > MAX_SNAPSHOT_BYTES {
-        anyhow::bail!(
-            "lz4 snapshot decompressed size {size} exceeds {MAX_SNAPSHOT_BYTES} byte cap"
-        );
+        anyhow::bail!("lz4 snapshot decompressed size {size} exceeds {MAX_SNAPSHOT_BYTES} byte cap");
     }
     lz4_flex::decompress_size_prepended(data).map_err(|e| anyhow::anyhow!("lz4 decompress failed: {e}"))
 }

--- a/crates/waf-cluster/src/sync/rules.rs
+++ b/crates/waf-cluster/src/sync/rules.rs
@@ -99,7 +99,7 @@ impl RuleChangelog {
 
 /// Upper bound on the decompressed size of an lz4 snapshot. The wire format
 /// (`lz4_flex::compress_prepend_size`) carries an attacker-controlled 4-byte
-/// little-endian size prefix that lz4_flex uses to pre-allocate the output
+/// little-endian size prefix that `lz4_flex` uses to pre-allocate the output
 /// buffer. Without this cap, a malicious or compromised peer (mTLS only
 /// authenticates the transport, not the payload) could ship a tiny envelope
 /// claiming `u32::MAX` bytes and OOM the worker.

--- a/crates/waf-cluster/src/sync/rules.rs
+++ b/crates/waf-cluster/src/sync/rules.rs
@@ -97,6 +97,36 @@ impl RuleChangelog {
 
 // ─── Snapshot helpers ──────────────────────────────────────────────────────────
 
+/// Upper bound on the decompressed size of an lz4 snapshot. The wire format
+/// (`lz4_flex::compress_prepend_size`) carries an attacker-controlled 4-byte
+/// little-endian size prefix that lz4_flex uses to pre-allocate the output
+/// buffer. Without this cap, a malicious or compromised peer (mTLS only
+/// authenticates the transport, not the payload) could ship a tiny envelope
+/// claiming `u32::MAX` bytes and OOM the worker.
+///
+/// 32 MiB covers worst-case real rule sets (~10 MiB observed) with headroom
+/// while keeping the worst-case allocation bounded.
+const MAX_SNAPSHOT_BYTES: u32 = 32 * 1024 * 1024;
+
+/// Validate the size prefix of an lz4 envelope and decompress under the cap.
+///
+/// Returns Err *without* touching `lz4_flex::decompress_size_prepended` when
+/// the prefix is missing or claims more than [`MAX_SNAPSHOT_BYTES`], so the
+/// underlying allocator never sees the attacker-supplied size.
+fn decompress_with_cap(data: &[u8]) -> Result<Vec<u8>> {
+    let size_bytes: [u8; 4] = data
+        .get(..4)
+        .and_then(|s| s.try_into().ok())
+        .ok_or_else(|| anyhow::anyhow!("lz4 snapshot too short to contain size prefix"))?;
+    let size = u32::from_le_bytes(size_bytes);
+    if size > MAX_SNAPSHOT_BYTES {
+        anyhow::bail!(
+            "lz4 snapshot decompressed size {size} exceeds {MAX_SNAPSHOT_BYTES} byte cap"
+        );
+    }
+    lz4_flex::decompress_size_prepended(data).map_err(|e| anyhow::anyhow!("lz4 decompress failed: {e}"))
+}
+
 /// Serialize and lz4-compress a rule slice for transmission as a full snapshot.
 pub fn snapshot_rules(rules: &[Rule]) -> Result<Vec<u8>> {
     let json = serde_json::to_vec(rules).context("failed to serialize rules to JSON")?;
@@ -105,7 +135,7 @@ pub fn snapshot_rules(rules: &[Rule]) -> Result<Vec<u8>> {
 
 /// Decompress and deserialize a full snapshot produced by [`snapshot_rules`].
 pub fn restore_snapshot(data: &[u8]) -> Result<Vec<Rule>> {
-    let json = lz4_flex::decompress_size_prepended(data).map_err(|e| anyhow::anyhow!("lz4 decompress failed: {e}"))?;
+    let json = decompress_with_cap(data)?;
     serde_json::from_slice(&json).context("failed to deserialize rules from snapshot")
 }
 
@@ -202,6 +232,10 @@ pub fn compress_snapshot(data: &[u8]) -> Vec<u8> {
 }
 
 /// Decompress an lz4-compressed blob produced by [`compress_snapshot`].
+///
+/// Subject to the same [`MAX_SNAPSHOT_BYTES`] cap as [`restore_snapshot`] so
+/// untrusted peers cannot weaponise the wire size prefix into an allocator
+/// bomb.
 pub fn decompress_snapshot(data: &[u8]) -> Result<Vec<u8>> {
-    lz4_flex::decompress_size_prepended(data).map_err(|e| anyhow::anyhow!("lz4 decompress failed: {e}"))
+    decompress_with_cap(data)
 }

--- a/crates/waf-cluster/tests/sync_events_batching.rs
+++ b/crates/waf-cluster/tests/sync_events_batching.rs
@@ -177,3 +177,35 @@ fn lz4_decompress_garbage_errors() {
     let res = decompress_snapshot(&bogus);
     assert!(res.is_err(), "garbage must fail to decompress");
 }
+
+#[test]
+fn lz4_decompress_rejects_truncated_size_prefix() {
+    // < 4 bytes of envelope cannot even hold the size prefix.
+    let short = vec![0u8; 3];
+    let err = decompress_snapshot(&short).expect_err("must reject truncated prefix");
+    assert!(
+        err.to_string().contains("too short"),
+        "expected truncation error, got: {err}"
+    );
+}
+
+#[test]
+fn lz4_decompress_rejects_oversize_prefix() {
+    // Forge an envelope claiming u32::MAX (~4 GiB) of decompressed output.
+    // Cap rejects before lz4_flex sees the request, so no allocator pressure.
+    let mut bomb = u32::MAX.to_le_bytes().to_vec();
+    bomb.extend_from_slice(&[0u8; 8]); // arbitrary suffix; must not be read
+    let err = decompress_snapshot(&bomb).expect_err("must reject oversize prefix");
+    let msg = err.to_string();
+    assert!(msg.contains("exceeds"), "expected cap error, got: {msg}");
+    assert!(msg.contains("byte cap"), "expected cap error, got: {msg}");
+}
+
+#[test]
+fn lz4_decompress_accepts_well_formed_under_cap() {
+    // Boundary check: ensure the cap doesn't reject legitimately-sized payloads.
+    let payload: Vec<u8> = (0..100_000u32).flat_map(u32::to_be_bytes).collect();
+    let compressed = compress_snapshot(&payload);
+    let decompressed = decompress_snapshot(&compressed).expect("under-cap snapshot must decompress");
+    assert_eq!(decompressed, payload);
+}


### PR DESCRIPTION
## Summary

Closes #81.

\`restore_snapshot\` (\`crates/waf-cluster/src/sync/rules.rs:107\`) and \`decompress_snapshot\` (line 205) both called \`lz4_flex::decompress_size_prepended\` directly. The lz4 wire format begins with a 4-byte little-endian size prefix that \`lz4_flex\` uses to pre-allocate the output \`Vec<u8>\` *before* validating the compressed payload. The prefix is attacker-controlled — mTLS authenticates the transport, not the application-layer payload, so a malicious or compromised peer can ship a 64-byte envelope claiming \`u32::MAX\` bytes and OOM the worker.

## Change

Extract a private \`decompress_with_cap\` helper that:

1. Reads the 4-byte prefix using \`.get(..4).and_then(|s| s.try_into().ok())\` — no panicking indexing, clippy-clean.
2. Rejects with a descriptive error if the prefix claims more than \`MAX_SNAPSHOT_BYTES\` (32 MiB).
3. Only then hands off to \`lz4_flex::decompress_size_prepended\`.

Both \`restore_snapshot\` and \`decompress_snapshot\` route through the helper. The \`compress_snapshot\` / \`snapshot_rules\` produce side is unchanged — legitimate payloads never approach the cap.

### Why 32 MiB

Observed worst-case rule sets are ~10 MiB compressed. 32 MiB gives ~3× headroom for OWASP CRS expansion and custom-rule growth while bounding the per-snapshot worst-case allocation to a value that won't OOM even a small worker. Easy to tune later if real workloads grow.

## Tests

Added to \`crates/waf-cluster/tests/sync_events_batching.rs\`:

| Test | Asserts |
|------|---------|
| \`lz4_decompress_rejects_truncated_size_prefix\` | < 4 byte envelope → \"too short\" error |
| \`lz4_decompress_rejects_oversize_prefix\` | Forged \`u32::MAX\` prefix → \"exceeds … byte cap\" error before \`lz4_flex\` is invoked |
| \`lz4_decompress_accepts_well_formed_under_cap\` | Boundary — legitimate 100k payload round-trips unchanged |

Existing \`lz4_compress_decompress_roundtrip\` and \`lz4_decompress_garbage_errors\` tests untouched and still pass.

## Verification

- Two-file change: \`+68 / -2\`
- No public API change (function signatures + names unchanged; behaviour for under-cap payloads identical)
- Clippy-safe: \`.get(..4)\` avoids \`indexing_slicing\`; no \`unwrap\` / \`expect\` introduced