### PR TITLE
feat(engine,api): port CrowdSec circuit breaker + dynamic log-level control from main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ sqlx = { version = "0.8", default-features = false, features = ["postgres", "run
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 anyhow = "1"
 thiserror = "2"
 dashmap = "6"

--- a/crates/gateway/src/proxy.rs
+++ b/crates/gateway/src/proxy.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 use pingora_core::upstreams::peer::{HttpPeer, Peer};
 use pingora_proxy::{FailToProxy, ProxyHttp, Session};
@@ -485,7 +485,7 @@ impl ProxyHttp for WafProxy {
             ctx.request_ctx = Some(builder.build());
         }
 
-        info!("Proxying {} → {}", host_header, upstream_addr);
+        debug!("Proxying {} → {}", host_header, upstream_addr);
         let mut peer = HttpPeer::new(&upstream_addr, use_tls, host_config.remote_host.clone());
         apply_fr039_timeouts(&mut peer, &host_config);
         apply_upstream_alpn(&mut peer, &host_config);

--- a/crates/prx-waf/src/main.rs
+++ b/crates/prx-waf/src/main.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::{EnvFilter, fmt, prelude::*, reload};
 use anyhow::Context;
 use gateway::{HostRouter, TunnelConfig, WafProxy};
 use pingora_core::listeners::tls::TlsSettings;
-use waf_api::{AppState, start_api_server};
+use waf_api::{AppState, LogLevelSetter, start_api_server};
 use waf_common::config::{AppConfig, load_config};
 use waf_engine::logging::{AuditSender, BatchConfig, LayerSlot, VictoriaLogsLayer, spawn_batch_flusher};
 use waf_engine::{
@@ -337,15 +337,14 @@ fn main() -> anyhow::Result<()> {
                 .block_on(run_seed_admin(&config))?;
         }
         Commands::Run => {
-            let log_level_setter: Arc<dyn Fn(&str) -> anyhow::Result<()> + Send + Sync> =
-                Arc::new(move |filter_str: &str| {
-                    let new_filter =
-                        EnvFilter::try_new(filter_str).map_err(|e| anyhow::anyhow!("invalid filter directive: {e}"))?;
-                    reload_handle
-                        .reload(new_filter)
-                        .map_err(|e| anyhow::anyhow!("failed to reload filter: {e}"))?;
-                    Ok(())
-                });
+            let log_level_setter: LogLevelSetter = Arc::new(move |filter_str: &str| {
+                let new_filter =
+                    EnvFilter::try_new(filter_str).map_err(|e| anyhow::anyhow!("invalid filter directive: {e}"))?;
+                reload_handle
+                    .reload(new_filter)
+                    .map_err(|e| anyhow::anyhow!("failed to reload filter: {e}"))?;
+                Ok(())
+            });
             run_server(&config, &cli.config, vlogs_layer_slot, Some(log_level_setter))?;
         }
         Commands::Crowdsec(sub) => {
@@ -1195,7 +1194,7 @@ fn run_server(
     config: &AppConfig,
     config_file_path: &str,
     vlogs_layer_slot: LayerSlot,
-    log_level_setter: Option<Arc<dyn Fn(&str) -> anyhow::Result<()> + Send + Sync>>,
+    log_level_setter: Option<LogLevelSetter>,
 ) -> anyhow::Result<()> {
     use pingora_core::server::Server;
 
@@ -1536,7 +1535,7 @@ async fn init_async(
     cluster_state: Option<Arc<waf_cluster::NodeState>>,
     panel_config_path: Option<std::path::PathBuf>,
     vlogs_layer_slot: LayerSlot,
-    log_level_setter: Option<Arc<dyn Fn(&str) -> anyhow::Result<()> + Send + Sync>>,
+    log_level_setter: Option<LogLevelSetter>,
 ) -> anyhow::Result<(
     Arc<WafEngine>,
     Arc<HostRouter>,

--- a/crates/prx-waf/src/main.rs
+++ b/crates/prx-waf/src/main.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use clap::{Parser, Subcommand};
 use tracing::{info, warn};
-use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+use tracing_subscriber::{EnvFilter, fmt, prelude::*, reload};
 
 use anyhow::Context;
 use gateway::{HostRouter, TunnelConfig, WafProxy};
@@ -305,12 +305,13 @@ fn main() -> anyhow::Result<()> {
     // that don't go through `run_server` are unaffected.
     let (vlogs_layer, vlogs_layer_slot) = VictoriaLogsLayer::new();
 
+    let env_filter =
+        EnvFilter::from_default_env().add_directive(tracing_subscriber::filter::Directive::from(tracing::Level::INFO));
+    let (filter_layer, reload_handle) = reload::Layer::new(env_filter);
+
     tracing_subscriber::registry()
+        .with(filter_layer)
         .with(fmt::layer())
-        .with(
-            EnvFilter::from_default_env()
-                .add_directive(tracing_subscriber::filter::Directive::from(tracing::Level::INFO)),
-        )
         .with(vlogs_layer)
         .init();
 
@@ -336,7 +337,16 @@ fn main() -> anyhow::Result<()> {
                 .block_on(run_seed_admin(&config))?;
         }
         Commands::Run => {
-            run_server(&config, &cli.config, vlogs_layer_slot)?;
+            let log_level_setter: Arc<dyn Fn(&str) -> anyhow::Result<()> + Send + Sync> =
+                Arc::new(move |filter_str: &str| {
+                    let new_filter =
+                        EnvFilter::try_new(filter_str).map_err(|e| anyhow::anyhow!("invalid filter directive: {e}"))?;
+                    reload_handle
+                        .reload(new_filter)
+                        .map_err(|e| anyhow::anyhow!("failed to reload filter: {e}"))?;
+                    Ok(())
+                });
+            run_server(&config, &cli.config, vlogs_layer_slot, Some(log_level_setter))?;
         }
         Commands::Crowdsec(sub) => {
             tokio::runtime::Builder::new_current_thread()
@@ -1151,6 +1161,8 @@ fn app_config_to_crowdsec(config: &AppConfig) -> CrowdSecConfig {
         api_key: config.crowdsec.appsec_key.clone().unwrap_or_default(),
         timeout_ms: config.crowdsec.appsec_timeout_ms,
         failure_action: FallbackAction::Allow,
+        circuit_breaker_threshold: 5,
+        circuit_breaker_reset_secs: 30,
     });
 
     let pusher = config
@@ -1179,7 +1191,12 @@ fn app_config_to_crowdsec(config: &AppConfig) -> CrowdSecConfig {
 }
 
 /// Start the full server: async init → API server thread → Pingora proxy
-fn run_server(config: &AppConfig, config_file_path: &str, vlogs_layer_slot: LayerSlot) -> anyhow::Result<()> {
+fn run_server(
+    config: &AppConfig,
+    config_file_path: &str,
+    vlogs_layer_slot: LayerSlot,
+    log_level_setter: Option<Arc<dyn Fn(&str) -> anyhow::Result<()> + Send + Sync>>,
+) -> anyhow::Result<()> {
     use pingora_core::server::Server;
 
     let rt = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
@@ -1220,6 +1237,7 @@ fn run_server(config: &AppConfig, config_file_path: &str, vlogs_layer_slot: Laye
         cluster_state_for_api,
         panel_config_path,
         vlogs_layer_slot,
+        log_level_setter,
     ))?;
 
     // Start the management API in a background thread
@@ -1518,6 +1536,7 @@ async fn init_async(
     cluster_state: Option<Arc<waf_cluster::NodeState>>,
     panel_config_path: Option<std::path::PathBuf>,
     vlogs_layer_slot: LayerSlot,
+    log_level_setter: Option<Arc<dyn Fn(&str) -> anyhow::Result<()> + Send + Sync>>,
 ) -> anyhow::Result<(
     Arc<WafEngine>,
     Arc<HostRouter>,
@@ -1769,6 +1788,8 @@ async fn init_async(
     if config.victoria_logs.enabled {
         api_state.victoria_logs_base_url = Some(config.victoria_logs.base_url());
     }
+
+    api_state.log_level_setter = log_level_setter;
 
     // Phase 4: create default admin user if none exist
     {

--- a/crates/waf-api/src/handlers.rs
+++ b/crates/waf-api/src/handlers.rs
@@ -704,6 +704,29 @@ pub async fn delete_certificate(State(state): State<Arc<AppState>>, Path(id): Pa
     Ok(Json(json!({ "success": true, "data": null })))
 }
 
+// ─── Log level ───────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct SetLogLevelRequest {
+    pub filter: String,
+}
+
+pub async fn set_log_level(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<SetLogLevelRequest>,
+) -> ApiResult<Json<Value>> {
+    if req.filter.len() > 256 {
+        return Err(ApiError::BadRequest("filter string exceeds 256 character limit".into()));
+    }
+    let setter = state
+        .log_level_setter
+        .as_ref()
+        .ok_or_else(|| ApiError::Internal(anyhow::anyhow!("log level control not initialized")))?;
+    setter(&req.filter).map_err(|e| ApiError::BadRequest(e.to_string()))?;
+    tracing::info!("Log filter updated to: {}", req.filter);
+    Ok(Json(json!({ "success": true, "data": { "filter": req.filter } })))
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -822,5 +845,20 @@ mod tests {
         let err = validate_pem_field(Some(big.as_str()), "chain_pem", cert_parser).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("exceeds"), "expected size error, got: {msg}");
+    }
+
+    // ── Dynamic log-level control ─────────────────────────────────────────────
+
+    #[test]
+    fn set_log_level_request_deserializes() {
+        let json = r#"{"filter": "info,waf_engine=debug"}"#;
+        let req: super::SetLogLevelRequest = serde_json::from_str(json).expect("parse");
+        assert_eq!(req.filter, "info,waf_engine=debug");
+    }
+
+    #[test]
+    fn set_log_level_filter_length_limit() {
+        let long_filter = "a".repeat(257);
+        assert!(long_filter.len() > 256, "test expects > 256 chars");
     }
 }

--- a/crates/waf-api/src/lib.rs
+++ b/crates/waf-api/src/lib.rs
@@ -22,4 +22,4 @@ pub mod tunnels;
 pub mod websocket;
 
 pub use server::start_api_server;
-pub use state::AppState;
+pub use state::{AppState, LogLevelSetter};

--- a/crates/waf-api/src/server.rs
+++ b/crates/waf-api/src/server.rs
@@ -33,8 +33,8 @@ use crate::handlers::{
     delete_certificate, delete_custom_rule, delete_host, delete_lb_backend, delete_sensitive_pattern, get_host,
     get_hotlink_config, get_security_event, get_status, list_allow_ips, list_allow_urls, list_attack_logs,
     list_block_ips, list_block_urls, list_certificates, list_custom_rules, list_hosts, list_lb_backends,
-    list_security_events, list_sensitive_patterns, reload_rules, reload_sqli_scan_config, update_custom_rule,
-    update_host, upload_certificate, upsert_hotlink_config,
+    list_security_events, list_sensitive_patterns, reload_rules, reload_sqli_scan_config, set_log_level,
+    update_custom_rule, update_host, upload_certificate, upsert_hotlink_config,
 };
 use crate::health::health_check;
 use crate::logs::{logs_query, logs_stats, logs_streams};
@@ -249,6 +249,8 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/v1/logs/query", get(logs_query))
         .route("/api/v1/logs/stats", get(logs_stats))
         .route("/api/v1/logs/streams", get(logs_streams))
+        // Dynamic log level control
+        .route("/api/admin/logs/level", post(set_log_level))
         .layer(middleware::from_fn_with_state(state.clone(), require_auth))
         .layer(middleware::from_fn_with_state(
             state.clone(),

--- a/crates/waf-api/src/state.rs
+++ b/crates/waf-api/src/state.rs
@@ -8,6 +8,11 @@ use waf_storage::Database;
 
 use crate::notifications::NotifRateLimiter;
 
+/// Setter closure handed by the binary boot path so admin handlers can
+/// reconfigure the global tracing filter at runtime. `None` when the
+/// dynamic reload layer is not wired (e.g. CLI sub-commands).
+pub type LogLevelSetter = Arc<dyn Fn(&str) -> anyhow::Result<()> + Send + Sync>;
+
 /// Shared application state for the API server.
 #[derive(Clone)]
 pub struct AppState {
@@ -66,8 +71,7 @@ pub struct AppState {
     /// only needs it to populate filter dropdowns.
     pub logs_streams_cache: Arc<crate::logs::StreamsCache>,
     /// Closure to change the global tracing filter at runtime.
-    /// `None` when the dynamic reload layer is not wired (e.g. CLI sub-commands).
-    pub log_level_setter: Option<Arc<dyn Fn(&str) -> anyhow::Result<()> + Send + Sync>>,
+    pub log_level_setter: Option<LogLevelSetter>,
 }
 
 impl AppState {

--- a/crates/waf-api/src/state.rs
+++ b/crates/waf-api/src/state.rs
@@ -65,6 +65,9 @@ pub struct AppState {
     /// distinct-value enumeration is expensive on `VictoriaLogs` and the FE
     /// only needs it to populate filter dropdowns.
     pub logs_streams_cache: Arc<crate::logs::StreamsCache>,
+    /// Closure to change the global tracing filter at runtime.
+    /// `None` when the dynamic reload layer is not wired (e.g. CLI sub-commands).
+    pub log_level_setter: Option<Arc<dyn Fn(&str) -> anyhow::Result<()> + Send + Sync>>,
 }
 
 impl AppState {
@@ -113,6 +116,7 @@ impl AppState {
             main_config_file: None,
             victoria_logs_base_url: None,
             logs_streams_cache: crate::logs::new_streams_cache(),
+            log_level_setter: None,
         })
     }
 

--- a/crates/waf-engine/src/crowdsec/appsec.rs
+++ b/crates/waf-engine/src/crowdsec/appsec.rs
@@ -5,6 +5,7 @@ use tracing::{debug, warn};
 
 use waf_common::{DetectionResult, Phase, RequestCtx};
 
+use super::circuit_breaker::AppSecCircuitBreaker;
 use super::config::AppSecConfig;
 use super::models::AppSecResponse;
 
@@ -23,9 +24,11 @@ pub enum AppSecResult {
 ///
 /// Implements the `CrowdSec` `AppSec` protocol: forward each request to the
 /// `AppSec` HTTP endpoint using special headers, then act on the response.
+/// A circuit breaker prevents cascade failures when the endpoint is down.
 pub struct AppSecClient {
     client: Client,
     config: AppSecConfig,
+    circuit_breaker: AppSecCircuitBreaker,
 }
 
 impl AppSecClient {
@@ -34,18 +37,39 @@ impl AppSecClient {
             .timeout(Duration::from_millis(config.timeout_ms))
             .build()
             .context("failed to build AppSec HTTP client")?;
-        Ok(Self { client, config })
+        let circuit_breaker =
+            AppSecCircuitBreaker::new(config.circuit_breaker_threshold, config.circuit_breaker_reset_secs);
+        Ok(Self {
+            client,
+            config,
+            circuit_breaker,
+        })
     }
 
     /// Check a request against the `CrowdSec` `AppSec` engine.
     ///
-    /// Returns `AppSecResult::Unavailable` on network/timeout errors so that
-    /// the caller can apply the configured `failure_action`.
+    /// Returns `AppSecResult::Unavailable` when the circuit breaker is open
+    /// or on network/timeout errors so that the caller can apply the
+    /// configured `failure_action`.
     pub async fn check_request(&self, ctx: &RequestCtx) -> AppSecResult {
+        if !self.circuit_breaker.check_allow() {
+            warn!("AppSec circuit breaker OPEN; returning fallback");
+            return AppSecResult::Unavailable;
+        }
         match self.check_request_inner(ctx).await {
-            Ok(r) => r,
+            Ok(AppSecResult::Unavailable) => {
+                // HTTP 401/500/bad-status returns Ok(Unavailable) — treat as failure
+                // so persistent server errors trip the circuit.
+                self.circuit_breaker.on_failure();
+                AppSecResult::Unavailable
+            }
+            Ok(result) => {
+                self.circuit_breaker.on_success();
+                result
+            }
             Err(e) => {
                 warn!("AppSec check error: {}", e);
+                self.circuit_breaker.on_failure();
                 AppSecResult::Unavailable
             }
         }
@@ -124,6 +148,8 @@ mod tests {
             api_key: "k".to_string(),
             timeout_ms: 200,
             failure_action: FallbackAction::Allow,
+            circuit_breaker_threshold: 5,
+            circuit_breaker_reset_secs: 30,
         }
     }
 
@@ -173,5 +199,29 @@ mod tests {
         // Endpoint is unreachable — we just exercise the body branch.
         let result = client.check_request(&c).await;
         assert!(matches!(result, AppSecResult::Unavailable));
+    }
+
+    #[tokio::test]
+    async fn circuit_breaker_opens_after_repeated_failures() {
+        let mut config = cfg();
+        config.circuit_breaker_threshold = 2;
+        let client = AppSecClient::new(config).expect("client");
+        let c = ctx();
+        // First 2 requests hit the unreachable endpoint and fail.
+        let _ = client.check_request(&c).await;
+        let _ = client.check_request(&c).await;
+        // Third request should be short-circuited by the circuit breaker
+        // (no HTTP call, immediate Unavailable).
+        let start = std::time::Instant::now();
+        let result = client.check_request(&c).await;
+        let elapsed = start.elapsed();
+        assert!(matches!(result, AppSecResult::Unavailable));
+        // Circuit-breaker short-circuit should be near-instant (< 5ms),
+        // much faster than the 200ms timeout.
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "expected fast short-circuit, took {:?}",
+            elapsed
+        );
     }
 }

--- a/crates/waf-engine/src/crowdsec/appsec.rs
+++ b/crates/waf-engine/src/crowdsec/appsec.rs
@@ -220,8 +220,7 @@ mod tests {
         // much faster than the 200ms timeout.
         assert!(
             elapsed < Duration::from_millis(50),
-            "expected fast short-circuit, took {:?}",
-            elapsed
+            "expected fast short-circuit, took {elapsed:?}",
         );
     }
 }

--- a/crates/waf-engine/src/crowdsec/circuit_breaker.rs
+++ b/crates/waf-engine/src/crowdsec/circuit_breaker.rs
@@ -1,0 +1,218 @@
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use tracing::info;
+
+/// Internal state of the circuit breaker.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum CircuitState {
+    /// Normal operation; tracks consecutive failure count.
+    Closed { failure_count: u32 },
+    /// Too many failures; all requests short-circuit until cooldown expires.
+    Open { opened_at: Instant },
+    /// Cooldown elapsed; exactly one probe request is allowed through.
+    HalfOpen,
+}
+
+/// Circuit breaker for CrowdSec AppSec HTTP checks.
+///
+/// Tracks consecutive failures and opens the circuit after `threshold`
+/// failures. After `reset_duration` elapses the circuit enters half-open
+/// state to allow a single probe request.
+pub struct AppSecCircuitBreaker {
+    /// All mutable state inside one mutex to avoid TOCTOU races.
+    state: Mutex<CircuitState>,
+    /// Number of consecutive failures required to open the circuit.
+    threshold: u32,
+    /// How long the circuit stays open before transitioning to half-open.
+    reset_duration: Duration,
+}
+
+impl AppSecCircuitBreaker {
+    /// Create a new circuit breaker.
+    ///
+    /// `threshold` is clamped to a minimum of 1 (threshold=0 is ambiguous).
+    pub fn new(threshold: u32, reset_secs: u64) -> Self {
+        Self {
+            state: Mutex::new(CircuitState::Closed { failure_count: 0 }),
+            threshold: threshold.max(1),
+            reset_duration: Duration::from_secs(reset_secs),
+        }
+    }
+
+    /// Returns `true` if the request should proceed, `false` to short-circuit.
+    ///
+    /// When the circuit is Open and the cooldown has elapsed, transitions to
+    /// HalfOpen and allows one probe request through.
+    pub fn check_allow(&self) -> bool {
+        let mut state = self.state.lock();
+        match *state {
+            CircuitState::Closed { .. } => true,
+            CircuitState::Open { opened_at } => {
+                if opened_at.elapsed() >= self.reset_duration {
+                    *state = CircuitState::HalfOpen;
+                    info!("AppSec circuit breaker transitioning to HalfOpen");
+                    true
+                } else {
+                    false
+                }
+            }
+            CircuitState::HalfOpen => {
+                // Only one probe is allowed; subsequent calls while still
+                // HalfOpen are blocked until the probe completes.
+                false
+            }
+        }
+    }
+
+    /// Record a successful request. Resets failure count / closes the circuit.
+    pub fn on_success(&self) {
+        let mut state = self.state.lock();
+        let was_half_open = matches!(*state, CircuitState::HalfOpen);
+        *state = CircuitState::Closed { failure_count: 0 };
+        if was_half_open {
+            info!("AppSec circuit breaker closed after successful probe");
+        }
+    }
+
+    /// Record a failed request. Increments failure count and may open the circuit.
+    pub fn on_failure(&self) {
+        let mut state = self.state.lock();
+        match *state {
+            CircuitState::Closed { failure_count } => {
+                let new_count = failure_count + 1;
+                if new_count >= self.threshold {
+                    *state = CircuitState::Open {
+                        opened_at: Instant::now(),
+                    };
+                    info!(
+                        threshold = self.threshold,
+                        "AppSec circuit breaker OPENED after {} consecutive failures", new_count,
+                    );
+                } else {
+                    *state = CircuitState::Closed {
+                        failure_count: new_count,
+                    };
+                }
+            }
+            CircuitState::HalfOpen => {
+                // Probe failed — reopen.
+                *state = CircuitState::Open {
+                    opened_at: Instant::now(),
+                };
+                info!("AppSec circuit breaker re-opened after failed probe");
+            }
+            CircuitState::Open { .. } => {
+                // Already open; nothing to do.
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    #[test]
+    fn starts_closed_and_allows_requests() {
+        let cb = AppSecCircuitBreaker::new(3, 30);
+        assert!(cb.check_allow());
+    }
+
+    #[test]
+    fn n_consecutive_failures_open_circuit() {
+        let cb = AppSecCircuitBreaker::new(3, 30);
+        cb.on_failure();
+        assert!(cb.check_allow(), "1 failure: still closed");
+        cb.on_failure();
+        assert!(cb.check_allow(), "2 failures: still closed");
+        cb.on_failure();
+        assert!(!cb.check_allow(), "3 failures: circuit should be open");
+    }
+
+    #[test]
+    fn open_transitions_to_half_open_after_reset() {
+        let cb = AppSecCircuitBreaker::new(1, 60);
+        cb.on_failure();
+        assert!(!cb.check_allow(), "circuit should be open with long reset");
+
+        // Separate CB with 0s reset to test the HalfOpen transition.
+        let cb2 = AppSecCircuitBreaker::new(1, 0);
+        cb2.on_failure();
+        thread::sleep(Duration::from_millis(1));
+        assert!(cb2.check_allow(), "should transition to HalfOpen and allow probe");
+    }
+
+    #[test]
+    fn half_open_success_closes_circuit() {
+        let cb = AppSecCircuitBreaker::new(1, 0);
+        cb.on_failure(); // open
+        thread::sleep(Duration::from_millis(1));
+        assert!(cb.check_allow()); // transitions to HalfOpen, allows probe
+        cb.on_success(); // probe succeeded — close
+        // Circuit is now closed; should allow freely.
+        assert!(cb.check_allow());
+        assert!(cb.check_allow());
+    }
+
+    #[test]
+    fn half_open_failure_reopens_circuit() {
+        let cb = AppSecCircuitBreaker::new(1, 0);
+        cb.on_failure(); // open
+        thread::sleep(Duration::from_millis(1));
+        assert!(cb.check_allow()); // transitions to HalfOpen, allows probe
+        cb.on_failure(); // probe failed — reopens circuit
+
+        // Verify it went back to Open (and with 0s reset, immediately
+        // transitions to HalfOpen on next check — still proves the
+        // Open→HalfOpen→failure→Open round-trip).
+        thread::sleep(Duration::from_millis(1));
+        assert!(cb.check_allow()); // HalfOpen again after reopen expired
+        // Now succeed to close it, proving the full cycle.
+        cb.on_success();
+        assert!(cb.check_allow(), "circuit should be closed after success");
+    }
+
+    #[test]
+    fn success_resets_failure_count() {
+        let cb = AppSecCircuitBreaker::new(3, 30);
+        cb.on_failure();
+        cb.on_failure();
+        // 2 failures, then a success should reset count.
+        cb.on_success();
+        // Need 3 more failures to open, not just 1.
+        cb.on_failure();
+        assert!(cb.check_allow(), "failure count should have been reset");
+    }
+
+    #[test]
+    fn threshold_zero_clamped_to_one() {
+        let cb = AppSecCircuitBreaker::new(0, 30);
+        // threshold clamped to 1, so a single failure opens.
+        cb.on_failure();
+        assert!(!cb.check_allow());
+    }
+
+    #[test]
+    fn concurrent_access_is_safe() {
+        use std::sync::Arc;
+        let cb = Arc::new(AppSecCircuitBreaker::new(100, 30));
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let cb_clone = Arc::clone(&cb);
+            handles.push(thread::spawn(move || {
+                for _ in 0..50 {
+                    cb_clone.on_failure();
+                    let _ = cb_clone.check_allow();
+                    cb_clone.on_success();
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        // No panic means thread-safe. Circuit should be closed since last ops were on_success.
+        assert!(cb.check_allow());
+    }
+}

--- a/crates/waf-engine/src/crowdsec/circuit_breaker.rs
+++ b/crates/waf-engine/src/crowdsec/circuit_breaker.rs
@@ -14,7 +14,7 @@ enum CircuitState {
     HalfOpen,
 }
 
-/// Circuit breaker for CrowdSec AppSec HTTP checks.
+/// Circuit breaker for `CrowdSec` `AppSec` HTTP checks.
 ///
 /// Tracks consecutive failures and opens the circuit after `threshold`
 /// failures. After `reset_duration` elapses the circuit enters half-open
@@ -28,6 +28,10 @@ pub struct AppSecCircuitBreaker {
     reset_duration: Duration,
 }
 
+// The mutex guard lives across each transition match by design — the TOCTOU
+// rationale documented on `state` is the whole point of the breaker. Clippy
+// would have us copy-out / drop-early, which re-opens the race.
+#[allow(clippy::significant_drop_tightening)]
 impl AppSecCircuitBreaker {
     /// Create a new circuit breaker.
     ///
@@ -43,7 +47,7 @@ impl AppSecCircuitBreaker {
     /// Returns `true` if the request should proceed, `false` to short-circuit.
     ///
     /// When the circuit is Open and the cooldown has elapsed, transitions to
-    /// HalfOpen and allows one probe request through.
+    /// `HalfOpen` and allows one probe request through.
     pub fn check_allow(&self) -> bool {
         let mut state = self.state.lock();
         match *state {

--- a/crates/waf-engine/src/crowdsec/config.rs
+++ b/crates/waf-engine/src/crowdsec/config.rs
@@ -90,6 +90,12 @@ pub struct AppSecConfig {
     /// Action when `AppSec` is unavailable
     #[serde(default)]
     pub failure_action: FallbackAction,
+    /// Number of consecutive failures before the circuit breaker opens
+    #[serde(default = "default_cb_threshold")]
+    pub circuit_breaker_threshold: u32,
+    /// Seconds the circuit stays open before allowing a probe request
+    #[serde(default = "default_cb_reset_secs")]
+    pub circuit_breaker_reset_secs: u64,
 }
 
 /// Log pusher configuration (machine credentials)
@@ -106,6 +112,12 @@ const fn default_update_frequency() -> u64 {
 }
 const fn default_appsec_timeout() -> u64 {
     500
+}
+const fn default_cb_threshold() -> u32 {
+    5
+}
+const fn default_cb_reset_secs() -> u64 {
+    30
 }
 
 #[cfg(test)]
@@ -157,5 +169,17 @@ mod tests {
             let back: FallbackAction = serde_json::from_str(&s).expect("de");
             assert_eq!(a, back);
         }
+    }
+
+    #[test]
+    fn appsec_config_circuit_breaker_defaults_from_json() {
+        let raw = r#"{
+            "endpoint": "http://localhost:7422",
+            "api_key": "test-key"
+        }"#;
+        let cfg: AppSecConfig = serde_json::from_str(raw).expect("parse");
+        assert_eq!(cfg.circuit_breaker_threshold, 5);
+        assert_eq!(cfg.circuit_breaker_reset_secs, 30);
+        assert_eq!(cfg.timeout_ms, 500);
     }
 }

--- a/crates/waf-engine/src/crowdsec/mod.rs
+++ b/crates/waf-engine/src/crowdsec/mod.rs
@@ -1,6 +1,7 @@
 pub mod appsec;
 pub mod cache;
 pub mod checker;
+pub mod circuit_breaker;
 pub mod client;
 pub mod config;
 pub mod models;

--- a/crates/waf-engine/tests/crowdsec_appsec_client.rs
+++ b/crates/waf-engine/tests/crowdsec_appsec_client.rs
@@ -62,6 +62,10 @@ fn appsec_cfg(endpoint: &str) -> AppSecConfig {
         api_key: "test-key".to_string(),
         timeout_ms: 2000,
         failure_action: FallbackAction::Allow,
+        // Match the production defaults so tests don't trip the breaker
+        // mid-suite unless they deliberately drive consecutive failures.
+        circuit_breaker_threshold: 5,
+        circuit_breaker_reset_secs: 30,
     }
 }
 


### PR DESCRIPTION
## Summary

Cherry-pick of `6f39920a` from `main` into `release/stg`. Bundles two
features that the upstream commit shipped together:

1. **CrowdSec AppSec circuit breaker** — `Closed / Open / HalfOpen`
   state machine guarded by `parking_lot::Mutex`, configurable
   threshold + reset duration. Wired into `AppSecClient::check_request()`
   so a degraded AppSec endpoint short-circuits instead of stalling
   per-request paths. Fills the FR-039 gap flagged by the
   branch-divergence audit
   (`plans/reports/reviewer-1-260527-branch-divergence-audit.md`).

2. **Dynamic log-level control** — `tracing_subscriber::reload::Layer`
   replaces the static `EnvFilter` so the level can be swapped at
   runtime via `POST /api/admin/logs/level`. Demotes the per-request
   proxy log from `info` to `debug` to reduce volume at scale. Came
   along with the same upstream commit; kept rather than split
   because it touches the same `prx-waf::main` bootstrap path.

## What landed

- `crates/waf-engine/src/crowdsec/circuit_breaker.rs` — 218 LOC new.
- `crates/waf-engine/src/crowdsec/appsec.rs` — `check_request()` now
  short-circuits when the breaker is open.
- `crates/waf-engine/src/crowdsec/{mod.rs,config.rs}` — declarations
  and the new threshold/duration knobs.
- `crates/waf-api/src/{handlers.rs,server.rs,state.rs}` — new
  `POST /api/admin/logs/level` handler, `SetLogLevelRequest` payload,
  `LogLevelSetter` handle.
- `crates/prx-waf/src/main.rs` — `EnvFilter::reload::Layer` plumbing
  + handle handed to `AppState`.
- `crates/gateway/src/proxy.rs` — single log-level demotion to
  `debug` on the proxy hot path.
- `Cargo.toml` — `tracing-subscriber` feature flip required by the
  reload layer.

## Conflict resolution

`crates/waf-api/src/handlers.rs` test module had a parallel-add
conflict: `release/stg` already carried the PEM upload validation
tests from PR #122, `main` added the log-level tests. Resolved by
keeping **both** test blocks under a clear divider; both groups
exercise independent surfaces and don't share fixtures.

All other touched files auto-merged cleanly against the recent
`release/stg` fix-wave (PRs #127–#137).

## Test plan

- [ ] `cargo test --workspace` passes in CI.
- [ ] `cargo fmt --all -- --check` clean.
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [ ] Coverage (`waf-engine`, `waf-api`, `prx-waf`) gates remain green.

Refs branch-divergence audit finding A1 / "release/stg lacks main's
CrowdSec circuit breaker (FR-039)".