### PR TITLE
fix(gateway): fail-secure XFF when trusted_proxies is empty

### DIFF
--- a/crates/gateway/src/ctx_builder/request_ctx_builder.rs
+++ b/crates/gateway/src/ctx_builder/request_ctx_builder.rs
@@ -194,8 +194,8 @@ pub fn build_from_parts(
 /// Resolve the effective client IP from session state.
 ///
 /// Honours `X-Forwarded-For` only when `trust_proxy_headers` is `true` **and**
-/// the TCP peer falls within `trusted_proxies` (or the list is empty, which
-/// means "trust any peer" for backwards compatibility).
+/// the TCP peer falls within `trusted_proxies`. An empty `trusted_proxies`
+/// list means no peer is trusted and XFF is ignored (fail-secure).
 fn extract_client_ip_from_session(
     session: &Session,
     peer_ip: IpAddr,
@@ -209,8 +209,8 @@ fn extract_client_ip_from_session(
 /// Pure helper that mirrors `extract_client_ip_from_session` for unit testing.
 ///
 /// Returns `peer_ip` unchanged unless `trust_proxy_headers` is `true`, the peer
-/// is within (or list is empty) `trusted_proxies`, and the first XFF token
-/// parses as an IP.
+/// is within `trusted_proxies` (non-empty), and the first XFF token parses
+/// as an IP.
 pub(crate) fn resolve_client_ip(
     peer_ip: IpAddr,
     trust_proxy_headers: bool,
@@ -220,7 +220,7 @@ pub(crate) fn resolve_client_ip(
     if !trust_proxy_headers {
         return peer_ip;
     }
-    let peer_trusted = trusted_proxies.is_empty() || trusted_proxies.iter().any(|net| net.contains(&peer_ip));
+    let peer_trusted = trusted_proxies.iter().any(|net| net.contains(&peer_ip));
     if !peer_trusted {
         return peer_ip;
     }
@@ -404,10 +404,11 @@ mod tests {
     }
 
     #[test]
-    fn resolve_client_ip_uses_xff_when_trusted_and_list_empty() {
+    fn resolve_client_ip_returns_peer_when_trusted_list_empty() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        // Fail-secure: trust_proxy_headers=true with empty trusted_proxies must NOT honour XFF.
         let got = resolve_client_ip(peer, true, &[], Some(b"203.0.113.7, 10.0.0.1"));
-        assert_eq!(got, IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7)));
+        assert_eq!(got, peer);
     }
 
     #[test]
@@ -429,28 +430,32 @@ mod tests {
     #[test]
     fn resolve_client_ip_returns_peer_when_xff_missing() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5));
-        let got = resolve_client_ip(peer, true, &[], None);
+        let trusted: Vec<ipnet::IpNet> = vec!["10.0.0.0/8".parse().unwrap()];
+        let got = resolve_client_ip(peer, true, &trusted, None);
         assert_eq!(got, peer);
     }
 
     #[test]
     fn resolve_client_ip_returns_peer_when_xff_unparseable() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5));
-        let got = resolve_client_ip(peer, true, &[], Some(b"not-an-ip, also-junk"));
+        let trusted: Vec<ipnet::IpNet> = vec!["10.0.0.0/8".parse().unwrap()];
+        let got = resolve_client_ip(peer, true, &trusted, Some(b"not-an-ip, also-junk"));
         assert_eq!(got, peer);
     }
 
     #[test]
     fn resolve_client_ip_returns_peer_when_xff_invalid_utf8() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5));
-        let got = resolve_client_ip(peer, true, &[], Some(&[0xff, 0xfe, 0xfd]));
+        let trusted: Vec<ipnet::IpNet> = vec!["10.0.0.0/8".parse().unwrap()];
+        let got = resolve_client_ip(peer, true, &trusted, Some(&[0xff, 0xfe, 0xfd]));
         assert_eq!(got, peer);
     }
 
     #[test]
     fn resolve_client_ip_picks_first_xff_token_trimmed() {
         let peer = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5));
-        let got = resolve_client_ip(peer, true, &[], Some(b"   192.0.2.50   , 10.0.0.5"));
+        let trusted: Vec<ipnet::IpNet> = vec!["10.0.0.0/8".parse().unwrap()];
+        let got = resolve_client_ip(peer, true, &trusted, Some(b"   192.0.2.50   , 10.0.0.5"));
         assert_eq!(got, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 50)));
     }
 

--- a/crates/gateway/tests/ctx_builder_session.rs
+++ b/crates/gateway/tests/ctx_builder_session.rs
@@ -209,10 +209,8 @@ async fn build_detects_tls_when_ssl_digest_present_on_session_digest() {
 }
 
 #[tokio::test]
-async fn build_honours_xff_only_when_trust_proxy_headers_enabled() {
-    // Mock has no real peer IP → peer = UNSPECIFIED. Trusted-proxies list
-    // is empty so any peer counts as trusted. Builder should pick the first
-    // XFF token.
+async fn build_honours_xff_only_when_trust_enabled_and_peer_trusted() {
+    // Mock has no real peer IP → peer = UNSPECIFIED.
     let req = b"GET / HTTP/1.1\r\nHost: ex.com\r\nX-Forwarded-For: 198.51.100.7, 10.0.0.1\r\n\r\n";
     let session = session_for(req).await;
 
@@ -223,8 +221,16 @@ async fn build_honours_xff_only_when_trust_proxy_headers_enabled() {
         "XFF must not be honoured when trust=false"
     );
 
-    // trust_proxy_headers = true with empty trusted_proxies (= trust any peer).
+    // trust_proxy_headers = true with EMPTY trusted_proxies → fail-secure: XFF dropped.
     let ctx = RequestCtxBuilder::new(&session, true, &[]).build();
+    assert!(
+        ctx.client_ip.is_unspecified(),
+        "XFF must not be honoured when trusted_proxies is empty (fail-secure)"
+    );
+
+    // trust_proxy_headers = true and peer covered by trusted CIDR → XFF honoured.
+    let trusted: Vec<IpNet> = vec!["0.0.0.0/0".parse().expect("cidr")];
+    let ctx = RequestCtxBuilder::new(&session, true, &trusted).build();
     assert_eq!(ctx.client_ip.to_string(), "198.51.100.7");
 }
 

--- a/crates/prx-waf/src/main.rs
+++ b/crates/prx-waf/src/main.rs
@@ -1366,13 +1366,14 @@ fn run_server(config: &AppConfig, config_file_path: &str, vlogs_layer_slot: Laye
         }
     });
 
-    // Warn when XFF trust is enabled but no trusted proxy CIDRs are configured,
-    // meaning XFF headers from ANY source will be honoured (fail-open).
+    // Warn when XFF trust is enabled but no trusted proxy CIDRs are configured.
+    // Fail-secure: XFF headers will NOT be honoured because no peer is in the
+    // trust list. Operators must enumerate `trusted_proxies` to enable XFF.
     if proxy.trust_proxy_headers && proxy.trusted_proxies.is_empty() {
         tracing::warn!(
             "trust_proxy_headers is enabled but trusted_proxies is empty — \
-             XFF headers from ANY source will be trusted. \
-             Consider adding trusted proxy CIDRs for production use."
+             XFF headers will NOT be honoured (fail-secure). \
+             Add trusted proxy CIDRs to trusted_proxies to enable XFF parsing."
         );
     }
 


### PR DESCRIPTION
## Summary

When `trust_proxy_headers = true` and `trusted_proxies = []`, the previous
`is_empty()` short-circuit caused `resolve_client_ip` to honour the leftmost
`X-Forwarded-For` token from any TCP peer. Direct-from-internet clients could
therefore spoof `client_ip`, polluting rate-limit keys (FR-004), XFF validation
(FR-007), allow/block tables (FR-008), and the per-IP cumulative risk score
(FR-025).

This change switches the helper to **fail-secure**: an empty trust list means
no peer is trusted, so the resolver returns the immediate `peer_ip` and leaves
XFF parsing disabled.

## Behavioural change

- Operator action required: deployments that have `trust_proxy_headers = true`
  and an empty `trusted_proxies` (intentionally or because every CIDR failed to
  parse) will no longer honour XFF. The startup WARN log already fires for this
  condition and is updated to direct the operator to populate `trusted_proxies`.
- Default config (`trust_proxy_headers = false`) is unaffected.

## What changed

- `crates/gateway/src/ctx_builder/request_ctx_builder.rs`
  - `resolve_client_ip`: dropped the `trusted_proxies.is_empty()` branch from
    the `peer_trusted` calculation.
  - Updated the doc comments on `extract_client_ip_from_session` and
    `resolve_client_ip` to reflect fail-secure semantics.
  - Migrated five unit tests that relied on the empty-list shortcut to populate
    `trusted_proxies`. Renamed `resolve_client_ip_uses_xff_when_trusted_and_list_empty`
    to `resolve_client_ip_returns_peer_when_trusted_list_empty` and inverted its
    assertion to lock in the fail-secure invariant.
- `crates/prx-waf/src/main.rs`
  - Rewrote the startup WARN log to state that XFF will **not** be honoured
    until `trusted_proxies` is populated.

## Test plan

- [ ] `cargo test -p gateway ctx_builder` passes in CI.
- [ ] `cargo fmt --all -- --check` clean.
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [ ] Gateway coverage gate still ≥ 95% on `ctx_builder/request_ctx_builder.rs`.