### PR TITLE
fix(api): fail-closed admin IP allowlist when ConnectInfo is missing

### DIFF
--- a/crates/waf-api/src/security.rs
+++ b/crates/waf-api/src/security.rs
@@ -206,10 +206,7 @@ pub async fn list_audit_log(
 /// allowlist preserves the legacy "allow all" semantics for both branches.
 #[must_use]
 pub fn evaluate_admin_ip(peer_ip: Option<IpAddr>, allowlist: &[String]) -> bool {
-    match peer_ip {
-        Some(addr) => is_admin_ip_allowed(&addr, allowlist),
-        None => allowlist.is_empty(),
-    }
+    peer_ip.map_or(allowlist.is_empty(), |addr| is_admin_ip_allowed(&addr, allowlist))
 }
 
 /// Rejects requests from IPs not in the admin allowlist.
@@ -620,16 +617,16 @@ mod tests {
         assert!(!evaluate_admin_ip(ip, &allowlist));
     }
 
-    /// Fail-closed: missing ConnectInfo + non-empty allowlist must deny so a
+    /// Fail-closed: missing `ConnectInfo` + non-empty allowlist must deny so a
     /// missing trust signal cannot bypass the operator's network gate
-    /// (axum routing without ConnectInfo, oneshot integration paths).
+    /// (axum routing without `ConnectInfo`, `oneshot` integration paths).
     #[test]
     fn evaluate_admin_ip_missing_with_allowlist_denies() {
         let allowlist = vec!["10.0.0.0/8".to_owned()];
         assert!(!evaluate_admin_ip(None, &allowlist));
     }
 
-    /// Empty allowlist preserves allow-all even when ConnectInfo missing.
+    /// Empty allowlist preserves allow-all even when `ConnectInfo` missing.
     #[test]
     fn evaluate_admin_ip_missing_with_empty_allowlist_allows() {
         assert!(evaluate_admin_ip(None, &[]));

--- a/crates/waf-api/src/security.rs
+++ b/crates/waf-api/src/security.rs
@@ -197,19 +197,45 @@ pub async fn list_audit_log(
 
 // ─── Admin IP allowlist middleware ────────────────────────────────────────────
 
+/// Pure helper that decides whether a request must be forwarded by the admin
+/// IP middleware. Returns `true` to allow, `false` to deny.
+///
+/// Fail-closed: when `peer_ip` is `None` (axum did not populate the
+/// `ConnectInfo` extension) **and** `allowlist` is non-empty, the request is
+/// denied so a missing trust signal cannot bypass the allowlist. An empty
+/// allowlist preserves the legacy "allow all" semantics for both branches.
+#[must_use]
+pub fn evaluate_admin_ip(peer_ip: Option<IpAddr>, allowlist: &[String]) -> bool {
+    match peer_ip {
+        Some(addr) => is_admin_ip_allowed(&addr, allowlist),
+        None => allowlist.is_empty(),
+    }
+}
+
 /// Rejects requests from IPs not in the admin allowlist.
 /// If the allowlist is empty, all IPs are allowed.
+///
+/// When the `ConnectInfo` extension is missing and the allowlist is configured,
+/// the request is denied (fail-closed) to prevent the allowlist being silently
+/// bypassed via an unresolved peer IP.
 pub async fn admin_ip_check_middleware(
     State(state): State<Arc<AppState>>,
     req: Request<Body>,
     next: Next,
 ) -> impl IntoResponse {
-    let ip = req
+    let peer_ip = req
         .extensions()
         .get::<axum::extract::connect_info::ConnectInfo<std::net::SocketAddr>>()
-        .map_or(IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED), |ci| ci.0.ip());
+        .map(|ci| ci.0.ip());
 
-    if !is_admin_ip_allowed(&ip, &state.security_config.admin_ip_allowlist) {
+    let allowlist = &state.security_config.admin_ip_allowlist;
+    if !evaluate_admin_ip(peer_ip, allowlist) {
+        if peer_ip.is_none() {
+            tracing::warn!(
+                "admin_ip_check_middleware: ConnectInfo extension missing — denying request \
+                 (allowlist non-empty)"
+            );
+        }
         return (
             StatusCode::FORBIDDEN,
             Json(json!({ "error": "IP address not allowed" })),
@@ -574,5 +600,45 @@ mod tests {
             !is_admin_ip_allowed(&ipv4_mapped, &allowlist),
             "IPv4-mapped IPv6 ::ffff:192.168.1.1 should NOT match plain IPv4 entry"
         );
+    }
+
+    // ── evaluate_admin_ip (middleware decision helper) ────────────────────────
+
+    /// Peer IP inside the configured allowlist is permitted.
+    #[test]
+    fn evaluate_admin_ip_present_in_allowlist_passes() {
+        let ip = Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+        let allowlist = vec!["10.0.0.0/8".to_owned()];
+        assert!(evaluate_admin_ip(ip, &allowlist));
+    }
+
+    /// Peer IP outside the configured allowlist is denied.
+    #[test]
+    fn evaluate_admin_ip_present_not_in_allowlist_denied() {
+        let ip = Some(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+        let allowlist = vec!["10.0.0.0/8".to_owned()];
+        assert!(!evaluate_admin_ip(ip, &allowlist));
+    }
+
+    /// Fail-closed: missing ConnectInfo + non-empty allowlist must deny so a
+    /// missing trust signal cannot bypass the operator's network gate
+    /// (axum routing without ConnectInfo, oneshot integration paths).
+    #[test]
+    fn evaluate_admin_ip_missing_with_allowlist_denies() {
+        let allowlist = vec!["10.0.0.0/8".to_owned()];
+        assert!(!evaluate_admin_ip(None, &allowlist));
+    }
+
+    /// Empty allowlist preserves allow-all even when ConnectInfo missing.
+    #[test]
+    fn evaluate_admin_ip_missing_with_empty_allowlist_allows() {
+        assert!(evaluate_admin_ip(None, &[]));
+    }
+
+    /// Empty allowlist still allows every present IP.
+    #[test]
+    fn evaluate_admin_ip_present_with_empty_allowlist_allows() {
+        let ip = Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)));
+        assert!(evaluate_admin_ip(ip, &[]));
     }
 }


### PR DESCRIPTION
## Summary

`admin_ip_check_middleware` previously coerced the peer IP to `0.0.0.0`
whenever axum did not populate the `ConnectInfo` extension, then forwarded
that unspecified address to `is_admin_ip_allowed`. Any allowlist that
covered `0.0.0.0` (e.g. an operator-configured `0.0.0.0/0` sentinel)
therefore silently bypassed the only network control on the admin API.

This change extracts the decision into a pure `evaluate_admin_ip` helper:

- `Some(ip)` → delegates to the existing `is_admin_ip_allowed` matcher.
- `None` → returns `true` only when the allowlist is empty; otherwise
  the request is denied (fail-closed) and the middleware logs a `WARN`.

Empty-allowlist behaviour ("allow all") is preserved for both branches,
matching the documented contract.

## What changed

- `crates/waf-api/src/security.rs`
  - New `evaluate_admin_ip(peer_ip: Option<IpAddr>, allowlist) -> bool`
    helper (pub, `#[must_use]`).
  - `admin_ip_check_middleware` now holds an `Option<IpAddr>` and routes
    through the helper; emits a `WARN` log on the missing-ConnectInfo
    denial branch.
  - 5 new unit tests:
    - present + in allowlist → allow
    - present + not in allowlist → deny
    - **missing + non-empty allowlist → deny (fail-closed invariant)**
    - missing + empty allowlist → allow
    - present + empty allowlist → allow

## Test plan

- [ ] `cargo test -p waf-api security` passes in CI.
- [ ] `cargo fmt --all -- --check` clean.
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [ ] Coverage (waf-api) gate remains green.