### PR TITLE
ci: bump actions/checkout@v4 → @v5 (Node.js 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: Toolchain versions
         run: |
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: Toolchain versions
         run: |
@@ -87,7 +87,7 @@ jobs:
 #    runs-on: ubuntu-latest
 #    timeout-minutes: 30
 #    steps:
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@v5
 #      - uses: dtolnay/rust-toolchain@stable
 #        with:
 #          components: llvm-tools-preview
@@ -128,7 +128,7 @@ jobs:
 #    runs-on: ubuntu-latest
 #    timeout-minutes: 30
 #    steps:
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@v5
 #      - uses: dtolnay/rust-toolchain@stable
 #        with:
 #          components: llvm-tools-preview
@@ -164,7 +164,7 @@ jobs:
 #    runs-on: ubuntu-latest
 #    timeout-minutes: 30
 #    steps:
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@v5
 #      - uses: dtolnay/rust-toolchain@stable
 #        with:
 #          components: llvm-tools-preview

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,7 +51,7 @@ jobs:
           - { crate: prx-waf,     floor: 5 }
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # The ubuntu-latest runner ships with ~14 GB free on /. cargo llvm-cov
       # compiles the vendored pingora workspace into target/llvm-cov-target

--- a/.github/workflows/ddos-soak.yml
+++ b/.github/workflows/ddos-soak.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-action@stable

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -38,7 +38,7 @@ jobs:
 #    runs-on: ubuntu-latest
 #    timeout-minutes: 30
 #    steps:
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@v5
 #      - uses: dtolnay/rust-toolchain@stable
 #      - uses: Swatinem/rust-cache@v2
 #        with:
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -110,7 +110,7 @@ jobs:
     timeout-minutes: 30
     if: ${{ inputs.suites == '' || contains(inputs.suites, 'rules-engine') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v4
         with: { name: prx-waf-bin, path: target/release }
       - run: chmod +x target/release/prx-waf tests/e2e/*.sh
@@ -172,7 +172,7 @@ jobs:
     timeout-minutes: 30
     if: ${{ inputs.suites == '' || contains(inputs.suites, 'gateway') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v4
         with: { name: prx-waf-bin, path: target/release }
       - run: chmod +x target/release/prx-waf tests/e2e/*.sh
@@ -234,7 +234,7 @@ jobs:
     timeout-minutes: 30
     if: ${{ inputs.suites == '' || contains(inputs.suites, 'waf-api') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v4
         with: { name: prx-waf-bin, path: target/release }
       - run: chmod +x target/release/prx-waf tests/e2e/*.sh
@@ -296,7 +296,7 @@ jobs:
     timeout-minutes: 45
     if: ${{ inputs.suites == '' || contains(inputs.suites, 'cluster') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v4
         with: { name: prx-waf-bin, path: target/release }
       - run: chmod +x target/release/prx-waf tests/e2e/*.sh tests/e2e-cluster.sh
@@ -347,7 +347,7 @@ jobs:
     timeout-minutes: 10
     if: always()
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download all suite artefacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,7 @@ jobs:
             git tar gzip xz which perl \
             nodejs npm
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive

--- a/.github/workflows/sec-audit.yml
+++ b/.github/workflows/sec-audit.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # Run cargo-audit directly instead of `rustsec/audit-check@v2`. That
       # action publishes findings via the GitHub Checks API, which is NOT
       # available to workflows running on a fork (GitHub returns
@@ -65,7 +65,7 @@ jobs:
     # ignore list in deny.toml. bans/licenses/sources MUST stay green.
     continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check ${{ matrix.checks }}


### PR DESCRIPTION
## Summary

GitHub deprecates Node.js 20 actions starting **2026-06-02**:

> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

\`actions/checkout@v5\` runs on Node.js 24 and is API-compatible with the v4 options we use. Bumping now removes the deprecation warning that fires on every workflow run and avoids a forced upgrade with no review window.

## Scope

Replace \`actions/checkout@v4\` → \`@v5\` across 14 active references in 6 workflow files (\`ci.yml\`, \`coverage.yml\`, \`sec-audit.yml\`, \`release.yaml\`, \`nightly-e2e.yml\`, \`ddos-soak.yml\`). 4 commented snippet references updated too so they stay consistent if those jobs are ever revived.

## Out of scope

\`actions/upload-artifact@v4\` and \`actions/cache@v4\` are still on Node.js 20 but were not surfaced in the deprecation message yet. Will be bumped in a follow-up when their warnings appear or before the 2026-06-02 deadline.