### PR TITLE
fix(api): enforce admin role on WS upgrade and heartbeat re-check

### DIFF
--- a/crates/waf-api/src/auth.rs
+++ b/crates/waf-api/src/auth.rs
@@ -60,6 +60,19 @@ pub fn validate_access_token(token: &str, secret: &str) -> anyhow::Result<Claims
     Ok(data.claims)
 }
 
+/// Validate an access token AND require the bearer to carry the `admin` role.
+///
+/// Returns the decoded claims on success. Signature failures, expiry, missing
+/// claims, and any non-`admin` role all map to an error. Callers MUST reject
+/// the request on `Err` — there is no "soft fail" branch.
+pub fn validate_admin_token(token: &str, secret: &str) -> anyhow::Result<Claims> {
+    let claims = validate_access_token(token, secret)?;
+    if claims.role != "admin" {
+        anyhow::bail!("admin role required");
+    }
+    Ok(claims)
+}
+
 pub fn hash_token(token: &str) -> String {
     let mut h = Sha256::new();
     h.update(token.as_bytes());
@@ -316,6 +329,34 @@ mod tests {
         let user_id = uuid::Uuid::new_v4();
         let token = generate_access_token(user_id, "bob", "user", "secret1").unwrap();
         let result = validate_access_token(&token, "secret2");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_admin_token_accepts_admin_role() {
+        let user_id = uuid::Uuid::new_v4();
+        let secret = "admin-gate-secret";
+        let token = generate_access_token(user_id, "alice", "admin", secret).unwrap();
+        let claims = validate_admin_token(&token, secret).expect("admin claims");
+        assert_eq!(claims.role, "admin");
+    }
+
+    #[test]
+    fn validate_admin_token_rejects_non_admin_role() {
+        // viewer / readonly / any future non-admin role must be denied at the
+        // gate even though the signature and expiry are otherwise valid.
+        let user_id = uuid::Uuid::new_v4();
+        let secret = "admin-gate-secret";
+        let token = generate_access_token(user_id, "carol", "viewer", secret).unwrap();
+        let err = validate_admin_token(&token, secret).expect_err("viewer must be denied");
+        assert!(err.to_string().contains("admin role required"));
+    }
+
+    #[test]
+    fn validate_admin_token_rejects_invalid_token() {
+        // Garbage token must fail at the signature check before the role
+        // check ever runs.
+        let result = validate_admin_token("not-a-jwt", "any-secret");
         assert!(result.is_err());
     }
 

--- a/crates/waf-api/src/websocket.rs
+++ b/crates/waf-api/src/websocket.rs
@@ -28,7 +28,7 @@ use serde_json::json;
 use tokio::time::interval;
 use tracing::warn;
 
-use crate::auth::validate_access_token;
+use crate::auth::validate_admin_token;
 use crate::state::AppState;
 
 #[derive(Deserialize)]
@@ -112,7 +112,7 @@ async fn auth_and_upgrade(
             .into_response();
     };
 
-    if validate_access_token(&token, &state.jwt_secret).is_err() {
+    if validate_admin_token(&token, &state.jwt_secret).is_err() {
         return (StatusCode::UNAUTHORIZED, Json(json!({ "error": "invalid token" }))).into_response();
     }
 
@@ -131,10 +131,11 @@ async fn auth_and_upgrade(
 }
 
 /// Returns `true` when the heartbeat tick must terminate the connection
-/// because the bound JWT no longer validates (expired, revoked, or signed
-/// with a now-rotated secret). Pure helper extracted for unit-testing.
+/// because the bound JWT no longer satisfies the admin gate — expired,
+/// revoked, signed with a now-rotated secret, or role demoted away from
+/// `admin`. Pure helper extracted for unit-testing.
 fn jwt_requires_close(token: &str, secret: &str) -> bool {
-    validate_access_token(token, secret).is_err()
+    validate_admin_token(token, secret).is_err()
 }
 
 async fn handle_ws(mut socket: WebSocket, state: Arc<AppState>, stream: &'static str, token: String) {
@@ -211,11 +212,21 @@ mod tests {
     }
 
     #[test]
-    fn jwt_requires_close_false_for_fresh_token() {
-        // A token signed with the same secret and not yet expired must keep
-        // the heartbeat path open.
+    fn jwt_requires_close_false_for_fresh_admin_token() {
+        // A token signed with the same secret, not yet expired, and carrying
+        // the admin role must keep the heartbeat path open.
         let secret = "shared-secret";
         let token = generate_access_token(Uuid::new_v4(), "admin", "admin", secret).expect("issue token");
         assert!(!jwt_requires_close(&token, secret));
+    }
+
+    #[test]
+    fn jwt_requires_close_true_for_non_admin_role() {
+        // A valid JWT carrying a viewer / read-only role must NOT be allowed
+        // to keep streaming — admin-only is the contract for /ws/events and
+        // /ws/logs because both forward sensitive audit payloads.
+        let secret = "shared-secret";
+        let token = generate_access_token(Uuid::new_v4(), "carol", "viewer", secret).expect("issue token");
+        assert!(jwt_requires_close(&token, secret));
     }
 }


### PR DESCRIPTION
## Summary

`auth_and_upgrade` and the heartbeat re-check both called
`validate_access_token`, which only verifies signature and expiry. Any
caller with a valid JWT — including future viewer / read-only roles —
could subscribe to `/ws/events` or `/ws/logs` and receive the full
security-event payload (attacker IPs, PII, redacted-or-not body
samples). The HTTP audit handlers in `logs.rs` already gated this
behind `require_admin`; the WebSocket path did not. Affects FR-029
(live request feed) and FR-032 (audit log access control).

## What changed

- `crates/waf-api/src/auth.rs`
  - New `validate_admin_token(token, secret) -> anyhow::Result<Claims>`
    helper. Chains `validate_access_token` with a `role == "admin"`
    assertion; returns the claims on success. Three new unit tests
    cover the helper directly: admin allowed, viewer rejected (carries
    `admin role required` in the error message), garbage rejected.

- `crates/waf-api/src/websocket.rs`
  - `auth_and_upgrade`: swap the `validate_access_token` call for
    `validate_admin_token`. A non-admin caller now gets the existing
    `UNAUTHORIZED / "invalid token"` response.
  - `jwt_requires_close`: same swap, so a mid-session role demotion is
    caught by the next 30-s heartbeat tick and the socket is closed via
    the path the previous fix wired up.
  - One new unit test asserts that a freshly issued viewer-role token
    under a valid secret returns `true` from `jwt_requires_close` —
    locks the regression that would re-open the bypass.

`logs.rs::require_admin` is intentionally left unchanged for this PR —
it already enforces the role gate via a header-extraction path that
preserves distinct error messages.

## Test plan

- [ ] `cargo test -p waf-api auth` covers the 3 new helper tests.
- [ ] `cargo test -p waf-api websocket` covers the new viewer-role test.
- [ ] `cargo fmt --all -- --check` clean.
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [ ] Coverage (waf-api) gate remains green.