### PR TITLE
fix(logs): default Security Logs LogsQL to stream:waf_audit (#43)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,34 @@ jobs:
       - name: Build release
         run: cargo build --workspace --release
 
+  # Admin panel currently has no CI gate; type-check + build catches
+  # the bulk of regressions (broken imports, stale prop types, refine
+  # data-provider drift). Runs in parallel with the Rust jobs.
+  admin-panel:
+    name: Admin Panel (type-check + build)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: web/admin-panel
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: web/admin-panel/package-lock.json
+      - name: Tool versions
+        run: |
+          node --version
+          npm --version
+      - name: Install
+        run: npm ci
+      - name: Type check
+        run: npm run type-check
+      - name: Build
+        run: npm run build
+
   # FR-009 phase-05: 95% line coverage gate scoped to the cache module.
   # Workspace-aggregate coverage would mask gaps inside cache/**, so we
   # measure only files under crates/gateway/src/cache/**.

--- a/crates/waf-engine/src/logging/audit_sender.rs
+++ b/crates/waf-engine/src/logging/audit_sender.rs
@@ -194,7 +194,7 @@ mod tests {
     }
 
     /// Locks the wire-format contract relied on by the admin panel Security
-    /// Logs page. The `Rule` column reads `rule_name`, the default LogsQL
+    /// Logs page. The `Rule` column reads `rule_name`, the default `LogsQL`
     /// filters on `stream:waf_audit`, and operators slice further by
     /// `rule_id` / `event_type` / `phase` — every block event must carry
     /// all of them.
@@ -219,7 +219,7 @@ mod tests {
     }
 
     /// When a rule fires without a stable identifier (e.g. a runtime
-    /// heuristic) `rule_id` serializes as JSON null. LogsQL `rule_id:*`
+    /// heuristic) `rule_id` serializes as JSON null. `LogsQL` `rule_id:*`
     /// can still distinguish present-vs-absent so the FE stays consistent.
     #[test]
     fn missing_optional_fields_serialize_as_null() {
@@ -259,7 +259,7 @@ mod tests {
     }
 
     /// Non-block events (`allow`, `challenge`, `rate_limit`, `log_only`)
-    /// share the same schema so a single LogsQL preset filters everything
+    /// share the same schema so a single `LogsQL` preset filters everything
     /// in `stream:waf_audit`.
     #[test]
     fn all_event_types_share_the_audit_stream() {

--- a/crates/waf-engine/src/logging/audit_sender.rs
+++ b/crates/waf-engine/src/logging/audit_sender.rs
@@ -145,8 +145,7 @@ mod tests {
 
     fn sample_block_event() -> AuditEvent {
         AuditEvent {
-            timestamp: chrono::DateTime::<chrono::Utc>::from_timestamp(1_700_000_000, 0)
-                .unwrap_or_default(),
+            timestamp: chrono::DateTime::<chrono::Utc>::from_timestamp(1_700_000_000, 0).unwrap_or_default(),
             event_type: AuditEventType::Block,
             rule_name: "SQLi: classic UNION-based".to_string(),
             rule_id: Some("OWASP-942100".to_string()),
@@ -250,7 +249,7 @@ mod tests {
     #[test]
     fn build_payload_truncates_long_path() {
         let mut ev = sample_block_event();
-        ev.path = "/api/".to_string() + &"a".repeat(PATH_TRUNCATE_AT * 2);
+        ev.path = format!("/api/{}", "a".repeat(PATH_TRUNCATE_AT * 2));
 
         let payload = build_payload(ev);
 

--- a/crates/waf-engine/src/logging/audit_sender.rs
+++ b/crates/waf-engine/src/logging/audit_sender.rs
@@ -90,48 +90,84 @@ impl AuditSender {
         if !self.inner.buffer.is_active() {
             return;
         }
-
-        let path = if event.path.len() > PATH_TRUNCATE_AT {
-            // Slice on a UTF-8 char boundary to stay safe for non-ASCII URIs.
-            let mut end = PATH_TRUNCATE_AT;
-            while end > 0 && !event.path.is_char_boundary(end) {
-                end -= 1;
-            }
-            format!("{}…", &event.path[..end])
-        } else {
-            event.path
-        };
-
-        let payload = json!({
-            "_time": event.timestamp.to_rfc3339(),
-            "_msg": format!(
-                "{} {} {} → {} (rule={})",
-                event.event_type.as_str(),
-                event.method,
-                path,
-                event.client_ip,
-                event.rule_name,
-            ),
-            "event_type": event.event_type.as_str(),
-            "rule_name": event.rule_name,
-            "rule_id": event.rule_id,
-            "phase": event.phase,
-            "client_ip": event.client_ip,
-            "host": event.host,
-            "method": event.method,
-            "path": path,
-            "tier": event.tier,
-            "detail": event.detail,
-            "req_id": event.req_id,
-            "stream": "waf_audit",
-        });
-        self.inner.buffer.try_send(payload);
+        self.inner.buffer.try_send(build_payload(event));
     }
+}
+
+/// Truncate `path` on a UTF-8 char boundary so non-ASCII URIs stay valid.
+fn truncate_path(path: String) -> String {
+    if path.len() <= PATH_TRUNCATE_AT {
+        return path;
+    }
+    let mut end = PATH_TRUNCATE_AT;
+    while end > 0 && !path.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &path[..end])
+}
+
+/// Build the NDJSON payload shipped to `VictoriaLogs`. Extracted from `send`
+/// so the wire-format contract relied on by the admin panel (`stream`,
+/// `rule_name`, `rule_id`, `event_type`, `phase`) is unit-testable without
+/// spinning up a `BatchSender`.
+fn build_payload(event: AuditEvent) -> serde_json::Value {
+    let path = truncate_path(event.path);
+    json!({
+        "_time": event.timestamp.to_rfc3339(),
+        "_msg": format!(
+            "{} {} {} → {} (rule={})",
+            event.event_type.as_str(),
+            event.method,
+            path,
+            event.client_ip,
+            event.rule_name,
+        ),
+        "event_type": event.event_type.as_str(),
+        "rule_name": event.rule_name,
+        "rule_id": event.rule_id,
+        "phase": event.phase,
+        "client_ip": event.client_ip,
+        "host": event.host,
+        "method": event.method,
+        "path": path,
+        "tier": event.tier,
+        "detail": event.detail,
+        "req_id": event.req_id,
+        "stream": "waf_audit",
+    })
 }
 
 #[cfg(test)]
 mod tests {
+    use serde_json::Value;
+
     use super::*;
+
+    fn sample_block_event() -> AuditEvent {
+        AuditEvent {
+            timestamp: chrono::DateTime::<chrono::Utc>::from_timestamp(1_700_000_000, 0)
+                .unwrap_or_default(),
+            event_type: AuditEventType::Block,
+            rule_name: "SQLi: classic UNION-based".to_string(),
+            rule_id: Some("OWASP-942100".to_string()),
+            phase: Some("request_body".to_string()),
+            client_ip: "203.0.113.7".to_string(),
+            host: "api.example.com".to_string(),
+            method: "POST".to_string(),
+            path: "/api/login".to_string(),
+            tier: Some("critical".to_string()),
+            detail: Some("UNION SELECT detected".to_string()),
+            req_id: Some("req-abc".to_string()),
+        }
+    }
+
+    fn field_str<'a>(payload: &'a Value, key: &str) -> Option<&'a str> {
+        payload.get(key).and_then(Value::as_str)
+    }
+
+    fn field_is_null(payload: &Value, key: &str) -> bool {
+        payload.get(key).is_some_and(Value::is_null)
+    }
 
     #[test]
     fn event_type_string_round_trip() {
@@ -151,13 +187,94 @@ mod tests {
             p.push('é');
         }
         assert!(p.len() > PATH_TRUNCATE_AT);
-        // Use the same logic as `send` for the boundary calculation.
-        let mut end = PATH_TRUNCATE_AT;
-        while end > 0 && !p.is_char_boundary(end) {
-            end -= 1;
+        let truncated = truncate_path(p);
+        // Ellipsis is appended after the truncation, so the byte length
+        // is bounded by PATH_TRUNCATE_AT plus the ellipsis encoding.
+        assert!(truncated.ends_with('…'));
+        assert!(truncated.len() <= PATH_TRUNCATE_AT + '…'.len_utf8());
+    }
+
+    /// Locks the wire-format contract relied on by the admin panel Security
+    /// Logs page. The `Rule` column reads `rule_name`, the default LogsQL
+    /// filters on `stream:waf_audit`, and operators slice further by
+    /// `rule_id` / `event_type` / `phase` — every block event must carry
+    /// all of them.
+    #[test]
+    fn block_payload_contains_all_admin_panel_fields() {
+        let payload = build_payload(sample_block_event());
+
+        assert_eq!(field_str(&payload, "stream"), Some("waf_audit"));
+        assert_eq!(field_str(&payload, "event_type"), Some("block"));
+        assert_eq!(field_str(&payload, "rule_name"), Some("SQLi: classic UNION-based"));
+        assert_eq!(field_str(&payload, "rule_id"), Some("OWASP-942100"));
+        assert_eq!(field_str(&payload, "phase"), Some("request_body"));
+        assert_eq!(field_str(&payload, "client_ip"), Some("203.0.113.7"));
+        assert_eq!(field_str(&payload, "host"), Some("api.example.com"));
+        assert_eq!(field_str(&payload, "method"), Some("POST"));
+        assert_eq!(field_str(&payload, "path"), Some("/api/login"));
+        assert_eq!(field_str(&payload, "tier"), Some("critical"));
+        assert_eq!(field_str(&payload, "req_id"), Some("req-abc"));
+        // `_time` and `_msg` are required by VictoriaLogs' ingest schema.
+        assert!(field_str(&payload, "_time").is_some());
+        assert!(field_str(&payload, "_msg").is_some());
+    }
+
+    /// When a rule fires without a stable identifier (e.g. a runtime
+    /// heuristic) `rule_id` serializes as JSON null. LogsQL `rule_id:*`
+    /// can still distinguish present-vs-absent so the FE stays consistent.
+    #[test]
+    fn missing_optional_fields_serialize_as_null() {
+        let mut ev = sample_block_event();
+        ev.rule_id = None;
+        ev.phase = None;
+        ev.tier = None;
+        ev.detail = None;
+        ev.req_id = None;
+
+        let payload = build_payload(ev);
+
+        assert!(field_is_null(&payload, "rule_id"));
+        assert!(field_is_null(&payload, "phase"));
+        assert!(field_is_null(&payload, "tier"));
+        assert!(field_is_null(&payload, "detail"));
+        assert!(field_is_null(&payload, "req_id"));
+        // Required identifiers stay populated.
+        assert_eq!(field_str(&payload, "stream"), Some("waf_audit"));
+        assert_eq!(field_str(&payload, "event_type"), Some("block"));
+        assert_eq!(field_str(&payload, "rule_name"), Some("SQLi: classic UNION-based"));
+    }
+
+    /// Long paths are truncated with an ellipsis, but the payload field
+    /// is still a non-empty string so the admin panel's `Path` column
+    /// never renders blank.
+    #[test]
+    fn build_payload_truncates_long_path() {
+        let mut ev = sample_block_event();
+        ev.path = "/api/".to_string() + &"a".repeat(PATH_TRUNCATE_AT * 2);
+
+        let payload = build_payload(ev);
+
+        let path = field_str(&payload, "path").unwrap_or_default();
+        assert!(path.ends_with('…'));
+        assert!(path.len() <= PATH_TRUNCATE_AT + '…'.len_utf8());
+    }
+
+    /// Non-block events (`allow`, `challenge`, `rate_limit`, `log_only`)
+    /// share the same schema so a single LogsQL preset filters everything
+    /// in `stream:waf_audit`.
+    #[test]
+    fn all_event_types_share_the_audit_stream() {
+        for ty in [
+            AuditEventType::Allow,
+            AuditEventType::Challenge,
+            AuditEventType::RateLimit,
+            AuditEventType::LogOnly,
+        ] {
+            let mut ev = sample_block_event();
+            ev.event_type = ty;
+            let payload = build_payload(ev);
+            assert_eq!(field_str(&payload, "stream"), Some("waf_audit"));
+            assert_eq!(field_str(&payload, "event_type"), Some(ty.as_str()));
         }
-        let truncated = &p[..end];
-        assert!(truncated.is_char_boundary(0));
-        assert!(truncated.len() <= PATH_TRUNCATE_AT);
     }
 }

--- a/web/admin-panel/src/providers/victoria-logs-data-provider.ts
+++ b/web/admin-panel/src/providers/victoria-logs-data-provider.ts
@@ -22,6 +22,13 @@ import { httpClient } from "../utils/axios";
 
 const LOGS_QUERY_URL = "/api/v1/logs/query";
 
+// Default LogsQL when the filter sidebar is empty. We restrict to the WAF
+// audit stream so the Security Logs table always shows rows that carry
+// `rule_name` / `rule_id` / `event_type`. Operators who want raw traffic
+// (proxy `waf_tracing`, etc.) opt in via the Advanced toggle which sends
+// `{ field: "raw", value: "*" }`.
+const DEFAULT_LOGSQL = "stream:waf_audit";
+
 const LOGSQL_RESERVED = /[\s"\\:|]/;
 
 /** Quote a LogsQL value when it contains reserved characters. */
@@ -79,14 +86,12 @@ const filterToLogsQL = (filter: CrudFilter): string | null => {
  */
 const buildLogsQL = (filters: CrudFilter[] | undefined): string => {
   if (!filters || filters.length === 0) {
-    // Empty query is rejected by the proxy; fall back to a wildcard so
-    // the empty-state on the FE just shows the most recent rows.
-    return "*";
+    return DEFAULT_LOGSQL;
   }
   const parts = filters
     .map((f) => filterToLogsQL(f))
     .filter((p): p is string => p !== null && p.length > 0);
-  return parts.length === 0 ? "*" : parts.join(" ");
+  return parts.length === 0 ? DEFAULT_LOGSQL : parts.join(" ");
 };
 
 const toHttpError = (err: unknown): HttpError => {
@@ -183,4 +188,4 @@ export const victoriaLogsDataProvider: DataProvider = {
 };
 
 // Re-exports useful for tests and downstream tooling.
-export { buildLogsQL, escapeValue, filterToLogsQL, parseNdjson };
+export { DEFAULT_LOGSQL, buildLogsQL, escapeValue, filterToLogsQL, parseNdjson };


### PR DESCRIPTION
Closes #43.

## Problem

The admin panel's Security Logs page used `*` as the default LogsQL query, so the table mixed two streams:

- `stream:waf_audit` — WAF access-decision rows from `audit_sender` carrying `rule_name`, `rule_id`, `event_type`, `phase`.
- `stream:waf_tracing` — generic Pingora / `tracing` events from `vlogs_layer` with no WAF rule metadata.

Because most ingested rows are tracing noise, the `Rule` column rendered as `-` for the majority of rows even though the audit pipeline was emitting all the right fields. Operators had to manually type `stream:waf_audit` to see anything useful.

## Fix

### `web/admin-panel/src/providers/victoria-logs-data-provider.ts`
- New `DEFAULT_LOGSQL = "stream:waf_audit"` constant; `buildLogsQL` returns it when filters are empty or all fragments are dropped.
- The Advanced toggle's raw-LogsQL escape hatch (`{ field: "raw", value: "*" }`) is unchanged, so power users can still grab unfiltered traffic.

### `crates/waf-engine/src/logging/audit_sender.rs`
- Extract NDJSON construction into a pure `build_payload(event)` function and a `truncate_path` helper. `send()` becomes a one-line forward to the buffer.
- New unit tests lock the contract the admin panel reads:
  - `block_payload_contains_all_admin_panel_fields` — verifies `stream`, `event_type`, `rule_name`, `rule_id`, `phase`, `client_ip`, `host`, `method`, `path`, `tier`, `req_id`, `_time`, `_msg` are populated for a representative block event.
  - `missing_optional_fields_serialize_as_null` — when a rule fires without a stable id, optional fields serialize as JSON `null` so LogsQL `field:*` keeps working.
  - `build_payload_truncates_long_path` — long URIs land with a trailing `…` and never blank out the table's `Path` column.
  - `all_event_types_share_the_audit_stream` — `allow` / `challenge` / `rate_limit` / `log_only` all share `stream:"waf_audit"` so the new default catches every decision.

### `.github/workflows/ci.yml`
- New `admin-panel` job: `actions/setup-node@v4` (Node 20) + `npm ci` + `npm run type-check` + `npm run build`. The TypeScript dashboard previously had zero CI coverage; any broken refine prop type or data-provider drift could land unnoticed.

## Acceptance criteria (from #43)

- Default Security Logs view shows populated `Rule` column for blocked requests — **yes** (default query now filters to `waf_audit`).
- Operators can no longer confuse `waf_tracing` proxy noise with `waf_audit` decision rows without opting in — **yes** (raw query path still available via Advanced).
- Optional: field-value endpoints used for filters still list `rule_name` for `waf_audit` stream — **unchanged** (backend already supported this).

## Test plan

- [x] Existing audit_sender tests still pass (path truncation, event-type round-trip).
- [x] New audit_sender tests cover the wire-format contract.
- [x] `npm run type-check` + `npm run build` for admin-panel run in CI.
- [ ] Manual verification: open Security Logs → see populated `Rule` column on a fresh staging instance with both streams ingesting.