### PR TITLE
fix(cluster): reject stale/duplicate rule sync responses (#82)

### DIFF
--- a/crates/waf-cluster/src/sync/rules.rs
+++ b/crates/waf-cluster/src/sync/rules.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 
 use anyhow::{Context, Result};
+use tracing::warn;
 use waf_engine::{Rule, RuleRegistry, RuleReloader};
 
 use crate::protocol::{ChangeOp, RuleChange, RuleSyncRequest, RuleSyncResponse, SyncType};
@@ -208,6 +209,19 @@ pub async fn apply_sync_response(
     registry: &mut RuleRegistry,
     reloader: &dyn RuleReloader,
 ) -> Result<()> {
+    // Reject stale / duplicate responses before mutating registry state.
+    // Out-of-order delivery (retransmit, multi-stream reorder, stale post-
+    // failover main) would otherwise wipe a newer registry with an older
+    // snapshot.
+    if response.version <= registry.version {
+        warn!(
+            stale_version = response.version,
+            current = registry.version,
+            sync_type = ?response.sync_type,
+            "stale rule sync ignored",
+        );
+        return Ok(());
+    }
     match response.sync_type {
         SyncType::Incremental => {
             apply_rule_changes(registry, response.changes)?;

--- a/crates/waf-cluster/tests/cluster_integration.rs
+++ b/crates/waf-cluster/tests/cluster_integration.rs
@@ -41,7 +41,7 @@ use waf_cluster::{
     ClusterMessage, NodeState, RuleReloader, StorageMode,
     crypto::{ca::CertificateAuthority, node_cert::NodeCertificate},
     node::PeerInfo,
-    protocol::{ChangeOp, RuleSyncRequest, SyncType},
+    protocol::{ChangeOp, RuleSyncRequest, RuleSyncResponse, SyncType},
     sync::rules::{RuleChangelog, apply_sync_response, handle_sync_request},
     transport::{client::ClusterClient, server::ClusterServer},
 };
@@ -383,4 +383,82 @@ async fn rule_sync_falls_back_to_full_when_worker_too_far_behind() {
 
     assert_eq!(registry.rules.len(), 3, "all 3 rules should be in worker registry");
     assert_eq!(registry.version, changelog.current_version());
+}
+
+/// Out-of-order delivery (retransmit, stale post-failover main, multi-stream
+/// reorder) can re-deliver an older `RuleSyncResponse` after a newer one has
+/// already advanced the worker. The guard at the top of `apply_sync_response`
+/// must reject the stale frame so the registry never silently rolls back.
+#[tokio::test]
+async fn stale_sync_response_does_not_regress_registry() {
+    // Seed a worker with two rules at version 5.
+    let mut registry = RuleRegistry::new();
+    let rule_a = make_test_rule("rule-current-a");
+    let rule_b = make_test_rule("rule-current-b");
+    registry.insert(rule_a);
+    registry.insert(rule_b);
+    registry.version = 5;
+    let pre_len = registry.rules.len();
+
+    // Construct a stale Full snapshot at version 3 carrying only one (different)
+    // rule. Without the guard this would clear the registry and replace it.
+    let stale_rule = make_test_rule("rule-stale-only");
+    let stale_payload =
+        waf_cluster::sync::rules::snapshot_rules(std::slice::from_ref(&stale_rule)).expect("snapshot stale rule");
+    let stale_response = RuleSyncResponse {
+        version: 3,
+        sync_type: SyncType::Full,
+        changes: Vec::new(),
+        snapshot_lz4: stale_payload,
+    };
+
+    let reloader = NoopReloader;
+    apply_sync_response(stale_response, &mut registry, &reloader)
+        .await
+        .expect("stale sync must return Ok (skipped)");
+
+    assert_eq!(registry.version, 5, "registry version must not regress");
+    assert_eq!(registry.rules.len(), pre_len, "registry rules must not be wiped");
+    assert!(
+        registry.rules.contains_key("rule-current-a"),
+        "pre-existing rule-a must survive stale sync"
+    );
+    assert!(
+        !registry.rules.contains_key("rule-stale-only"),
+        "stale rule must NOT have been applied"
+    );
+}
+
+/// A response carrying the worker's current version is a duplicate — same
+/// guard branch as stale, must be a no-op rather than re-applying.
+#[tokio::test]
+async fn duplicate_version_sync_is_skipped() {
+    let mut registry = RuleRegistry::new();
+    registry.insert(make_test_rule("rule-only"));
+    registry.version = 7;
+
+    // Construct an Incremental response at the same version with a delete
+    // change. Without the guard this delete would land and the rule would
+    // disappear.
+    let dup_response = RuleSyncResponse {
+        version: 7,
+        sync_type: SyncType::Incremental,
+        changes: vec![waf_cluster::protocol::RuleChange {
+            op: ChangeOp::Delete,
+            rule_id: "rule-only".to_string(),
+            rule_json: None,
+        }],
+        snapshot_lz4: Vec::new(),
+    };
+
+    let reloader = NoopReloader;
+    apply_sync_response(dup_response, &mut registry, &reloader)
+        .await
+        .expect("duplicate sync must return Ok (skipped)");
+
+    assert_eq!(registry.version, 7, "registry version unchanged");
+    assert!(
+        registry.rules.contains_key("rule-only"),
+        "duplicate sync must NOT have re-applied the delete"
+    );
 }


### PR DESCRIPTION
## Summary

Closes #82.

\`apply_sync_response\` (\`crates/waf-cluster/src/sync/rules.rs:206\`) unconditionally overwrote \`registry.version = response.version\` regardless of which side carried newer state. Out-of-order delivery (QUIC retransmit, multi-stream reorder, or a stale post-failover main that came back online) could re-deliver an older \`RuleSyncResponse\` after the worker had already advanced — and the older response would silently win:

- Worker at v10 receives delayed v3 Full snapshot → \`apply_full_snapshot\` wipes the registry → \`registry.version = 3\`. Rules v4..v10 silently disappear with no audit trail.

## Change

Add a guard at the top of \`apply_sync_response\`:

\`\`\`rust
if response.version <= registry.version {
    warn!(
        stale_version = response.version,
        current = registry.version,
        sync_type = ?response.sync_type,
        \"stale rule sync ignored\",
    );
    return Ok(());
}
\`\`\`

\`<=\` covers both the *strict regression* case (v3 after v10) and the *duplicate* case (v7 arriving twice after the first one already applied). Duplicates are idempotent for Upserts but **not** for Deletes — re-applying a Delete change at the same version would remove a rule that the worker is supposed to have. The guard makes the function strictly forward-progress.

\`reloader.on_rules_updated\` is intentionally not invoked when the guard fires — the version did not actually change, so downstream consumers (engine hot-reload, pattern cache) shouldn't be triggered either.

## Tests

Added to \`crates/waf-cluster/tests/cluster_integration.rs\`:

| Test | Asserts |
|------|---------|
| \`stale_sync_response_does_not_regress_registry\` | Registry at v5 with rules A+B receives a Full snapshot at v3 carrying only a different rule. Guard fires → registry preserved (version still 5, A+B intact, stale rule never lands). |
| \`duplicate_version_sync_is_skipped\` | Registry at v7 with rule R receives an Incremental at v7 carrying \`Delete R\`. Guard fires → R survives. |

Existing forward-progress tests (\`rule_created_on_main_synced_to_worker\`, \`rule_sync_falls_back_to_full_when_worker_too_far_behind\`) continue to pass: those drive worker from v0 → vN with N > 0, so the guard never trips.

## Out of scope

Issue body mentions adding per-change \`seq: u64\` to \`RuleChange\` in \`protocol.rs:127\` for finer-grained reordering protection. Not bundled — the per-response \`version\` field is sufficient for the regression case described, and adding \`seq\` would change the wire protocol (breaking compatibility with already-deployed nodes). Filed as follow-up if multi-change-per-version becomes a real attack vector.

## Verification

- Two-file change: \`+93 / -1\`
- No public API change (function signature unchanged; behaviour for newer responses identical)
- Returns \`Ok(())\` rather than \`Err\` for stale frames so retry loops in the caller don't spin