### PR TITLE
ci: free disk space on coverage runners + always-on backtraces and toolchain echoes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
+  # Full backtraces on test panics + `?`-chain unwraps so CI failures are
+  # debuggable from the run log alone, no re-run needed.
+  RUST_BACKTRACE: full
 
 jobs:
   lint:
@@ -48,9 +51,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Toolchain versions
+        run: |
+          rustc --version
+          cargo --version
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --workspace --all-features
+        # `--nocapture` surfaces println!/dbg! output from a failing test
+        # directly in the CI log so contributors do not have to re-run
+        # locally just to see diagnostic output.
+        run: cargo test --workspace --all-features -- --nocapture
 
   build:
     name: Build
@@ -60,6 +70,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Toolchain versions
+        run: |
+          rustc --version
+          cargo --version
       - uses: Swatinem/rust-cache@v2
       - name: Build release
         run: cargo build --workspace --release

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,10 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # Make panics and `?`-chains print full backtraces in coverage logs so a
+  # CI failure surfaces enough context to debug without having to re-run with
+  # a separate trigger commit.
+  RUST_BACKTRACE: full
 
 jobs:
   coverage:
@@ -49,9 +53,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The ubuntu-latest runner ships with ~14 GB free on /. cargo llvm-cov
+      # compiles the vendored pingora workspace into target/llvm-cov-target
+      # for every crate, and waf-engine + waf-api have repeatedly hit
+      # "No space left on device" mid-run. Free ~20 GB by removing toolchains
+      # we never touch (.NET, Android SDK, Haskell GHC, Boost) before any
+      # cargo step grows target/.
+      - name: Free disk space (avoid llvm-cov "No space left on device")
+        run: |
+          set -euxo pipefail
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+          sudo rm -rf "${AGENT_TOOLSDIRECTORY:-}" || true
+          df -h /
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+
+      - name: Toolchain versions
+        run: |
+          rustc --version
+          cargo --version
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -61,3 +84,7 @@ jobs:
 
       - name: Enforce coverage floor
         run: bash .github/scripts/coverage-check.sh ${{ matrix.crate }} ${{ matrix.floor }}
+
+      - name: Disk usage after coverage
+        if: always()
+        run: df -h /


### PR DESCRIPTION
## Summary

CI quality-of-life only — no production logic touched.

### 1. Pre-emptive disk-space cleanup on Coverage runners

`ubuntu-latest` has ~14 GB free on \`/\`. The Coverage matrix runs \`cargo llvm-cov\` per crate, and \`waf-api\` + \`waf-engine\` have repeatedly hit:

\`\`\`
rustc-LLVM ERROR: IO failure on output stream: No space left on device
\`\`\`

Recurrence: 3 times across the last 10 PRs landed in \`release/stg\`. Until now the workaround has been \`gh run rerun --failed\`, which costs a fresh runner allocation per incident.

This adds a single step at the top of the Coverage matrix that sweeps ~20 GB of unused toolchains (\`.NET\`, Android SDK, Haskell GHC, Boost, \`\$AGENT_TOOLSDIRECTORY\`) before any cargo step grows \`target/\`. \`df -h /\` before/after for visibility, plus a post-coverage \`df -h /\` so a future failure surfaces the actual usage in the log.

### 2. \`RUST_BACKTRACE: full\` workflow-level env

Both \`ci.yml\` and \`coverage.yml\` now export \`RUST_BACKTRACE=full\`. A test panic or \`?\`-chain unwrap surfaces its full backtrace in the run log, so contributors can debug a failure directly from the log instead of pushing a "retrigger with backtrace on" commit.

### 3. Diagnostic echoes

- \`rustc --version\` / \`cargo --version\` at the start of each job — drift is now obvious in the log.
- \`cargo test ... -- --nocapture\` so a failing test's \`println!\`/\`dbg!\` output reaches the log.

## Risk

Zero impact on production code or test behaviour. The disk-space sweep removes runner-side toolchains that no cargo step on this workspace touches. \`--nocapture\` increases log volume on failure — explicitly the point.

## Verification

After merge, the next push to \`release/stg\` should:
- Show free space go from ~14 GB → ~34 GB in the Coverage logs.
- Show Rust toolchain versions on the first line of every job.
- (On a hypothetical future failure) show a full backtrace inline instead of just the panic message.