### PR TITLE
fix(storage): filter NULL rule_id in heatmap path_ranks CTE (#74.4)

### DIFF
--- a/crates/waf-storage/src/repo.rs
+++ b/crates/waf-storage/src/repo.rs
@@ -1528,6 +1528,10 @@ impl Database {
         // per-row compute of the previous CROSS JOIN LATERAL form, which
         // evaluated the function before the WHERE clause excluded null rows.
         //
+        // All three CTEs filter rule_id IS NOT NULL — keeps non-WAF events
+        // (health probes, infra noise) from out-ranking real attack paths
+        // into the LIMIT-20 path set before the per-cell join even runs.
+        //
         // GROUP BY / ORDER BY use SELECT positions (1, 2, 3) — fully
         // unambiguous between column aliases and underlying table columns.
         let rows = sqlx::query(
@@ -1538,6 +1542,7 @@ impl Database {
               WHERE created_at >= NOW() - make_interval(hours => $1::int)
                 AND ($2::text IS NULL OR host_code = $2)
                 AND ($3::text IS NULL OR action    = $3)
+                AND rule_id IS NOT NULL
               GROUP BY LEFT(path, 256)
               ORDER BY total_events DESC
               LIMIT 20

--- a/crates/waf-storage/tests/repo_endpoint_heatmap.rs
+++ b/crates/waf-storage/tests/repo_endpoint_heatmap.rs
@@ -378,3 +378,46 @@ async fn heatmap_window_uses_make_interval_smoke() {
     assert_eq!(result.cells.len(), 1);
     assert_eq!(result.cells[0].path, "/boundary");
 }
+
+// ── 14 ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn heatmap_path_ranks_excludes_null_rule_id_paths() {
+    // path_ranks must filter NULL rule_id BEFORE the LIMIT 20 ranking,
+    // otherwise noisy non-WAF paths (e.g. health probes that produce
+    // security_events with NULL rule_id) push real attack paths out of
+    // the top-20 set entirely.
+    let fx = start_postgres().await;
+
+    // 21 distinct paths × 5 events each, all with NULL rule_id.
+    // Without the filter on path_ranks, these saturate the LIMIT 20.
+    for i in 0..21_u32 {
+        for _ in 0..5_u32 {
+            insert_event(fx.db.pool(), "h1", &format!("/noise/{i:02}"), None, "block", 1).await;
+        }
+    }
+    // One real attack path with a non-null rule_id — only 1 event.
+    insert_event(fx.db.pool(), "h1", "/api/attack", Some("SQLI-1"), "block", 1).await;
+
+    let result = fx
+        .db
+        .get_endpoint_heatmap(&HeatmapFilter {
+            hours: 24,
+            host_code: None,
+            action: None,
+        })
+        .await
+        .expect("query");
+
+    // With the filter on path_ranks, /noise/* paths never enter the LIMIT 20,
+    // so /api/attack survives. Without the filter, /api/attack ranks at #22
+    // (1 event vs. 5 each for the 21 noise paths) and disappears entirely.
+    assert_eq!(
+        result.cells.len(),
+        1,
+        "expected /api/attack to survive path_ranks; got cells {:?}",
+        result.cells.iter().map(|c| c.path.clone()).collect::<Vec<_>>()
+    );
+    assert_eq!(result.cells[0].path, "/api/attack");
+    assert_eq!(result.cells[0].category, "sqli");
+}


### PR DESCRIPTION
## Summary

`get_endpoint_heatmap` ranks the top-20 endpoint paths in `path_ranks`
before joining categories. The companion `scoped` and `category_top`
CTEs filter `rule_id IS NOT NULL`, but `path_ranks` did not — so non-WAF
events (health probes and other infrastructure noise that land in
`security_events` with NULL `rule_id`) could saturate the LIMIT 20 and
push real attack paths out of the heatmap entirely. Affects FR-030
attack-visualisation correctness.

## What changed

- `crates/waf-storage/src/repo.rs`
  - `path_ranks` CTE WHERE clause now includes `AND rule_id IS NOT NULL`,
    matching the existing filter on `scoped` and `category_top`.
  - Comment updated to document the shared invariant across all three
    CTEs and the rationale (keeps non-WAF noise out of the LIMIT-20 set).

- `crates/waf-storage/tests/repo_endpoint_heatmap.rs`
  - New regression test `heatmap_path_ranks_excludes_null_rule_id_paths`:
    inserts 21 distinct paths × 5 NULL-rule_id events + 1 real attack
    path with a single SQLI event. Without the fix the attack path is
    ranked at #22 and never enters the result; with the fix it survives
    and is the only cell.

## Test plan

- [ ] `cargo test -p waf-storage --test repo_endpoint_heatmap` passes
      (existing 13 tests + 1 new = 14).
- [ ] `cargo fmt --all -- --check` clean.
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [ ] Coverage (waf-storage) gate remains green.

Refs sub-item 4 of issue #74.