### PR TITLE
fix(cluster): drop PendingForwards entry on forward error paths (#83)

### DIFF
--- a/crates/waf-cluster/src/cluster_forward.rs
+++ b/crates/waf-cluster/src/cluster_forward.rs
@@ -70,6 +70,16 @@ impl PendingForwards {
         }
     }
 
+    /// Drop a pending entry without delivering a response.
+    ///
+    /// Used by [`forward_write`] error paths (send failure, timeout, receiver
+    /// drop) to release the registered `oneshot::Sender` so that the entry
+    /// does not accumulate as garbage in the `HashMap` when no response will
+    /// ever arrive.
+    pub async fn remove(&self, request_id: &str) {
+        self.inner.lock().await.remove(request_id);
+    }
+
     /// Cancel all pending requests (e.g., when the QUIC connection drops).
     ///
     /// Dropping the senders causes each waiting `Receiver` to return an error,
@@ -119,16 +129,31 @@ pub async fn forward_write(
         headers,
     });
 
-    sender
-        .send(msg)
-        .await
-        .context("failed to queue ApiForward message; outbound channel closed")?;
+    let result = async {
+        sender
+            .send(msg)
+            .await
+            .context("failed to queue ApiForward message; outbound channel closed")?;
 
-    let timeout = tokio::time::Duration::from_millis(timeout_ms.max(1));
-    tokio::time::timeout(timeout, rx)
-        .await
-        .context("API forward timed out waiting for response from main")?
-        .context("API forward response channel dropped")
+        let timeout = tokio::time::Duration::from_millis(timeout_ms.max(1));
+        tokio::time::timeout(timeout, rx)
+            .await
+            .context("API forward timed out waiting for response from main")?
+            .context("API forward response channel dropped")
+    }
+    .await;
+
+    // `resolve()` and `cancel_all()` already strip the pending entry on their
+    // happy paths, but the send-failure / timeout / receiver-drop branches
+    // never re-enter the registry — without an explicit cleanup the
+    // `oneshot::Sender` would live in the `HashMap` forever, leaking memory
+    // proportional to retried admin writes whenever the main is unreachable.
+    // Defensive removal: no-op when the entry was already taken by either
+    // `resolve()` or `cancel_all()`.
+    if result.is_err() {
+        pending.remove(&request_id).await;
+    }
+    result
 }
 
 // ─── Main-side handler ────────────────────────────────────────────────────────

--- a/crates/waf-cluster/tests/cluster_forward_routing.rs
+++ b/crates/waf-cluster/tests/cluster_forward_routing.rs
@@ -151,12 +151,13 @@ async fn forward_write_round_trip() {
 #[tokio::test(start_paused = true)]
 async fn forward_write_times_out_when_no_response() {
     let pending = PendingForwards::new();
+    let pending_clone = pending.clone();
     let (tx, _rx) = mpsc::channel::<ClusterMessage>(8);
 
     let h = tokio::spawn(async move {
         forward_write(
             &tx,
-            &pending,
+            &pending_clone,
             "req-timeout".to_string(),
             "PUT".to_string(),
             "/x".to_string(),
@@ -170,6 +171,12 @@ async fn forward_write_times_out_when_no_response() {
     tokio::time::advance(Duration::from_millis(100)).await;
     let res = h.await.expect("join");
     assert!(res.is_err(), "must time out");
+    // Regression: pre-fix the timeout path leaked the oneshot::Sender forever.
+    assert_eq!(
+        pending.pending_count().await,
+        0,
+        "timeout must drop the pending entry to avoid unbounded HashMap growth"
+    );
 }
 
 #[tokio::test]
@@ -193,4 +200,22 @@ async fn forward_write_errors_when_outbound_closed() {
     let err = res.expect_err("must fail when channel closed");
     let msg = format!("{err}");
     assert!(msg.contains("outbound channel closed"), "msg = {msg}");
+    // Regression: pre-fix a send-failure also leaked the registered entry.
+    assert_eq!(
+        pending.pending_count().await,
+        0,
+        "send failure must drop the pending entry"
+    );
+}
+
+#[tokio::test]
+async fn pending_forwards_remove_drops_entry() {
+    let p = PendingForwards::new();
+    let _rx = p.register("explicit".to_string()).await;
+    assert_eq!(p.pending_count().await, 1);
+    p.remove("explicit").await;
+    assert_eq!(p.pending_count().await, 0);
+    // Removing a missing key is a no-op (not an error).
+    p.remove("ghost").await;
+    assert_eq!(p.pending_count().await, 0);
 }


### PR DESCRIPTION
## Summary

Closes #83.

\`forward_write\` (\`crates/waf-cluster/src/cluster_forward.rs:102\`) registered a \`oneshot::Sender<ApiForwardResponse>\` keyed by \`request_id\` and then ran the QUIC send + response wait. \`PendingForwards::resolve\` removes the entry when a matching response arrives, and \`cancel_all\` clears everything on connection drop, but the **send-failure / timeout / receiver-drop** branches never re-entered the registry. Each failure left an orphan \`Sender\` in the \`HashMap\`.

With the main node unreachable (overloaded, crashed, network-partitioned), every retried admin write would leak one entry. Memory grows unbounded → DoS over time.

## Change

\`crates/waf-cluster/src/cluster_forward.rs\`:

1. Add \`PendingForwards::remove(request_id: &str)\` — drops a pending entry without delivering a response. No-op when the key is already absent (so it's safe to call defensively after either \`resolve\` or \`cancel_all\`).
2. Wrap the send + timeout work inside \`forward_write\` in an inner \`async\` block. On \`Err\`, call \`pending.remove(&request_id)\` before returning.

The happy path is unchanged: \`resolve\` already removes the entry when the response arrives, so the defensive \`remove\` is only exercised on the error branches.

## Why explicit cleanup over RAII guard

The issue body suggests a \`PendingGuard\` RAII pattern. The inner mutex is \`tokio::sync::Mutex\` (async); a \`Drop\` impl cannot \`.await\`. Switching to \`parking_lot::Mutex\` would touch every caller's signature (currently \`async fn\`) for an internal helper — disproportionate to the bug. The explicit cleanup converges in 1 + 5 lines and surfaces the invariant clearly in the call site.

## Tests

\`crates/waf-cluster/tests/cluster_forward_routing.rs\`:

| Test | Asserts |
|------|---------|
| \`forward_write_times_out_when_no_response\` (augmented) | After timeout error, \`pending.pending_count() == 0\` |
| \`forward_write_errors_when_outbound_closed\` (augmented) | After send-failure error, \`pending.pending_count() == 0\` |
| \`pending_forwards_remove_drops_entry\` (new) | Explicit \`remove\` drops one entry; removing a missing key is a no-op |

Existing \`pending_forwards_register_and_resolve\`, \`pending_forwards_cancel_all_drops_receivers\`, \`forward_write_round_trip\` etc. continue to pass — happy paths and connection-drop semantics unchanged.

## Verification

- Two-file change: \`+61 / -11\`
- No public API change (new \`remove\` is additive; existing signatures untouched)
- All error paths in \`forward_write\` now share a single cleanup point