### PR TITLE
fix(cluster): pick up late-joining peers in heartbeat sender (#80)

### DIFF
--- a/crates/waf-cluster/src/health/mod.rs
+++ b/crates/waf-cluster/src/health/mod.rs
@@ -13,18 +13,20 @@ use tracing::{debug, warn};
 use crate::node::NodeState;
 use crate::protocol::{ClusterMessage, Heartbeat};
 
-/// Broadcast periodic heartbeats to all connected peer channels.
+/// Broadcast periodic heartbeats to all currently connected peer channels.
 ///
-/// Sends a [`ClusterMessage::Heartbeat`] to every sender in `peer_senders` on
-/// each `interval_ms` tick.  Full channels and closed channels are handled
-/// gracefully without stopping the loop.
+/// On each `interval_ms` tick the function takes a fresh snapshot of
+/// `node_state.peer_channels` via [`NodeState::peer_channels_snapshot`] and
+/// `try_send`s a [`ClusterMessage::Heartbeat`] to every sender. Channels added
+/// by `NodeState::add_peer_channel` AFTER this task spawned (late-joining
+/// peers) are picked up on the next iteration — pre-fix, the snapshot was
+/// captured once at spawn time, so late joiners never received heartbeats and
+/// the peer-side phi-accrual detector would falsely declare this node dead,
+/// driving spurious eviction / split-brain.
 ///
-/// Runs until the process exits (tokio task cancellation).
-pub async fn run_heartbeat_sender(
-    node_state: Arc<NodeState>,
-    interval_ms: u64,
-    peer_senders: Vec<mpsc::Sender<ClusterMessage>>,
-) {
+/// Full channels and closed channels are handled gracefully without stopping
+/// the loop. Runs until the process exits (tokio task cancellation).
+pub async fn run_heartbeat_sender(node_state: Arc<NodeState>, interval_ms: u64) {
     let mut ticker = tokio::time::interval(tokio::time::Duration::from_millis(interval_ms.max(1)));
     let mut sequence: u64 = 0;
     let start_ms = now_unix_ms();
@@ -54,7 +56,12 @@ pub async fn run_heartbeat_sender(
 
         let msg = ClusterMessage::Heartbeat(hb);
 
-        for sender in &peer_senders {
+        let senders = node_state.peer_channels_snapshot();
+        if senders.is_empty() {
+            continue;
+        }
+
+        for sender in &senders {
             match sender.try_send(msg.clone()) {
                 Ok(()) => {}
                 Err(mpsc::error::TrySendError::Full(_)) => {

--- a/crates/waf-cluster/src/lib.rs
+++ b/crates/waf-cluster/src/lib.rs
@@ -124,8 +124,6 @@ impl ClusterNode {
 
         // ── Dial seed peers ──────────────────────────────────────────────────
 
-        let mut peer_senders: Vec<mpsc::Sender<ClusterMessage>> = Vec::with_capacity(self.config.seeds.len());
-
         for seed_str in &self.config.seeds {
             // Resolve hostname+port to SocketAddr (supports DNS names used in docker etc.)
             let Some(seed_addr) = resolve_seed_addr(seed_str).await else {
@@ -139,9 +137,9 @@ impl ClusterNode {
 
             let (tx, rx) = mpsc::channel::<ClusterMessage>(256);
 
-            // Register channel with NodeState so broadcast() reaches this peer.
+            // Register channel with NodeState so broadcast() and the heartbeat
+            // sender both reach this peer.
             node_state.add_peer_channel(tx.clone());
-            peer_senders.push(tx.clone());
 
             // Send JoinRequest as the initial handshake message
             let join_req = ClusterMessage::JoinRequest(crate::protocol::JoinRequest {
@@ -176,12 +174,16 @@ impl ClusterNode {
         }
 
         // ── Heartbeat sender ─────────────────────────────────────────────────
-
-        if !peer_senders.is_empty() {
+        //
+        // Spawned unconditionally: even on a single-node bootstrap with no
+        // seeds, peers may join later via the inbound transport, and the
+        // heartbeat task picks them up by re-snapshotting `peer_channels`
+        // every tick. Ticks with an empty peer set are no-ops.
+        {
             let state_hb = Arc::clone(&node_state);
             let interval_ms = self.config.election.heartbeat_interval_ms;
             tokio::spawn(async move {
-                run_heartbeat_sender(state_hb, interval_ms, peer_senders).await;
+                run_heartbeat_sender(state_hb, interval_ms).await;
             });
         }
 

--- a/crates/waf-cluster/src/node.rs
+++ b/crates/waf-cluster/src/node.rs
@@ -238,6 +238,16 @@ impl NodeState {
         }
     }
 
+    /// Snapshot the current list of outbound peer channels.
+    ///
+    /// Cheap: each `mpsc::Sender` is internally an `Arc`. Used by long-running
+    /// broadcast loops (heartbeat) so peers registered via `add_peer_channel`
+    /// after the task spawned are picked up on the next iteration, without
+    /// holding the inner mutex across the send work.
+    pub fn peer_channels_snapshot(&self) -> Vec<mpsc::Sender<ClusterMessage>> {
+        self.peer_channels.lock().clone()
+    }
+
     // ── Version tracking ──────────────────────────────────────────────────────
 
     /// Update `rules_version` and return it.

--- a/crates/waf-cluster/tests/integration_test.rs
+++ b/crates/waf-cluster/tests/integration_test.rs
@@ -283,6 +283,6 @@ async fn heartbeat_sender_services_late_joining_peer() {
         Ok(Some(ClusterMessage::Heartbeat(_))) => {}
         Ok(Some(other)) => panic!("expected Heartbeat for late-joiner, got {other:?}"),
         Ok(None) => panic!("late-joiner channel closed before first heartbeat"),
-        Err(_) => panic!("late-joiner received no heartbeat within 300 ms"),
+        Err(elapsed) => panic!("late-joiner received no heartbeat within 300 ms: {elapsed}"),
     }
 }

--- a/crates/waf-cluster/tests/integration_test.rs
+++ b/crates/waf-cluster/tests/integration_test.rs
@@ -158,6 +158,11 @@ async fn two_node_heartbeat_exchange() {
     // NodeState needed by the heartbeat sender to populate the Heartbeat fields
     let node_state = Arc::new(NodeState::new(ClusterConfig::default(), StorageMode::ForwardOnly).unwrap());
 
+    // Register the outbound channel on NodeState BEFORE spawning the heartbeat
+    // task. The heartbeat sender reads `peer_channels` per tick, so the
+    // channel must be present (either pre- or post-spawn) for delivery.
+    node_state.add_peer_channel(msg_tx);
+
     // Spawn client connection task (auto-reconnects; will stop when msg_rx closes)
     let state_clone = Arc::clone(&node_state);
     tokio::spawn(async move {
@@ -165,10 +170,11 @@ async fn two_node_heartbeat_exchange() {
         let _ = client.run_with_reconnect(state_clone, msg_rx).await;
     });
 
-    // Heartbeat sender at 50 ms interval — broadcasts to the single peer channel
+    // Heartbeat sender at 50 ms interval — broadcasts to every channel
+    // currently registered on `node_state`.
     let state_hb = Arc::clone(&node_state);
     tokio::spawn(async move {
-        run_heartbeat_sender(state_hb, 50, vec![msg_tx]).await;
+        run_heartbeat_sender(state_hb, 50).await;
     });
 
     // ── Assert ────────────────────────────────────────────────────────────────
@@ -241,5 +247,42 @@ async fn mtls_rejects_unknown_cert() {
         // expected: connection error or timeout while retrying — both acceptable
         Ok(Err(_)) | Err(_) => {}
         Ok(Ok(())) => panic!("rogue client should not connect cleanly"),
+    }
+}
+
+/// Regression test: heartbeat sender must service peer channels registered
+/// AFTER the task has been spawned.
+///
+/// Pre-fix the heartbeat task took a `Vec<Sender>` by value at spawn time,
+/// so a late-joining peer was invisible to the sender — peer-side phi-accrual
+/// would falsely declare this node dead, driving spurious eviction. With the
+/// `peer_channels_snapshot()` per-tick re-read, the new channel must observe
+/// at least one heartbeat within a few ticks.
+#[tokio::test]
+async fn heartbeat_sender_services_late_joining_peer() {
+    let node_state = Arc::new(NodeState::new(ClusterConfig::default(), StorageMode::ForwardOnly).unwrap());
+
+    // Spawn the heartbeat task FIRST, on an empty peer set.
+    let state_hb = Arc::clone(&node_state);
+    tokio::spawn(async move {
+        run_heartbeat_sender(state_hb, 20).await;
+    });
+
+    // Let several ticks elapse with no peers registered. The task must remain
+    // alive (no panic, no early return) and simply emit no traffic.
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // Now register a peer channel — simulates a worker joining after the main
+    // node's heartbeat task has been running for a while.
+    let (tx, mut rx) = mpsc::channel::<ClusterMessage>(8);
+    node_state.add_peer_channel(tx);
+
+    // Within a few ticks the new channel must receive at least one heartbeat.
+    let recv = tokio::time::timeout(Duration::from_millis(300), rx.recv()).await;
+    match recv {
+        Ok(Some(ClusterMessage::Heartbeat(_))) => {}
+        Ok(Some(other)) => panic!("expected Heartbeat for late-joiner, got {other:?}"),
+        Ok(None) => panic!("late-joiner channel closed before first heartbeat"),
+        Err(_) => panic!("late-joiner received no heartbeat within 300 ms"),
     }
 }


### PR DESCRIPTION
## Summary

Closes #80.

`crates/waf-cluster/src/health/mod.rs` — `run_heartbeat_sender` previously took `peer_senders: Vec<mpsc::Sender>` by value at spawn time, so the peer set was frozen for the lifetime of the task. Late-joining peers (registered later via `NodeState::add_peer_channel`) never received heartbeats; the peer-side phi-accrual detector then falsely declared this node dead and drove spurious eviction → split-brain.

## Fix

* `NodeState::peer_channels_snapshot()` — new public accessor returning `Vec<mpsc::Sender<ClusterMessage>>`. `mpsc::Sender` is internally an `Arc`, so the clone is cheap and lets us release the inner mutex before doing any `try_send`.
* `run_heartbeat_sender(node_state, interval_ms)` — drops the `peer_senders` parameter and re-snapshots `peer_channels` every tick. Ticks with an empty snapshot short-circuit.
* `lib.rs` — drops the local `peer_senders` `Vec` accumulator that was redundant with `NodeState::add_peer_channel`. The heartbeat task is now spawned unconditionally: a single-node bootstrap whose peers join later must run the loop even if early ticks are no-ops.

## Tests

* Update `two_node_heartbeat_exchange` for the new 2-arg signature; the test now calls `node_state.add_peer_channel(msg_tx)` before spawning.
* Add `heartbeat_sender_services_late_joining_peer` — regression test that spawns the sender on an empty peer set, sleeps 80 ms (≥3 ticks), registers a channel, and asserts a heartbeat arrives within 300 ms. Fails on the pre-fix code.

## Risk / Compatibility

`run_heartbeat_sender`'s signature is `pub`. No external callers outside the crate were found (`rg`). Only call sites updated: `lib.rs:186`, `tests/integration_test.rs:177`. Heartbeat ticking on an empty peer set is negligible CPU.