### PR TITLE
fix(api): re-validate WS JWT on heartbeat tick

### DIFF
--- a/crates/waf-api/src/websocket.rs
+++ b/crates/waf-api/src/websocket.rs
@@ -127,10 +127,17 @@ async fn auth_and_upgrade(
             .into_response();
     }
 
-    ws.on_upgrade(move |socket| handle_ws(socket, state, stream))
+    ws.on_upgrade(move |socket| handle_ws(socket, state, stream, token))
 }
 
-async fn handle_ws(mut socket: WebSocket, state: Arc<AppState>, stream: &'static str) {
+/// Returns `true` when the heartbeat tick must terminate the connection
+/// because the bound JWT no longer validates (expired, revoked, or signed
+/// with a now-rotated secret). Pure helper extracted for unit-testing.
+fn jwt_requires_close(token: &str, secret: &str) -> bool {
+    validate_access_token(token, secret).is_err()
+}
+
+async fn handle_ws(mut socket: WebSocket, state: Arc<AppState>, stream: &'static str, token: String) {
     // Subscribe to the Database's real-time event broadcast channel
     let mut rx = state.db.subscribe_events();
     let mut ping_interval = interval(Duration::from_secs(30));
@@ -155,8 +162,15 @@ async fn handle_ws(mut socket: WebSocket, state: Arc<AppState>, stream: &'static
                 }
             }
 
-            // Heartbeat ping
+            // Heartbeat ping — also re-validates the bound JWT so an expired
+            // or revoked token cannot keep streaming audit data for the rest
+            // of the connection lifetime.
             _ = ping_interval.tick() => {
+                if jwt_requires_close(&token, &state.jwt_secret) {
+                    warn!(stream, "WS JWT no longer valid — closing socket");
+                    let _ = socket.send(Message::Close(None)).await;
+                    break;
+                }
                 if socket.send(Message::Ping(vec![].into())).await.is_err() {
                     break;
                 }
@@ -173,4 +187,37 @@ async fn handle_ws(mut socket: WebSocket, state: Arc<AppState>, stream: &'static
     }
 
     state.ws_connections.fetch_sub(1, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::auth::generate_access_token;
+    use uuid::Uuid;
+
+    #[test]
+    fn jwt_requires_close_true_for_garbage_token() {
+        assert!(jwt_requires_close("not-a-jwt", "secret"));
+    }
+
+    #[test]
+    fn jwt_requires_close_true_for_wrong_secret() {
+        // A token signed with one secret must fail validation under another —
+        // this is the path a rotated jwt_secret takes when a long-lived WS
+        // session is still streaming.
+        let token = generate_access_token(Uuid::new_v4(), "admin", "admin", "old-secret")
+            .expect("issue token");
+        assert!(jwt_requires_close(&token, "new-secret"));
+    }
+
+    #[test]
+    fn jwt_requires_close_false_for_fresh_token() {
+        // A token signed with the same secret and not yet expired must keep
+        // the heartbeat path open.
+        let secret = "shared-secret";
+        let token = generate_access_token(Uuid::new_v4(), "admin", "admin", secret)
+            .expect("issue token");
+        assert!(!jwt_requires_close(&token, secret));
+    }
 }

--- a/crates/waf-api/src/websocket.rs
+++ b/crates/waf-api/src/websocket.rs
@@ -206,8 +206,7 @@ mod tests {
         // A token signed with one secret must fail validation under another —
         // this is the path a rotated jwt_secret takes when a long-lived WS
         // session is still streaming.
-        let token = generate_access_token(Uuid::new_v4(), "admin", "admin", "old-secret")
-            .expect("issue token");
+        let token = generate_access_token(Uuid::new_v4(), "admin", "admin", "old-secret").expect("issue token");
         assert!(jwt_requires_close(&token, "new-secret"));
     }
 
@@ -216,8 +215,7 @@ mod tests {
         // A token signed with the same secret and not yet expired must keep
         // the heartbeat path open.
         let secret = "shared-secret";
-        let token = generate_access_token(Uuid::new_v4(), "admin", "admin", secret)
-            .expect("issue token");
+        let token = generate_access_token(Uuid::new_v4(), "admin", "admin", secret).expect("issue token");
         assert!(!jwt_requires_close(&token, secret));
     }
 }


### PR DESCRIPTION
## Summary

`auth_and_upgrade` validated the JWT once at upgrade then `handle_ws`
streamed audit / security events forever — for the entire 24h default
JWT lifetime. If the bearer token expired, the admin user was deleted,
or the JWT secret was rotated, the open WebSocket kept forwarding
sensitive event data until the client disconnected. Affects FR-029
(dashboard live feed) and FR-032 (audit log access control).

## What changed

- `crates/waf-api/src/websocket.rs`
  - `auth_and_upgrade` now threads the bearer `token` into the upgrade
    closure rather than discarding it post-validation. `handle_ws` takes
    an extra `token: String` parameter.
  - The heartbeat `ping_interval.tick()` arm calls a new pure helper
    `jwt_requires_close(token, secret)` before sending the ping. On
    `true` it emits a `WARN` log naming the stream, sends a clean
    `Message::Close(None)` frame to the client, and breaks the loop —
    which also frees the `MAX_WS_CONNECTIONS` slot via the existing
    cleanup at the end of `handle_ws`.
  - Three new unit tests for `jwt_requires_close`:
    - garbage token (parse failure)
    - token signed with a now-rotated secret
    - freshly issued token (must keep the connection open)

The previously single-shot auth-and-upgrade comment is updated to
reflect the new periodic check.

## Test plan

- [ ] `cargo test -p waf-api websocket` passes the 3 new tests.
- [ ] `cargo fmt --all -- --check` clean.
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [ ] Coverage (waf-api) gate remains green.