### PR TITLE
docs: port cluster + system-architecture updates from main

### DIFF
--- a/docs/cluster-design.md
+++ b/docs/cluster-design.md
@@ -232,21 +232,25 @@ operate without WASM plugins. Explicitly documented as a v1 limitation.
 
 | Dependency | Status | Notes |
 |-----------|--------|-------|
-| `quinn = "0.11"` | ✅ Already in workspace | Used in gateway (HTTP/3) |
-| `rustls = "0.23"` | ✅ Already in workspace | Used in gateway (HTTP/3) |
-| `rcgen = "0.13"` | ✅ Already in workspace | Used in gateway (ACME TLS) |
-| `rustls-pemfile = "2"` | ✅ Already in workspace | Used in gateway |
-| `serde_json` | ✅ Already in workspace | All cluster types use it |
-| `aes-gcm` | ✅ Already in waf-common | Reuse for CA key encryption |
-| `prost = "0.13"` | ❌ Not present | Avoided — use serde_json instead |
-| `prost-build = "0.13"` | ❌ Not present | Avoided — no protobuf |
-| `lz4_flex = "0.11"` | ❌ Not present | **Only genuinely new dep** |
+| `quinn` | ✅ Already in workspace | Used in gateway (HTTP/3) |
+| `rustls` | ✅ Already in workspace | Used in gateway (HTTP/3) |
+| `rcgen` | ✅ Already in workspace | Used in gateway (ACME TLS) |
+| `rustls-pki-types` | ✅ Already in workspace | Used in gateway |
+| `bytes` | ✅ Already in workspace | QUIC frame codec |
+| `serde_json` | ✅ Already in workspace | Wire format (no protobuf) |
+| `aes-gcm` | ✅ Already in workspace | CA key encryption |
+| `sha2`, `hmac`, `hex`, `base64` | ✅ Already in workspace | Join token HMAC + encoding |
+| `time` | ✅ Already in workspace | Timestamp handling |
+| `parking_lot` | ✅ Already in workspace | Sync primitives |
+| `async-trait` | ✅ Already in workspace | RuleReloader trait |
+| `toml` | ✅ Already in workspace | Config sync |
+| `reqwest` | ✅ Already in workspace | API write forwarding |
+| `lz4_flex` | ❌ **Only new dep** | Full rule snapshot compression |
 | SQLite sqlx feature | ❌ Not present | Not needed — in-memory cache |
 
-**Recommendation: Drop protobuf.** Use `serde_json` for wire encoding. All `Rule` and
-cluster message types already implement `Serialize + Deserialize`. JSON is adequate at
-cluster-internal LAN rates and eliminates a build.rs compilation step, prost-build, and
-proto file maintenance.
+**Note:** All crypto and serialization dependencies are already present in the workspace.
+The only genuinely new dependency added for clustering is `lz4_flex` for compressing large
+rule snapshots.
 
 ---
 
@@ -302,19 +306,32 @@ CA key encryption reuses those helpers directly.
 
 ### 5.3 Join Token Flow
 
+**v1 Implementation:** Workers use pre-generated certificates (no CSR signing in v1).
+
 ```
-1. Admin generates join token on main:
+1. Admin pre-generates cluster certificates:
+   $ prx-waf cluster cert-init --nodes node-a,node-b,node-c
+
+2. Certs distributed to each node (cluster-ca.pem to all; node-specific keys to respective nodes)
+
+3. Admin generates join token on main:
    $ prx-waf cluster token generate --ttl 1h
    → abc123-def456-ghi789  (HMAC-SHA256 signed, includes expiry)
 
-2. Worker starts with token:
+4. Worker starts with token:
    $ prx-waf run --cluster-join main.example.com:16851 --token abc123-def456-ghi789
 
-3. Worker connects to main via QUIC (server-only TLS initially — no client cert yet)
-4. Worker sends: JoinRequest { token, csr_pem, node_info }
-5. Main validates token + signs CSR → JoinResponse { node_cert_pem, ca_cert_pem, cluster_state }
-6. Worker reconnects with mTLS (both sides verified by CA)
-7. Main broadcasts: NodeJoined to all peers
+5. Worker connects to main via QUIC with mTLS (both sides have pre-generated certs)
+
+6. Worker sends: JoinRequest { token, csr_pem: "", node_info }
+
+7. Main validates token → JoinResponse { accepted, node_cert_pem, ca_cert_pem, 
+   cluster_state, encrypted_ca_key_b64 (if passphrase configured) }
+
+8. Main broadcasts: NodeJoined to all peers
+
+Note: Full CSR signing is deferred to a future phase. v1 uses pre-generated certificates
+for simplicity and reduced latency.
 ```
 
 ---
@@ -375,6 +392,9 @@ crates/waf-cluster/
 ├── src/
 │   ├── lib.rs              # pub use ClusterNode, ClusterConfig, NodeRole
 │   ├── node.rs             # NodeState, NodeRole enum, role state machine
+│   ├── protocol.rs         # All ClusterMessage types (serde_json, no protobuf)
+│   ├── discovery.rs        # Static peer list from ClusterConfig.seeds (mDNS deferred)
+│   ├── cluster_forward.rs  # API write forwarding (worker → main)
 │   ├── transport/
 │   │   ├── mod.rs          # QUIC connection manager
 │   │   ├── server.rs       # QUIC mTLS listener (reuses gateway/http3.rs patterns)
@@ -384,27 +404,39 @@ crates/waf-cluster/
 │   │   ├── mod.rs
 │   │   ├── ca.rs           # CA generation via rcgen (already in workspace)
 │   │   ├── node_cert.rs    # Node cert signing + CSR validation
-│   │   └── store.rs        # AES-GCM key storage (reuse waf-common::crypto)
-│   ├── discovery/
-│   │   └── static_seeds.rs # Static peer list from ClusterConfig.seeds (mDNS deferred)
-│   ├── sync/
-│   │   ├── mod.rs
-│   │   ├── rules.rs        # Rule sync using RuleRegistry.version + serde_json + lz4
-│   │   ├── config.rs       # Config sync (TOML string)
-│   │   └── events.rs       # Attack log batching + forwarding to main
+│   │   ├── store.rs        # AES-GCM key storage (reuse waf-common::crypto)
+│   │   └── token.rs        # Join token: HMAC-SHA256 generate + validate
 │   ├── election/
-│   │   ├── mod.rs          # Raft-lite leader election (term, vote, timeout)
-│   │   └── state.rs        # Election state machine
+│   │   └── mod.rs          # Raft-lite leader election (term, vote, timeout)
 │   ├── health/
 │   │   ├── mod.rs          # Heartbeat sender/receiver
 │   │   └── detector.rs     # Phi-accrual failure detector
-│   └── protocol/
-│       └── messages.rs     # All ClusterMessage types (serde_json, no protobuf)
+│   └── sync/
+│       ├── mod.rs
+│       ├── rules.rs        # Rule sync using RuleRegistry.version + serde_json + lz4
+│       ├── config.rs       # Config sync (TOML string)
+│       └── events.rs       # Attack log batching + forwarding to main
 │
 └── tests/
-    ├── integration.rs      # 2-node QUIC connect + heartbeat
-    ├── election_test.rs    # State machine edge cases
-    └── sync_test.rs        # Rule version diff + full snapshot
+    ├── cluster_integration.rs        # 2-node QUIC connect + heartbeat
+    ├── cluster_full_lifecycle.rs     # Full cluster bootstrap + rule sync
+    ├── cluster_forward_routing.rs    # API write forwarding
+    ├── election_test.rs              # State machine edge cases
+    ├── election_state_machine.rs     # Election state transitions
+    ├── peer_eviction_test.rs         # Phi-accrual + peer removal
+    ├── config_sync_test.rs           # Config replication
+    ├── rule_sync_e2e.rs              # Rule version diff + full snapshot
+    ├── discovery_static.rs           # Static seed discovery
+    ├── engine_bridge_test.rs         # RuleReloader integration
+    ├── event_forwarding_test.rs      # Event batch forwarding
+    ├── sync_events_batching.rs       # Event batching logic
+    ├── write_forwarding_test.rs      # API write forwarding
+    ├── transport_loopback.rs         # QUIC transport basics
+    ├── transport_dispatch_coverage.rs# Message routing
+    ├── transport_error_paths.rs      # Connection error handling
+    ├── crypto_store_extra.rs         # Crypto key storage
+    ├── integration_test.rs           # Full integration
+    └── lib_reexports_smoke.rs        # Public API smoke test
 ```
 
 ### A.2 Dependency Graph (Corrected)
@@ -417,14 +449,24 @@ prx-waf (binary)
 ├── waf-api        (Axum REST + Admin UI)
 ├── waf-common     (AppConfig extended with ClusterConfig)
 └── waf-cluster    (NEW)
-    ├── quinn          ✅ already workspace dep
-    ├── rustls         ✅ already workspace dep
-    ├── rcgen          ✅ already workspace dep
-    ├── rustls-pemfile ✅ already workspace dep
-    ├── serde_json     ✅ already workspace dep
-    ├── aes-gcm        ✅ already waf-common dep
-    ├── lz4_flex       ❌ ONLY GENUINELY NEW DEP
-    └── waf-common     ✅
+    ├── quinn                ✅ already workspace dep
+    ├── rustls               ✅ already workspace dep
+    ├── rcgen                ✅ already workspace dep
+    ├── rustls-pki-types     ✅ already workspace dep
+    ├── bytes                ✅ already workspace dep
+    ├── serde_json           ✅ already workspace dep
+    ├── aes-gcm              ✅ already workspace dep
+    ├── sha2                 ✅ already workspace dep
+    ├── hmac                 ✅ already workspace dep
+    ├── hex                  ✅ already workspace dep
+    ├── base64               ✅ already workspace dep
+    ├── time                 ✅ already workspace dep
+    ├── parking_lot          ✅ already workspace dep
+    ├── async-trait          ✅ already workspace dep
+    ├── toml                 ✅ already workspace dep
+    ├── reqwest              ✅ already workspace dep
+    ├── lz4_flex             ❌ ONLY GENUINELY NEW WORKSPACE DEP
+    └── waf-common, waf-engine ✅
 ```
 
 ### A.3 Cargo.toml for waf-cluster
@@ -439,24 +481,30 @@ license.workspace = true
 [dependencies]
 waf-common  = { path = "../waf-common" }
 waf-engine  = { path = "../waf-engine" }
-waf-storage = { path = "../waf-storage" }
 
-quinn          = { workspace = true }
-rustls         = { workspace = true }
-rcgen          = { workspace = true }
-rustls-pemfile = { workspace = true }
-tokio          = { workspace = true }
-serde          = { workspace = true }
-serde_json     = { workspace = true }
-tracing        = { workspace = true }
-anyhow         = { workspace = true }
-thiserror      = { workspace = true }
-rand           = { workspace = true }
-aes-gcm        = { workspace = true }
-bytes          = { workspace = true }
-dashmap        = { workspace = true }
+quinn            = { workspace = true }
+rustls           = { workspace = true }
+rcgen            = { workspace = true }
+rustls-pki-types = { workspace = true }
+bytes            = { workspace = true }
+tokio            = { workspace = true }
+serde            = { workspace = true }
+serde_json       = { workspace = true }
+tracing          = { workspace = true }
+anyhow           = { workspace = true }
+aes-gcm          = { workspace = true }
+sha2             = { workspace = true }
+hmac             = { workspace = true }
+hex              = { workspace = true }
+base64           = { workspace = true }
+rand             = { workspace = true }
+time             = { workspace = true }
+parking_lot      = { workspace = true }
+async-trait      = { workspace = true }
+toml             = { workspace = true }
+reqwest          = { workspace = true }
 
-lz4_flex = "0.11"   # Only new dep — used for full rule snapshot compression
+lz4_flex = { workspace = true }   # Only genuinely new dep — used for full rule snapshot compression
 ```
 
 Add to workspace root `Cargo.toml`:
@@ -511,22 +559,22 @@ impl Default for ClusterConfig {
 ```
 
 ```rust
-// crates/waf-common/src/lib.rs
+// crates/waf-common/src/lib.rs (config.rs — appended)
 pub use config::ClusterConfig;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NodeRole { Main, Worker, Candidate }
+```
 
-pub struct NodeId(pub String);
-impl NodeId {
-    pub fn from_hostname() -> Self {
-        let host = hostname::get()
-            .ok()
-            .and_then(|h| h.into_string().ok())
-            .unwrap_or_else(|| "unknown".to_string());
-        Self(format!("{}-{}", host, &uuid::Uuid::new_v4().to_string()[..8]))
-    }
-}
+Node ID generation is handled in `waf-cluster/src/node.rs`:
+
+```rust
+// crates/waf-cluster/src/node.rs
+let node_id = if config.node_id.is_empty() {
+    format!("node-{}", random_suffix())  // generates "node-xxxxxxxx" (8 random hex chars)
+} else {
+    config.node_id.clone()
+};
 ```
 
 #### waf-engine — Minimal

--- a/docs/cluster-guide.md
+++ b/docs/cluster-guide.md
@@ -266,15 +266,17 @@ prx-waf cluster cert-init \
 
 ## Network & Port Reference
 
-| Port | Protocol | Purpose |
-|------|----------|---------|
-| 80 | TCP | HTTP proxy |
-| 443 | TCP | HTTPS proxy |
-| 9527 | TCP | Management API + Admin UI |
-| **16851** | **UDP** | **QUIC cluster communication (inter-node only)** |
+| Port | Protocol | Service | Container Port | Docker Host Port |
+|------|----------|---------|-----------------|------------------|
+| 80 | TCP | HTTP proxy | 80 | 16880 |
+| 443 | TCP | HTTPS proxy | 443 | 16843 |
+| 9527 | TCP | Management API + Admin UI | 9527 | 16827 (node-a), 16828 (node-b), 16829 (node-c) |
+| **16851** | **UDP** | **QUIC cluster communication (inter-node only)** | 16851 | internal only |
 
-The cluster port (16851) should only be reachable between cluster nodes. Use a
-firewall or private network to prevent external access.
+**Note:** Container ports (80, 443, 9527, 16851) are internal to the Docker network.
+The Docker Host Port column shows the external mapping for docker-compose deployments.
+The cluster port (16851) should only be reachable between cluster nodes via a private
+network or firewall rules.
 
 ---
 

--- a/docs/cluster-protocol.md
+++ b/docs/cluster-protocol.md
@@ -75,11 +75,19 @@ pub struct Heartbeat {
     pub config_version: u64,
 }
 
+/// Vote cast by a candidate during an election, or a vote-grant echo from a peer.
+///
+/// When `voter_id` is `None` → this is a vote **request** from the candidate.
+/// When `voter_id` is `Some(id)` → this is a vote **grant** from `id`, echoed back
+/// to the candidate through the bidirectional stream.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ElectionVote {
     pub term: u64,
     pub candidate_id: String,
     pub last_log_index: u64,
+    /// Present only in vote-grant responses; identifies the voter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub voter_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -103,6 +111,11 @@ pub struct JoinResponse {
     pub node_cert_pem: String,
     pub ca_cert_pem: String,
     pub cluster_state: ClusterState,
+    /// AES-GCM encrypted CA private key (base64-encoded), included when the
+    /// main has a `ca_passphrase` configured.  Workers store this so a new
+    /// main can take over CA duties after failover.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encrypted_ca_key_b64: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -237,7 +250,7 @@ protocol, not Raft entries.
 2. Worker starts election timeout (random 150-300ms)
 3. If no heartbeat from main within timeout → become Candidate
 4. Candidate increments term, votes for self, requests votes from all peers
-5. Node grants vote if: candidate term > current term AND haven't voted this term
+5. Node grants vote if: candidate term >= current term AND (haven't voted this term OR already voted for same candidate)
 6. Candidate wins if: receives majority votes (N/2 + 1)
 7. Winner becomes Main, broadcasts `ElectionResult`
 8. Losers reset to Worker, accept new Main
@@ -267,7 +280,7 @@ every `insert()` or `remove()`. No new versioning infrastructure needed.
 Worker request: RuleSyncRequest { current_version: 42 }
 
 Main logic:
-  registry = rule_manager.registry.read().unwrap()
+  registry = node_state.rule_registry.read().unwrap()
   if registry.version == 42 → send empty RuleSyncResponse (no-op)
   else if changelog covers [42..registry.version] → send incremental
   else (worker too far behind or changelog evicted) → send full snapshot
@@ -277,7 +290,7 @@ Main logic:
 
 ```rust
 // Main: serialize + compress
-let registry = rule_manager.registry.read().unwrap();
+let registry = node_state.rule_registry.read().unwrap();
 let rules: Vec<_> = registry.rules.values().collect();
 let json = serde_json::to_vec(&rules).context("rule snapshot serialize")?;
 let compressed = lz4_flex::compress_prepend_size(&json);
@@ -288,13 +301,13 @@ let json = lz4_flex::decompress_size_prepended(&msg.snapshot_lz4)
     .context("rule snapshot decompress")?;
 let rules: Vec<waf_engine::rules::registry::Rule> = serde_json::from_slice(&json)
     .context("rule snapshot deserialize")?;
-let mut registry = engine.rule_registry.write().unwrap();
+let mut registry = node_state.rule_registry.write().unwrap();
 registry.rules.clear();
 registry.by_category.clear();
 registry.by_source.clear();
 for rule in rules { registry.insert(rule); }
 registry.version = msg.version;
-engine.on_rules_updated(msg.version).await?;
+node_state.on_rules_updated(msg.version).await?;
 ```
 
 ### 3.3 Incremental Change Log
@@ -339,7 +352,26 @@ impl RuleChangelog {
 | Periodic poll (every `sync.rules_interval_secs`) | Worker sends RuleSyncRequest; main responds if version differs |
 | Worker rejoins after disconnect | Full sync (safer than relying on stale changelog) |
 
-### 3.5 WASM Plugin Sync (v1 Limitation)
+### 3.5 Configuration Synchronization
+
+The cluster syncs a safe subset of configuration across all nodes via `ConfigSync` messages.
+Main pushes updates at `sync.config_interval_secs` (default 30s).
+
+**Synced sections:**
+- `proxy` — upstream targets, timeouts, routing rules
+- `rules` — rule management settings (path, auto-reload)
+- `cache` — cache behavior
+- `api` — API server settings
+
+**Excluded (safety):**
+- `cluster` — node role + identity must not be synced (would break cluster topology)
+- `storage` — database URL is node-specific
+- `security` — SSL keys are per-node
+
+Workers apply ConfigSync as a complete TOML replacement (atomic update), allowing
+coordinated policy changes across the cluster without manual node restarts.
+
+### 3.6 WASM Plugin Sync (v1 Limitation)
 
 WASM plugins are binary blobs stored in PostgreSQL. Worker nodes **do not receive WASM
 plugins** in v1. Workers run the WAF engine without plugin support. Add to deployment
@@ -485,11 +517,15 @@ async fn api_write_on_worker_forwarded_to_main() {
 
 ## 6. Implementation Phases
 
-> **Effort estimates use Claude-hours.** Claude AI performs all development 24/7 with no
-> context-switching overhead, roughly 3-5x faster than human-hours for comparable tasks.
-> Estimates assume no blocking external dependencies (network, hardware, vendor APIs).
+> **Status:** Phases 1–3 are fully implemented and tested as of 2026-05-28. Phase 4 (Admin UI)
+> has API endpoints implemented but UI pages are in progress.
 
-### Phase 1: Foundation — QUIC Transport + mTLS (~14 Claude-hours)
+> **Effort estimates (historical):** Claude AI performed all development at roughly 3-5x faster
+> than human-hours for comparable tasks, with minimal context-switching overhead.
+
+### Phase 1: Foundation — QUIC Transport + mTLS
+
+**Status:** ✅ COMPLETE
 
 **Goal:** Two nodes can discover each other, establish mTLS QUIC connection, and exchange heartbeats.
 
@@ -511,7 +547,9 @@ async fn api_write_on_worker_forwarded_to_main() {
 | Integration test: 2-node connect + heartbeat | 2h | waf-cluster/tests | |
 | **Phase 1 subtotal** | **~14h** | | |
 
-### Phase 2: Rule and Config Sync (~14 Claude-hours)
+### Phase 2: Rule and Config Sync
+
+**Status:** ✅ COMPLETE
 
 **Goal:** Workers auto-sync rules from main; attack logs aggregated on main; API writes forwarded.
 
@@ -532,7 +570,9 @@ async fn api_write_on_worker_forwarded_to_main() {
 | Integration test: create rule on main → synced to worker | 1.5h | tests | |
 | **Phase 2 subtotal** | **~14h** | | |
 
-### Phase 3: Election + Failover (~16 Claude-hours)
+### Phase 3: Election + Failover
+
+**Status:** ✅ COMPLETE
 
 **Goal:** Cluster survives main failure with automatic re-election, no manual intervention.
 
@@ -550,7 +590,9 @@ async fn api_write_on_worker_forwarded_to_main() {
 | Concurrent election test: single winner | 0.5h | tests | |
 | **Phase 3 subtotal** | **~16h** | | |
 
-### Phase 4: Admin UI + Polish (~10 Claude-hours)
+### Phase 4: Admin UI + Polish
+
+**Status:** 🔄 IN PROGRESS (API endpoints complete, UI pages pending)
 
 **Goal:** Full cluster management via Admin UI; 3-node cluster deployable with docker-compose.
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -102,6 +102,20 @@ Standards: OWASP ASVS V14.4, CWE-200, CWE-209, RFC 9110 §7.6, NIST SP 800-53 SI
 
 ---
 
+## Subsystem Summary
+
+Quick reference for subsystems detailed in dedicated sections below:
+
+| Subsystem | Feature | Module | Purpose |
+|-----------|---------|--------|---------|
+| **Challenge & PoW** | FR-006 | `waf-engine/challenge/` | Minimal HTML page (<5KB) with JS PoW puzzle; difficulty tiers (easy/medium/hard); nonce store prevents replay |
+| **Challenge Credit Tokens** | FR-025 Phase 8 | `waf-engine/risk/challenge_credit/` | Single-use HMAC-signed tokens on PoW completion; bidirectional actor_id binding; verify outcomes (Valid/Invalid/Replay/Expired) with risk deltas |
+| **Community Threat Intel** | — | `waf-engine/community/` | Two-way IP blocklist exchange; auto-enrollment with machine_id/api_key; Ed25519 signature verification (fail-closed); batched signal reporter |
+| **Logging & Audit** | FR-033 | `waf-engine/logging/` + `prx-waf/victoria_logs/` | VictoriaLogs JSON ingest layer; separate audit sink for non-Allow decisions; batched DB writer; fail-open on buffer saturation |
+| **Gateway Filter Chain** | FR-035 | `gateway/filters/` | 6 request filters + 8 response filters; response body chain: decompress → catalog scan → JSON redact → operator regex |
+
+---
+
 ## Component Interaction
 
 ### Gateway (Pingora) → WafEngine
@@ -479,3 +493,181 @@ Rule Load Operation
 
 **Integration**: Rule reload (via file watcher or API) invokes `classify_error()` to emit consistent metrics.
 
+### Cluster Mode (Optional 3-Node HA)
+
+QUIC mTLS mesh with automatic leader election, rule sync, event forwarding, config sync, and write forwarding.
+
+```
+Main Node (control plane)
+├── PostgreSQL storage (authoritative)
+├── RuleRegistry + RuleChangelog
+├── Admin API (read-write)
+└── QUIC server
+    ├── handles RuleSyncRequest → returns incremental/snapshot
+    ├── receives EventBatch → batch INSERT to DB
+    ├── broadcasts ConfigSync (TOML, version-gated, term-fenced)
+    └── replays ApiForward → returns ApiForwardResponse
+
+Worker Nodes (data plane)
+├── In-memory RuleRegistry (synced from main)
+├── Admin API (read-only; writes forwarded via QUIC)
+├── EventBatcher → forwards SecurityEvents to main
+└── QUIC client
+    ├── periodic RuleSyncRequest (pull model)
+    ├── receives ConfigSync → apply (proxy/rules/cache/api sections)
+    └── ApiForward for write requests (1MB payload limit, 10s timeout)
+```
+
+**Key flows:**
+
+1. **Rule sync** — Workers poll main every `rules_interval_secs`. Main responds with incremental delta (from `RuleChangelog` ring buffer) or lz4-compressed full snapshot. Workers apply to in-memory `RuleRegistry` and call `RuleReloader::reload_from_registry()` (no DB needed on workers).
+
+2. **Event forwarding** — Workers batch `SecurityEvent`s (configurable size/interval) via `EventBatcher`. Main persists with batch INSERT, tags `source_node_id` to prevent double-counting.
+
+3. **Config sync** — Main broadcasts `ConfigSync` with TOML-serialized `SyncableConfig` (proxy, rules, cache, api sections only — never overwrites cluster/storage). Includes election `term` for stale-main rejection.
+
+4. **Write forwarding** — Worker API middleware intercepts POST/PUT/DELETE/PATCH, serializes to `ApiForward`, sends via QUIC. Main replays via HTTP, returns `ApiForwardResponse`. Workers return 503 if main unreachable.
+
+5. **Transport dispatch** — All 13 `ClusterMessage` variants dispatched exhaustively (no catch-all) in both server and client. `NodeState` bridges to `WafEngine` via `Arc<dyn RuleReloader>`.
+
+**Module:** `crates/waf-cluster/` (transport/, sync/, node.rs, cluster_forward.rs, lib.rs).
+
+---
+
+## Challenge & Proof-of-Work System (FR-006)
+
+Risk score >= challenge_threshold triggers minimal (<5KB) HTML page with embedded JS PoW puzzle.
+
+```
+Risk Scorer (challenge_threshold breach)
+    ├─ DifficultyMap::select(score) → DifficultyTier
+    ├─ JsChallengeRenderer::render() → nonce + page
+    └─ Nonce store (in-memory LRU) + verify_pow()
+    │
+Client solves PoW → POST /retry with cookie
+    │
+    ├─ PowVerifyResult (Valid → issue token | Invalid/Replay → +risk)
+    └─ Token signed via HMAC-SHA256(secret, actor_id || nonce)
+```
+
+**Key types:** `ChallengeConfig`, `DifficultyMap`, `PowSolution`, `JsChallengeRenderer`.
+
+**Module:** `crates/waf-engine/src/challenge/`.
+
+---
+
+## Challenge Credit Tokens (FR-025 Phase 8)
+
+After PoW success, issue single-use HMAC-signed token (secret: `/var/lib/waf/challenge-hmac.key`).
+
+**Verify Outcomes:**
+| Outcome | Risk Delta | Condition |
+|---------|-----------|-----------|
+| Valid | -25 | Signature OK + nonce unused + TTL valid |
+| Invalid | +20 | Signature mismatch |
+| Replay | +30 | Nonce already consumed |
+| Expired | +10 | Token TTL exceeded |
+
+Token binds bidirectionally: actor_id must match in token and request. Nonce store (in-memory LRU) prevents replay.
+
+**Module:** `crates/waf-engine/src/risk/challenge_credit/`.
+
+---
+
+## Community Threat Intelligence
+
+Two-way IP blocklist + detection signal exchange. Auto-enroll (machine_id/api_key) on first run.
+
+**Inbound (blocklist check):**
+- Periodic sync (configurable interval, default 5min)
+- Ed25519 signature verification (fail-closed if public_key invalid)
+- In-memory cache lookup → +40 risk delta if hit
+
+**Outbound (report detections):**
+- Batched HTTP POST (signal type: SQLi, XSS, DDoS, etc.)
+- Configurable batch size + flush interval
+- Background flush task, fail-open on network errors
+
+**Module:** `crates/waf-engine/src/community/`.
+
+---
+
+## Logging & Audit Subsystem (FR-033)
+
+Two independent layers sharing batch-buffer abstraction:
+
+**VictoriaLogs Layer:** All `tracing` events → JSON to HTTP endpoint (batch: 1000 events or 5s).
+
+**Audit Layer:** Non-Allow decisions (Block/Challenge/Redirect) → PostgreSQL (batch: 500 events or 10s).
+
+**VictoriaLogs Sidecar:** Auto-downloaded from GitHub (SHA-256 verified), runs as managed child process, listens on :9428.
+
+**Fail-Open:** Buffer saturation or network errors drop entries (never block WAF path). DB connection failure → WARN + continue.
+
+**Module:** `crates/waf-engine/src/logging/` + `crates/prx-waf/src/victoria_logs/`.
+
+---
+
+## Gateway Filter Chain
+
+Trait-based Chain-of-Responsibility for request/response processing.
+
+**Request Filters:** ForwardedHost, ForwardedProto, HopByHop, HostPolicy, RealIp, Xff.
+
+**Response Filters:** BodyDecompressor → BodyContentScanner (audit) → JsonFieldRedactor (FR-034) → HeaderBlocklist → LocationRewriter, ServerPolicy, ViaStrip.
+
+**Response Body Chain:** Decompress → catalog PII/secrets (emit FR-033 audit) → redact JSONPath fields → operator regex.
+
+**Module:** `crates/gateway/src/filters/`.
+
+---
+
+## Security Check Pipeline (11 Checks)
+
+All checks run async, deltas accumulate → FR-025 scorer.
+
+| Check | Feature | Risk |
+|-------|---------|------|
+| BruteForce | FR-018 | +50 failed auth; -20 success |
+| Ssrf | FR-016 | +35 (metadata IP); +20 (obfuscated) |
+| HeaderInjection | FR-017 | +25 (CRLF); +30 (Host bypass) |
+| BodyAbuse | FR-020 | +10–20 (oversized/depth/explosion) |
+| SqlInjection | — | +40 (libinjection) |
+| Xss | — | +30 (script/event handler) |
+| Rce | — | +50 (shell metachar) |
+| DirTraversal | — | +35 (%2e%2e%2f) |
+| Scanner | — | +20 (known scanner UA) |
+| Geo | — | +5–15 (policy) |
+| AntiHotlink | — | +10 (missing Referer) |
+
+**Module:** `crates/waf-engine/src/checks/`.
+
+---
+
+## CrowdSec Integration (3 Modes)
+
+**Bouncer:** IP reputation cache (LRU, configurable TTL) → Allow or Block per policy.
+
+**AppSec:** Async HTTP check against AppSec endpoint (remote_addr, user_agent, rule_hit context) → Allow, Block, or Captcha.
+
+**Both:** Combine both modes.
+
+**Background Tasks:** Sync (periodic decision polling + cache eviction), Pusher (batched logs to LAPI).
+
+**Circuit Breaker:** Fallback to allow-all if LAPI unreachable; recover on success.
+
+**Module:** `crates/waf-engine/src/crowdsec/`.
+
+---
+
+## RequestCtx Population Order
+
+1. **RelayDetector** — XFF/X-Real-IP evaluation → `client_ip`
+2. **TierPolicyRegistry** — host/path classification → `tier` + `tier_policy`
+3. **GeoIP** — lookup → `geo` (optional)
+4. **Tier Cache Gate** — URL-based cache eligibility check
+5. **11 Checks** — async, deltas accumulate in `RequestCtx.risk_deltas`
+6. **Risk Scorer** — thresholds (allow_threshold, challenge_threshold) → Allow/Challenge/Block
+7. **Audit Sink** — FR-033 event emission for non-Allow decisions
+
+**Key fields:** `client_ip`, `method`, `path`, `headers`, `body_preview`, `host_config`, `geo`, `tier`, `tier_policy`, `cookies` (pre-parsed).


### PR DESCRIPTION
## Summary

Cherry-pick of `6803aeb34` from `main` into `release/stg`. Docs-only —
no code changes, no Cargo changes.

## What landed

- `docs/cluster-design.md` (+192 / −94) — schema, message taxonomy,
  failure-handling diagrams refreshed.
- `docs/cluster-guide.md` (+/− 20) — operator runbook trims.
- `docs/cluster-protocol.md` (+68 / −12) — `ClusterMessage` variant
  catalogue + dispatch / sync flow tables.
- `docs/system-architecture.md` (+154) — new sections (Cluster Mode
  diagram, Challenge & PoW, Community Threat Intel, Logging & Audit
  Subsystem, Gateway Filter Chain, Security Check Pipeline, CrowdSec
  Integration, RequestCtx Population Order).

## Conflict resolution

`docs/system-architecture.md` had a parallel-add at EOF — `release/stg`
HEAD had no overlapping section, the conflict markers just delimited
the empty HEAD slot. Resolved by keeping main's additions verbatim.

## Test plan

- [ ] CI lint / coverage / build / test all green (docs-only, no
      behavioural surface touched).