### PR TITLE
fix(storage): use category_of() in stats timeseries by category (#74.6)

### DIFF
--- a/crates/waf-api/tests/handler_stats_logs.rs
+++ b/crates/waf-api/tests/handler_stats_logs.rs
@@ -181,7 +181,47 @@ async fn stats_timeseries_by_category_buckets_seeded_event() {
     let body: serde_json::Value = resp.json().await.expect("json");
     let data = body["data"].as_array().expect("array");
     assert!(!data.is_empty(), "seeded SQLI-007 event must surface, got: {body}");
-    // The CASE expression maps `SQLI-%` rule_id to category `sqli`.
+    // `category_of(rule_id)` maps SQLI-* prefixes to category `sqli`.
     assert_eq!(data[0]["category"].as_str().expect("category"), "sqli");
     assert!(data[0]["count"].as_i64().unwrap_or(0) >= 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stats_timeseries_by_category_honours_category_of_prefix_priority() {
+    // Locks in the DRY refactor that replaced this query's inline CASE with
+    // `category_of(rule_id)`. The function gives `ADV-SSRF-*` priority over
+    // the generic `ADV-*` fallback — if a future change re-introduces a
+    // hand-rolled CASE that orders branches incorrectly (`ADV-%` before
+    // `ADV-SSRF%`), this test fails because the category surfaces as
+    // `advanced` instead of `ssrf`.
+    let s = start_test_server().await;
+    s.db.create_security_event(CreateSecurityEvent {
+        host_code: "h1".into(),
+        client_ip: "1.2.3.4".into(),
+        method: "GET".into(),
+        path: "/x".into(),
+        rule_id: Some("ADV-SSRF-001".into()),
+        rule_name: "x".into(),
+        action: "block".into(),
+        detail: None,
+        geo_info: None,
+    })
+    .await
+    .expect("seed event");
+
+    let resp = client()
+        .get(url_for(s.addr, "/api/stats/timeseries-by-category?hours=1"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.expect("json");
+    let data = body["data"].as_array().expect("array");
+    assert!(!data.is_empty(), "seeded ADV-SSRF-001 event must surface, got: {body}");
+    assert_eq!(
+        data[0]["category"].as_str().expect("category"),
+        "ssrf",
+        "ADV-SSRF-* must map to 'ssrf' (longer-prefix priority over ADV-* fallback)"
+    );
 }

--- a/crates/waf-storage/src/repo.rs
+++ b/crates/waf-storage/src/repo.rs
@@ -1352,49 +1352,20 @@ impl Database {
         host_code: Option<&str>,
         hours: i64,
     ) -> Result<Vec<CategoryTimeSeriesPoint>, StorageError> {
+        // Inline CASE replaced by category_of(rule_id) (DRY refactor).
+        // The category_of() Postgres function is defined in
+        // 0011_category_function.sql and is the single source of truth shared
+        // with get_stats_overview, get_attack_logs, and get_endpoint_heatmap.
         let rows: Vec<CategoryTimeSeriesPoint> = sqlx::query(
             "SELECT \
                 date_trunc('hour', created_at) AS ts, \
-                CASE \
-                    WHEN rule_id LIKE 'SQLI-%'        THEN 'sqli' \
-                    WHEN rule_id LIKE 'XSS-%'         THEN 'xss' \
-                    WHEN rule_id LIKE 'RCE-%'         THEN 'rce' \
-                    WHEN rule_id LIKE 'TRAV-%'        THEN 'path-traversal' \
-                    WHEN rule_id LIKE 'SCAN-%'        THEN 'scanner' \
-                    WHEN rule_id LIKE 'BOT-%'         THEN 'bot' \
-                    WHEN rule_id LIKE 'CC-%'          THEN 'cc-ddos' \
-                    WHEN rule_id LIKE 'SSRF-%'        THEN 'ssrf' \
-                    WHEN rule_id LIKE 'ADV-SSRF%'     THEN 'ssrf' \
-                    WHEN rule_id LIKE 'ADV-SSTI%'     THEN 'ssti' \
-                    WHEN rule_id LIKE 'ADV-%'         THEN 'advanced' \
-                    WHEN rule_id LIKE 'CRS-RESP%'     THEN 'data-leakage' \
-                    WHEN rule_id LIKE 'CRS-%'         THEN 'owasp-crs' \
-                    WHEN rule_id LIKE 'API-MASS%'     THEN 'mass-assignment' \
-                    WHEN rule_id LIKE 'API-%'         THEN 'api-security' \
-                    WHEN rule_id LIKE 'MODSEC-RESP%'  THEN 'web-shell' \
-                    WHEN rule_id LIKE 'MODSEC-%'      THEN 'modsecurity' \
-                    WHEN rule_id LIKE 'CVE-%'         THEN 'cve' \
-                    WHEN rule_id LIKE 'GEO-%'         THEN 'geo-blocking' \
-                    WHEN rule_id LIKE 'CUSTOM-%'      THEN 'custom' \
-                    WHEN rule_id LIKE 'IP-%'          THEN 'ip-rule' \
-                    WHEN rule_id LIKE 'URL-%'         THEN 'url-rule' \
-                    WHEN rule_id LIKE 'SENS-%'        THEN 'sensitive-data' \
-                    WHEN rule_id LIKE 'HOTLINK-%'     THEN 'anti-hotlink' \
-                    WHEN rule_id LIKE 'OWASP-942%'    THEN 'sqli' \
-                    WHEN rule_id LIKE 'OWASP-941%'    THEN 'xss' \
-                    WHEN rule_id LIKE 'OWASP-930%'    THEN 'lfi' \
-                    WHEN rule_id LIKE 'OWASP-931%'    THEN 'rfi' \
-                    WHEN rule_id LIKE 'OWASP-932%'    THEN 'rce' \
-                    WHEN rule_id LIKE 'OWASP-933%'    THEN 'php-injection' \
-                    WHEN rule_id LIKE 'OWASP-913%'    THEN 'scanner' \
-                    ELSE 'other' \
-                END AS category, \
+                category_of(rule_id) AS category, \
                 COUNT(*)::bigint AS cnt \
              FROM security_events \
              WHERE created_at >= NOW() - make_interval(hours => $1::int) \
                AND ($2::text IS NULL OR host_code = $2) \
                AND rule_id IS NOT NULL \
-             GROUP BY date_trunc('hour', created_at), category \
+             GROUP BY date_trunc('hour', created_at), category_of(rule_id) \
              ORDER BY ts ASC, category ASC",
         )
         .bind(i32::try_from(hours).unwrap_or(i32::MAX))


### PR DESCRIPTION
## Summary

`get_stats_timeseries_by_category` still inlined the per-prefix CASE
expression that migration `0011_category_function.sql` centralised into
the `category_of(rule_id)` SQL function. The companion repository
methods (`get_stats_overview`, `get_attack_logs`, and
`get_endpoint_heatmap`) had already moved across; this one was missed,
so any future tweak to category naming would have to be applied in two
places or risk silent drift between the timeseries chart and the rest
of the dashboard.

## What changed

- `crates/waf-storage/src/repo.rs`
  - Replaces the 33-line inline `CASE WHEN rule_id LIKE …` with
    `category_of(rule_id) AS category`. `GROUP BY` now references the
    function expression directly, matching the pattern in the sister
    methods. Behaviour is byte-identical to the previous CASE — the
    function body in `0011_category_function.sql` is the same mapping
    in the same order.

- `crates/waf-api/tests/handler_stats_logs.rs`
  - Refreshes the stale "CASE expression maps …" comment on the
    existing `..._buckets_seeded_event` test to mention `category_of()`.
  - New integration test `…_honours_category_of_prefix_priority` seeds
    an `ADV-SSRF-001` event and asserts the surfaced category is
    `ssrf` (not `advanced`). Locks in the prefix-priority semantic that
    a hand-rolled CASE could easily mis-order on re-introduction.

## Test plan

- [ ] `cargo test -p waf-api --test handler_stats_logs` passes (existing
      + 1 new).
- [ ] `cargo fmt --all -- --check` clean.
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [ ] Coverage (waf-storage) gate remains green.

Refs sub-item 6 of issue #74.