### PR TITLE
feat(api): admin-panel tier policies + DDoS + access lists endpoints (FR-002,005,008,036-038)

### DIFF
--- a/configs/ddos.yaml
+++ b/configs/ddos.yaml
@@ -1,0 +1,19 @@
+# FR-005 DDoS protection — default configuration.
+# Hot-reloaded on file save (~250ms debounce).
+
+enabled: true
+
+per_ip:
+  threshold_rps: 100
+  window_secs: 10
+
+per_fingerprint:
+  threshold_rps: 200
+  window_secs: 10
+
+# Ban escalation ladder: level1 / level2 / level3 durations in seconds.
+ban_durations_secs: [60, 300, 3600]
+
+store:
+  backend: memory
+  # redis_url: "redis://127.0.0.1:6379"

--- a/configs/tier-policies.yaml
+++ b/configs/tier-policies.yaml
@@ -1,0 +1,34 @@
+classifier_rules: []
+policies:
+  catch_all:
+    cache_policy: aggressive
+    ddos_threshold_rps: 1000
+    fail_mode: open
+    risk_thresholds:
+      allow: 20
+      block: 85
+      challenge: 60
+  critical:
+    cache_policy: no_cache
+    ddos_threshold_rps: 50
+    fail_mode: close
+    risk_thresholds:
+      allow: 20
+      block: 85
+      challenge: 60
+  high:
+    cache_policy: default
+    ddos_threshold_rps: 200
+    fail_mode: close
+    risk_thresholds:
+      allow: 20
+      block: 85
+      challenge: 60
+  medium:
+    cache_policy: short_ttl
+    ddos_threshold_rps: 500
+    fail_mode: open
+    risk_thresholds:
+      allow: 20
+      block: 85
+      challenge: 60

--- a/crates/waf-api/src/access_lists_api.rs
+++ b/crates/waf-api/src/access_lists_api.rs
@@ -1,0 +1,271 @@
+//! Access lists API — GET/PUT `/api/access-lists`, GET `/api/access-lists/test`.
+//!
+//! Config source: `configs/access-lists.yaml`. PUT validates the body with a
+//! typed serde schema and requires the `admin` role. Body size is capped at
+//! 256 KiB by the route layer. After a successful write the engine rule cache
+//! is refreshed so live traffic sees the new lists immediately.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::{Query, State},
+    http::HeaderMap,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::auth::{Claims, validate_admin_token};
+use crate::error::{ApiError, ApiResult};
+use crate::state::AppState;
+
+pub const MAX_BODY_BYTES: usize = 256 * 1024;
+
+// ─── Typed request models ────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HostWhitelist {
+    #[serde(default)]
+    pub critical: Vec<String>,
+    #[serde(default)]
+    pub high: Vec<String>,
+    #[serde(default)]
+    pub medium: Vec<String>,
+    #[serde(default)]
+    pub catch_all: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TierWhitelistMode {
+    pub critical: String,
+    pub high: String,
+    pub medium: String,
+    pub catch_all: String,
+}
+
+impl Default for TierWhitelistMode {
+    fn default() -> Self {
+        Self {
+            critical: "blacklist_only".to_string(),
+            high: "blacklist_only".to_string(),
+            medium: "full_bypass".to_string(),
+            catch_all: "full_bypass".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccessConfig {
+    #[serde(default = "default_version")]
+    pub version: i64,
+    #[serde(default)]
+    pub dry_run: bool,
+    #[serde(default)]
+    pub ip_whitelist: Vec<String>,
+    #[serde(default)]
+    pub ip_blacklist: Vec<String>,
+    #[serde(default)]
+    pub host_whitelist: HostWhitelist,
+    #[serde(default)]
+    pub tier_whitelist_mode: TierWhitelistMode,
+}
+
+const fn default_version() -> i64 {
+    1
+}
+
+impl Default for AccessConfig {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            dry_run: false,
+            ip_whitelist: Vec::new(),
+            ip_blacklist: Vec::new(),
+            host_whitelist: HostWhitelist::default(),
+            tier_whitelist_mode: TierWhitelistMode::default(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct TestQuery {
+    pub ip: Option<String>,
+    pub host: Option<String>,
+    pub tier: Option<String>,
+}
+
+// ─── Auth gate ───────────────────────────────────────────────────────────────
+
+fn require_admin(headers: &HeaderMap, jwt_secret: &str) -> Result<Claims, ApiError> {
+    let token = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .ok_or_else(|| ApiError::Unauthorized("missing bearer token".into()))?;
+    validate_admin_token(token, jwt_secret).map_err(|e| ApiError::Unauthorized(e.to_string()))
+}
+
+// ─── Filesystem helpers ──────────────────────────────────────────────────────
+
+fn resolve_path(state: &AppState, relative: &str) -> PathBuf {
+    state.main_config_file.as_ref().map_or_else(
+        || PathBuf::from(relative),
+        |main| {
+            let p = Path::new(main.as_str());
+            let root = p
+                .parent()
+                .and_then(Path::parent)
+                .unwrap_or_else(|| Path::new("."));
+            root.join(relative)
+        },
+    )
+}
+
+async fn read_yaml_opt(path: &Path) -> Option<AccessConfig> {
+    let raw = tokio::fs::read_to_string(path).await.ok()?;
+    match serde_yaml::from_str::<AccessConfig>(&raw) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            tracing::warn!(path = %path.display(), error = %e, "access-lists: YAML parse failed; falling back to defaults");
+            None
+        }
+    }
+}
+
+async fn write_yaml(path: &Path, value: &AccessConfig) -> Result<(), ApiError> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| ApiError::Internal(anyhow::anyhow!("mkdir: {e}")))?;
+    }
+    let s = serde_yaml::to_string(value).map_err(|e| ApiError::Internal(anyhow::anyhow!("serialize: {e}")))?;
+    let tmp = path.with_extension("yaml.tmp");
+    tokio::fs::write(&tmp, s.as_bytes())
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("write: {e}")))?;
+    tokio::fs::rename(&tmp, path)
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("rename: {e}")))?;
+    Ok(())
+}
+
+fn validate(cfg: &AccessConfig) -> Result<(), ApiError> {
+    for mode in [
+        &cfg.tier_whitelist_mode.critical,
+        &cfg.tier_whitelist_mode.high,
+        &cfg.tier_whitelist_mode.medium,
+        &cfg.tier_whitelist_mode.catch_all,
+    ] {
+        match mode.as_str() {
+            "blacklist_only" | "full_bypass" => {}
+            other => {
+                return Err(ApiError::BadRequest(format!(
+                    "invalid tier_whitelist_mode value: {other} (expected blacklist_only|full_bypass)"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+// ─── Handlers ────────────────────────────────────────────────────────────────
+
+pub async fn get_access_lists(State(state): State<Arc<AppState>>) -> ApiResult<Json<Value>> {
+    let path = resolve_path(&state, "configs/access-lists.yaml");
+    let cfg = read_yaml_opt(&path).await.unwrap_or_default();
+    Ok(Json(json!({ "success": true, "data": cfg })))
+}
+
+pub async fn put_access_lists(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<AccessConfig>,
+) -> ApiResult<Json<Value>> {
+    require_admin(&headers, &state.jwt_secret)?;
+    validate(&body)?;
+
+    let path = resolve_path(&state, "configs/access-lists.yaml");
+    write_yaml(&path, &body).await?;
+
+    if let Err(e) = state.engine.reload_rules().await {
+        tracing::warn!(error = %e, "access-lists: engine reload failed");
+    }
+
+    Ok(Json(json!({ "success": true, "data": body })))
+}
+
+pub async fn test_access_lists(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<TestQuery>,
+) -> ApiResult<Json<Value>> {
+    let path = resolve_path(&state, "configs/access-lists.yaml");
+    let cfg = read_yaml_opt(&path).await.unwrap_or_default();
+
+    let ip = q.ip.as_deref().unwrap_or("");
+    let host = q.host.as_deref().unwrap_or("");
+    let tier = q.tier.as_deref().unwrap_or("catch_all");
+
+    if cfg.ip_blacklist.iter().any(|v| v == ip) {
+        return Ok(Json(json!({
+            "success": true,
+            "data": { "verdict": "block", "reason": "ip_blacklist" }
+        })));
+    }
+    if cfg.ip_whitelist.iter().any(|v| v == ip) {
+        return Ok(Json(json!({
+            "success": true,
+            "data": { "verdict": "allow", "reason": "ip_whitelist" }
+        })));
+    }
+
+    let (hosts, mode) = match tier {
+        "critical" => (&cfg.host_whitelist.critical, &cfg.tier_whitelist_mode.critical),
+        "high" => (&cfg.host_whitelist.high, &cfg.tier_whitelist_mode.high),
+        "medium" => (&cfg.host_whitelist.medium, &cfg.tier_whitelist_mode.medium),
+        _ => (&cfg.host_whitelist.catch_all, &cfg.tier_whitelist_mode.catch_all),
+    };
+    if !host.is_empty() && hosts.iter().any(|v| v == host) {
+        let verdict = if mode == "full_bypass" { "bypass" } else { "allow" };
+        return Ok(Json(json!({
+            "success": true,
+            "data": { "verdict": verdict, "reason": "host_whitelist" }
+        })));
+    }
+
+    Ok(Json(json!({
+        "success": true,
+        "data": { "verdict": "pass", "reason": "no_match" }
+    })))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_round_trips_yaml() {
+        let cfg = AccessConfig::default();
+        let s = serde_yaml::to_string(&cfg).unwrap();
+        let back: AccessConfig = serde_yaml::from_str(&s).unwrap();
+        assert_eq!(back.version, 1);
+        assert!(!back.dry_run);
+        assert_eq!(back.tier_whitelist_mode.critical, "blacklist_only");
+        assert_eq!(back.tier_whitelist_mode.medium, "full_bypass");
+    }
+
+    #[test]
+    fn validate_accepts_known_modes() {
+        let cfg = AccessConfig::default();
+        validate(&cfg).unwrap();
+    }
+
+    #[test]
+    fn validate_rejects_unknown_mode() {
+        let mut cfg = AccessConfig::default();
+        cfg.tier_whitelist_mode.high = "block_everything".to_string();
+        let err = validate(&cfg).unwrap_err();
+        assert!(matches!(err, ApiError::BadRequest(_)));
+    }
+}

--- a/crates/waf-api/src/access_lists_api.rs
+++ b/crates/waf-api/src/access_lists_api.rs
@@ -5,7 +5,7 @@
 //! 256 KiB by the route layer. After a successful write the engine rule cache
 //! is refreshed so live traffic sees the new lists immediately.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use axum::{
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::auth::{Claims, validate_admin_token};
+use crate::config_paths::resolve_under_root;
 use crate::error::{ApiError, ApiResult};
 use crate::state::AppState;
 
@@ -108,20 +109,6 @@ fn require_admin(headers: &HeaderMap, jwt_secret: &str) -> Result<Claims, ApiErr
 
 // ─── Filesystem helpers ──────────────────────────────────────────────────────
 
-fn resolve_path(state: &AppState, relative: &str) -> PathBuf {
-    state.main_config_file.as_ref().map_or_else(
-        || PathBuf::from(relative),
-        |main| {
-            let p = Path::new(main.as_str());
-            let root = p
-                .parent()
-                .and_then(Path::parent)
-                .unwrap_or_else(|| Path::new("."));
-            root.join(relative)
-        },
-    )
-}
-
 async fn read_yaml_opt(path: &Path) -> Option<AccessConfig> {
     let raw = tokio::fs::read_to_string(path).await.ok()?;
     match serde_yaml::from_str::<AccessConfig>(&raw) {
@@ -172,7 +159,7 @@ fn validate(cfg: &AccessConfig) -> Result<(), ApiError> {
 // ─── Handlers ────────────────────────────────────────────────────────────────
 
 pub async fn get_access_lists(State(state): State<Arc<AppState>>) -> ApiResult<Json<Value>> {
-    let path = resolve_path(&state, "configs/access-lists.yaml");
+    let path = resolve_under_root(&state, "configs/access-lists.yaml");
     let cfg = read_yaml_opt(&path).await.unwrap_or_default();
     Ok(Json(json!({ "success": true, "data": cfg })))
 }
@@ -185,7 +172,7 @@ pub async fn put_access_lists(
     require_admin(&headers, &state.jwt_secret)?;
     validate(&body)?;
 
-    let path = resolve_path(&state, "configs/access-lists.yaml");
+    let path = resolve_under_root(&state, "configs/access-lists.yaml");
     write_yaml(&path, &body).await?;
 
     if let Err(e) = state.engine.reload_rules().await {
@@ -199,7 +186,7 @@ pub async fn test_access_lists(
     State(state): State<Arc<AppState>>,
     Query(q): Query<TestQuery>,
 ) -> ApiResult<Json<Value>> {
-    let path = resolve_path(&state, "configs/access-lists.yaml");
+    let path = resolve_under_root(&state, "configs/access-lists.yaml");
     let cfg = read_yaml_opt(&path).await.unwrap_or_default();
 
     let ip = q.ip.as_deref().unwrap_or("");

--- a/crates/waf-api/src/config_paths.rs
+++ b/crates/waf-api/src/config_paths.rs
@@ -1,0 +1,54 @@
+//! Shared YAML config path resolution for admin-panel API modules.
+//!
+//! Admin-panel handlers (tier policies, `DDoS`, access lists, …) store their
+//! YAML config under `<root>/configs/<name>.yaml`. `<root>` is the directory
+//! two levels above the main TOML config file the server was started with
+//! (e.g. `configs/default.toml` → root is `.`). When no main config file is
+//! known (CLI subcommands, some integration tests), paths fall back to being
+//! relative to the current working directory.
+
+use std::path::{Path, PathBuf};
+
+use crate::state::AppState;
+
+/// Resolve `relative` against the project root inferred from the main config
+/// path, or against the CWD when no main config is configured.
+#[must_use]
+pub fn resolve_under_root(state: &AppState, relative: &str) -> PathBuf {
+    state.main_config_file.as_ref().map_or_else(
+        || PathBuf::from(relative),
+        |main| {
+            let p = Path::new(main.as_str());
+            let root = p.parent().and_then(Path::parent).unwrap_or_else(|| Path::new("."));
+            root.join(relative)
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    /// Mirror of `resolve_under_root`'s `None` branch.
+    #[test]
+    fn relative_path_when_no_main_config() {
+        let main: Option<String> = None;
+        let got = main
+            .as_ref()
+            .map_or_else(|| PathBuf::from("configs/x.yaml"), |_| PathBuf::from("ignored"));
+        assert_eq!(got, PathBuf::from("configs/x.yaml"));
+    }
+
+    /// Mirror of `resolve_under_root`'s `Some` branch:
+    /// root is two levels above the main config file.
+    #[test]
+    fn root_is_two_levels_above_main_config() {
+        let main = Path::new("/srv/waf/configs/default.toml");
+        let root = main.parent().and_then(Path::parent).expect("two levels up");
+        assert_eq!(root, Path::new("/srv/waf"));
+        assert_eq!(
+            root.join("configs/tier-policies.yaml"),
+            Path::new("/srv/waf/configs/tier-policies.yaml"),
+        );
+    }
+}

--- a/crates/waf-api/src/ddos_api.rs
+++ b/crates/waf-api/src/ddos_api.rs
@@ -5,7 +5,7 @@
 //! `DynamicBanTable` held by `WafEngine`; mutations require the `admin` role.
 //! Request bodies are capped at 256 KiB by the route layer.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::auth::{Claims, validate_admin_token};
+use crate::config_paths::resolve_under_root;
 use crate::error::{ApiError, ApiResult};
 use crate::state::AppState;
 
@@ -59,20 +60,6 @@ fn require_admin(headers: &HeaderMap, jwt_secret: &str) -> Result<Claims, ApiErr
 }
 
 // ─── Filesystem helpers ──────────────────────────────────────────────────────
-
-fn resolve_path(state: &AppState, relative: &str) -> PathBuf {
-    state.main_config_file.as_ref().map_or_else(
-        || PathBuf::from(relative),
-        |main| {
-            let p = Path::new(main.as_str());
-            let root = p
-                .parent()
-                .and_then(Path::parent)
-                .unwrap_or_else(|| Path::new("."));
-            root.join(relative)
-        },
-    )
-}
 
 async fn read_yaml_opt(path: &Path) -> Option<DdosConfigBody> {
     let raw = tokio::fs::read_to_string(path).await.ok()?;
@@ -131,7 +118,7 @@ fn now_epoch_ms() -> i64 {
 // ─── Handlers ────────────────────────────────────────────────────────────────
 
 pub async fn get_ddos_config(State(state): State<Arc<AppState>>) -> ApiResult<Json<Value>> {
-    let path = resolve_path(&state, "configs/ddos.yaml");
+    let path = resolve_under_root(&state, "configs/ddos.yaml");
     let cfg = read_yaml_opt(&path).await.unwrap_or_else(default_ddos_config);
     Ok(Json(json!({ "success": true, "data": cfg })))
 }
@@ -147,7 +134,9 @@ pub async fn put_ddos_config(
         return Err(ApiError::BadRequest("ban_durations_secs must not be empty".into()));
     }
     if body.ban_durations_secs.iter().any(|d| *d <= 0) {
-        return Err(ApiError::BadRequest("ban_durations_secs entries must be positive".into()));
+        return Err(ApiError::BadRequest(
+            "ban_durations_secs entries must be positive".into(),
+        ));
     }
     if body.per_ip.threshold_rps <= 0 || body.per_fingerprint.threshold_rps <= 0 {
         return Err(ApiError::BadRequest("threshold_rps must be positive".into()));
@@ -156,7 +145,7 @@ pub async fn put_ddos_config(
         return Err(ApiError::BadRequest("window_secs must be positive".into()));
     }
 
-    let path = resolve_path(&state, "configs/ddos.yaml");
+    let path = resolve_under_root(&state, "configs/ddos.yaml");
     write_yaml(&path, &body).await?;
     Ok(Json(json!({ "success": true, "data": body })))
 }

--- a/crates/waf-api/src/ddos_api.rs
+++ b/crates/waf-api/src/ddos_api.rs
@@ -1,0 +1,246 @@
+//! `DDoS` protection API — GET/PUT `/api/ddos/config`, GET `/api/ddos/metrics`,
+//! GET `/api/ddos/ban-table`, DELETE `/api/ddos/ban-table/:ip`.
+//!
+//! Config source: `configs/ddos.yaml`. The ban-table is sourced from the live
+//! `DynamicBanTable` held by `WafEngine`; mutations require the `admin` role.
+//! Request bodies are capped at 256 KiB by the route layer.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::{
+    Json,
+    extract::{Path as AxumPath, State},
+    http::HeaderMap,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::auth::{Claims, validate_admin_token};
+use crate::error::{ApiError, ApiResult};
+use crate::state::AppState;
+
+pub const MAX_BODY_BYTES: usize = 256 * 1024;
+
+// ─── Typed request/response models ───────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DdosThreshold {
+    pub threshold_rps: i64,
+    pub window_secs: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DdosStore {
+    pub backend: String,
+    #[serde(default)]
+    pub redis_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DdosConfigBody {
+    pub enabled: bool,
+    pub per_ip: DdosThreshold,
+    pub per_fingerprint: DdosThreshold,
+    pub ban_durations_secs: Vec<i64>,
+    pub store: DdosStore,
+}
+
+// ─── Auth gate ───────────────────────────────────────────────────────────────
+
+fn require_admin(headers: &HeaderMap, jwt_secret: &str) -> Result<Claims, ApiError> {
+    let token = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .ok_or_else(|| ApiError::Unauthorized("missing bearer token".into()))?;
+    validate_admin_token(token, jwt_secret).map_err(|e| ApiError::Unauthorized(e.to_string()))
+}
+
+// ─── Filesystem helpers ──────────────────────────────────────────────────────
+
+fn resolve_path(state: &AppState, relative: &str) -> PathBuf {
+    state.main_config_file.as_ref().map_or_else(
+        || PathBuf::from(relative),
+        |main| {
+            let p = Path::new(main.as_str());
+            let root = p
+                .parent()
+                .and_then(Path::parent)
+                .unwrap_or_else(|| Path::new("."));
+            root.join(relative)
+        },
+    )
+}
+
+async fn read_yaml_opt(path: &Path) -> Option<DdosConfigBody> {
+    let raw = tokio::fs::read_to_string(path).await.ok()?;
+    match serde_yaml::from_str::<DdosConfigBody>(&raw) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            tracing::warn!(path = %path.display(), error = %e, "ddos: YAML parse failed; falling back to defaults");
+            None
+        }
+    }
+}
+
+async fn write_yaml(path: &Path, value: &DdosConfigBody) -> Result<(), ApiError> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| ApiError::Internal(anyhow::anyhow!("mkdir: {e}")))?;
+    }
+    let s = serde_yaml::to_string(value).map_err(|e| ApiError::Internal(anyhow::anyhow!("serialize: {e}")))?;
+    let tmp = path.with_extension("yaml.tmp");
+    tokio::fs::write(&tmp, s.as_bytes())
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("write: {e}")))?;
+    tokio::fs::rename(&tmp, path)
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("rename: {e}")))?;
+    Ok(())
+}
+
+fn default_ddos_config() -> DdosConfigBody {
+    DdosConfigBody {
+        enabled: true,
+        per_ip: DdosThreshold {
+            threshold_rps: 100,
+            window_secs: 10,
+        },
+        per_fingerprint: DdosThreshold {
+            threshold_rps: 200,
+            window_secs: 10,
+        },
+        ban_durations_secs: vec![60, 300, 3600],
+        store: DdosStore {
+            backend: "memory".to_string(),
+            redis_url: String::new(),
+        },
+    }
+}
+
+#[inline]
+fn now_epoch_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+}
+
+// ─── Handlers ────────────────────────────────────────────────────────────────
+
+pub async fn get_ddos_config(State(state): State<Arc<AppState>>) -> ApiResult<Json<Value>> {
+    let path = resolve_path(&state, "configs/ddos.yaml");
+    let cfg = read_yaml_opt(&path).await.unwrap_or_else(default_ddos_config);
+    Ok(Json(json!({ "success": true, "data": cfg })))
+}
+
+pub async fn put_ddos_config(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<DdosConfigBody>,
+) -> ApiResult<Json<Value>> {
+    require_admin(&headers, &state.jwt_secret)?;
+
+    if body.ban_durations_secs.is_empty() {
+        return Err(ApiError::BadRequest("ban_durations_secs must not be empty".into()));
+    }
+    if body.ban_durations_secs.iter().any(|d| *d <= 0) {
+        return Err(ApiError::BadRequest("ban_durations_secs entries must be positive".into()));
+    }
+    if body.per_ip.threshold_rps <= 0 || body.per_fingerprint.threshold_rps <= 0 {
+        return Err(ApiError::BadRequest("threshold_rps must be positive".into()));
+    }
+    if body.per_ip.window_secs <= 0 || body.per_fingerprint.window_secs <= 0 {
+        return Err(ApiError::BadRequest("window_secs must be positive".into()));
+    }
+
+    let path = resolve_path(&state, "configs/ddos.yaml");
+    write_yaml(&path, &body).await?;
+    Ok(Json(json!({ "success": true, "data": body })))
+}
+
+pub async fn get_ddos_metrics(State(state): State<Arc<AppState>>) -> ApiResult<Json<Value>> {
+    let snap = state.engine.ddos_metrics().snapshot();
+    Ok(Json(json!({
+        "success": true,
+        "data": {
+            "active_bans": snap.bans_active,
+            "bursts_total": snap.burst_total,
+            "bursts_per_ip": snap.burst_per_ip,
+            "bursts_per_fp": snap.burst_per_fp,
+            "bursts_per_tier": snap.burst_per_tier,
+            "bans_total": snap.bans_total,
+            "store_errors": snap.store_errors,
+            "degrade_events": snap.degrade_events
+        }
+    })))
+}
+
+pub async fn list_ban_table(State(state): State<Arc<AppState>>) -> ApiResult<Json<Value>> {
+    let now_ms = now_epoch_ms();
+    let mut entries: Vec<Value> = state
+        .engine
+        .ddos_ban_table()
+        .snapshot()
+        .into_iter()
+        .filter(|(_, exp)| *exp > now_ms)
+        .map(|(ip, exp)| {
+            json!({
+                "ip": ip.to_string(),
+                "expires_at_ms": exp,
+                "ttl_remaining_secs": ((exp - now_ms) / 1000).max(0),
+            })
+        })
+        .collect();
+    entries.sort_by(|a, b| {
+        a.get("ip")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .cmp(b.get("ip").and_then(Value::as_str).unwrap_or(""))
+    });
+    let total = entries.len();
+    Ok(Json(json!({ "success": true, "data": entries, "total": total })))
+}
+
+pub async fn delete_ban_entry(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    AxumPath(ip): AxumPath<String>,
+) -> ApiResult<Json<Value>> {
+    require_admin(&headers, &state.jwt_secret)?;
+
+    let parsed: std::net::IpAddr = ip
+        .parse()
+        .map_err(|_| ApiError::BadRequest(format!("invalid IP address: {ip}")))?;
+
+    let removed = state.engine.ddos_ban_table().remove(&parsed);
+    tracing::info!(ip = %parsed, removed, "ddos: manual unban");
+    Ok(Json(json!({
+        "success": true,
+        "data": { "ip": parsed.to_string(), "removed": removed }
+    })))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_round_trips_yaml() {
+        let cfg = default_ddos_config();
+        let s = serde_yaml::to_string(&cfg).unwrap();
+        let back: DdosConfigBody = serde_yaml::from_str(&s).unwrap();
+        assert_eq!(back.ban_durations_secs, cfg.ban_durations_secs);
+        assert_eq!(back.store.backend, "memory");
+    }
+
+    #[test]
+    fn empty_ban_durations_rejected() {
+        let mut cfg = default_ddos_config();
+        cfg.ban_durations_secs.clear();
+        assert!(cfg.ban_durations_secs.is_empty());
+    }
+}

--- a/crates/waf-api/src/lib.rs
+++ b/crates/waf-api/src/lib.rs
@@ -3,6 +3,7 @@ pub mod auth;
 pub mod bot_api;
 pub mod cache_api;
 pub mod cluster;
+pub mod config_paths;
 pub mod crowdsec;
 pub mod ddos_api;
 pub mod error;

--- a/crates/waf-api/src/lib.rs
+++ b/crates/waf-api/src/lib.rs
@@ -1,8 +1,10 @@
+pub mod access_lists_api;
 pub mod auth;
 pub mod bot_api;
 pub mod cache_api;
 pub mod cluster;
 pub mod crowdsec;
+pub mod ddos_api;
 pub mod error;
 pub mod handlers;
 pub mod health;
@@ -18,6 +20,7 @@ pub mod server;
 pub mod state;
 pub mod static_files;
 pub mod stats;
+pub mod tier_policies_api;
 pub mod tunnels;
 pub mod websocket;
 

--- a/crates/waf-api/src/server.rs
+++ b/crates/waf-api/src/server.rs
@@ -16,6 +16,7 @@ use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 use tracing::info;
 
+use crate::access_lists_api::{get_access_lists, put_access_lists, test_access_lists};
 use crate::auth::{login, logout, refresh_token};
 use crate::bot_api::{create_bot_pattern, list_bot_patterns, toggle_bot_pattern};
 use crate::cache_api::{
@@ -27,6 +28,7 @@ use crate::crowdsec::{
     crowdsec_stats, crowdsec_status, delete_crowdsec_decision, get_crowdsec_config, list_crowdsec_decisions,
     list_crowdsec_events, test_crowdsec_connection, update_crowdsec_config,
 };
+use crate::ddos_api::{delete_ban_entry, get_ddos_config, get_ddos_metrics, list_ban_table, put_ddos_config};
 use crate::handlers::{
     create_allow_ip, create_allow_url, create_block_ip, create_block_url, create_custom_rule, create_host,
     create_lb_backend, create_sensitive_pattern, delete_allow_ip, delete_allow_url, delete_block_ip, delete_block_url,
@@ -54,6 +56,7 @@ use crate::static_files::static_handler;
 use crate::stats::{
     stats_endpoints, stats_geo, stats_overview, stats_timeseries, stats_timeseries_by_category, threat_intel_status,
 };
+use crate::tier_policies_api::{dry_run_tier, get_tier_policies, put_tier_policies};
 use crate::tunnels::{create_tunnel, delete_tunnel, list_tunnels, ws_tunnel};
 use crate::websocket::{ws_events, ws_logs};
 
@@ -251,6 +254,35 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/v1/logs/streams", get(logs_streams))
         // Dynamic log level control
         .route("/api/admin/logs/level", post(set_log_level))
+        // PR-α: tier policies (FR-002)
+        .route(
+            "/api/tier-policies",
+            get(get_tier_policies)
+                .put(put_tier_policies)
+                .layer(DefaultBodyLimit::max(crate::tier_policies_api::MAX_BODY_BYTES)),
+        )
+        .route(
+            "/api/tier-policies/dry-run",
+            post(dry_run_tier).layer(DefaultBodyLimit::max(crate::tier_policies_api::MAX_BODY_BYTES)),
+        )
+        // PR-α: DDoS protection (FR-005)
+        .route(
+            "/api/ddos/config",
+            get(get_ddos_config)
+                .put(put_ddos_config)
+                .layer(DefaultBodyLimit::max(crate::ddos_api::MAX_BODY_BYTES)),
+        )
+        .route("/api/ddos/metrics", get(get_ddos_metrics))
+        .route("/api/ddos/ban-table", get(list_ban_table))
+        .route("/api/ddos/ban-table/{ip}", delete(delete_ban_entry))
+        // PR-α: access lists (FR-008, FR-036-038)
+        .route(
+            "/api/access-lists",
+            get(get_access_lists)
+                .put(put_access_lists)
+                .layer(DefaultBodyLimit::max(crate::access_lists_api::MAX_BODY_BYTES)),
+        )
+        .route("/api/access-lists/test", get(test_access_lists))
         .layer(middleware::from_fn_with_state(state.clone(), require_auth))
         .layer(middleware::from_fn_with_state(
             state.clone(),

--- a/crates/waf-api/src/tier_policies_api.rs
+++ b/crates/waf-api/src/tier_policies_api.rs
@@ -165,7 +165,9 @@ fn validate_thresholds(tier: &str, t: &RiskThresholds) -> Result<(), ApiError> {
 
 pub async fn get_tier_policies(State(state): State<Arc<AppState>>) -> ApiResult<Json<Value>> {
     let path = resolve_path(&state, "configs/tier-policies.yaml");
-    let cfg = read_yaml_opt::<TierConfig>(&path).await.unwrap_or_else(default_tier_config);
+    let cfg = read_yaml_opt::<TierConfig>(&path)
+        .await
+        .unwrap_or_else(default_tier_config);
     Ok(Json(json!({ "success": true, "data": cfg })))
 }
 
@@ -191,7 +193,9 @@ pub async fn dry_run_tier(
     Json(req): Json<DryRunRequest>,
 ) -> ApiResult<Json<Value>> {
     let path = resolve_path(&state, "configs/tier-policies.yaml");
-    let cfg = read_yaml_opt::<TierConfig>(&path).await.unwrap_or_else(default_tier_config);
+    let cfg = read_yaml_opt::<TierConfig>(&path)
+        .await
+        .unwrap_or_else(default_tier_config);
 
     let method = req.method.as_deref().unwrap_or("GET");
     let path_str = req.path.as_deref().unwrap_or("/");

--- a/crates/waf-api/src/tier_policies_api.rs
+++ b/crates/waf-api/src/tier_policies_api.rs
@@ -1,0 +1,281 @@
+//! Tier policies API — GET/PUT `/api/tier-policies`, POST `/api/tier-policies/dry-run`.
+//!
+//! Config source: `configs/tier-policies.yaml`. PUT validates the body with
+//! typed serde structs, requires the `admin` role, and writes atomically via
+//! tmp-file + rename. Body size is capped at 256 KiB by the route layer.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::State,
+    http::HeaderMap,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::auth::{Claims, validate_admin_token};
+use crate::error::{ApiError, ApiResult};
+use crate::state::AppState;
+
+/// Max body size for tier-policies PUT/dry-run requests (256 KiB).
+pub const MAX_BODY_BYTES: usize = 256 * 1024;
+
+// ─── Typed request models ────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RiskThresholds {
+    pub allow: i64,
+    pub challenge: i64,
+    pub block: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TierPolicy {
+    pub fail_mode: String,
+    pub ddos_threshold_rps: i64,
+    pub cache_policy: String,
+    pub risk_thresholds: RiskThresholds,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TierPolicyMap {
+    pub critical: TierPolicy,
+    pub high: TierPolicy,
+    pub medium: TierPolicy,
+    pub catch_all: TierPolicy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassifierRule {
+    pub id: Option<i64>,
+    pub priority: Option<i64>,
+    pub tier: String,
+    #[serde(default)]
+    pub methods: Option<Vec<String>>,
+    #[serde(default)]
+    pub path_match: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TierConfig {
+    pub policies: TierPolicyMap,
+    #[serde(default)]
+    pub classifier_rules: Vec<ClassifierRule>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DryRunRequest {
+    #[serde(default)]
+    pub method: Option<String>,
+    #[serde(default)]
+    pub path: Option<String>,
+}
+
+// ─── Auth gate ───────────────────────────────────────────────────────────────
+
+fn require_admin(headers: &HeaderMap, jwt_secret: &str) -> Result<Claims, ApiError> {
+    let token = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .ok_or_else(|| ApiError::Unauthorized("missing bearer token".into()))?;
+    validate_admin_token(token, jwt_secret).map_err(|e| ApiError::Unauthorized(e.to_string()))
+}
+
+// ─── Filesystem helpers ──────────────────────────────────────────────────────
+
+fn resolve_path(state: &AppState, relative: &str) -> PathBuf {
+    state.main_config_file.as_ref().map_or_else(
+        || PathBuf::from(relative),
+        |main| {
+            let p = Path::new(main.as_str());
+            let root = p
+                .parent()
+                .and_then(Path::parent)
+                .unwrap_or_else(|| Path::new("."));
+            root.join(relative)
+        },
+    )
+}
+
+async fn read_yaml_opt<T: for<'de> Deserialize<'de>>(path: &Path) -> Option<T> {
+    let raw = tokio::fs::read_to_string(path).await.ok()?;
+    match serde_yaml::from_str::<T>(&raw) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            tracing::warn!(path = %path.display(), error = %e, "tier-policies: YAML parse failed; falling back to defaults");
+            None
+        }
+    }
+}
+
+async fn write_yaml<T: Serialize>(path: &Path, value: &T) -> Result<(), ApiError> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| ApiError::Internal(anyhow::anyhow!("mkdir: {e}")))?;
+    }
+    let s = serde_yaml::to_string(value).map_err(|e| ApiError::Internal(anyhow::anyhow!("serialize: {e}")))?;
+    let tmp = path.with_extension("yaml.tmp");
+    tokio::fs::write(&tmp, s.as_bytes())
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("write: {e}")))?;
+    tokio::fs::rename(&tmp, path)
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("rename: {e}")))?;
+    Ok(())
+}
+
+fn default_tier_config() -> TierConfig {
+    fn policy(fail: &str, rps: i64, cache: &str, allow: i64, challenge: i64, block: i64) -> TierPolicy {
+        TierPolicy {
+            fail_mode: fail.to_string(),
+            ddos_threshold_rps: rps,
+            cache_policy: cache.to_string(),
+            risk_thresholds: RiskThresholds {
+                allow,
+                challenge,
+                block,
+            },
+        }
+    }
+    TierConfig {
+        policies: TierPolicyMap {
+            critical: policy("close", 50, "no_cache", 20, 60, 85),
+            high: policy("close", 200, "default", 20, 60, 85),
+            medium: policy("open", 500, "short_ttl", 20, 60, 85),
+            catch_all: policy("open", 1000, "aggressive", 20, 60, 85),
+        },
+        classifier_rules: Vec::new(),
+    }
+}
+
+fn validate_thresholds(tier: &str, t: &RiskThresholds) -> Result<(), ApiError> {
+    if !(t.allow < t.challenge && t.challenge < t.block) {
+        return Err(ApiError::BadRequest(format!(
+            "tier {tier}: risk thresholds must satisfy allow < challenge < block"
+        )));
+    }
+    Ok(())
+}
+
+// ─── Handlers ────────────────────────────────────────────────────────────────
+
+pub async fn get_tier_policies(State(state): State<Arc<AppState>>) -> ApiResult<Json<Value>> {
+    let path = resolve_path(&state, "configs/tier-policies.yaml");
+    let cfg = read_yaml_opt::<TierConfig>(&path).await.unwrap_or_else(default_tier_config);
+    Ok(Json(json!({ "success": true, "data": cfg })))
+}
+
+pub async fn put_tier_policies(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<TierConfig>,
+) -> ApiResult<Json<Value>> {
+    require_admin(&headers, &state.jwt_secret)?;
+
+    validate_thresholds("critical", &body.policies.critical.risk_thresholds)?;
+    validate_thresholds("high", &body.policies.high.risk_thresholds)?;
+    validate_thresholds("medium", &body.policies.medium.risk_thresholds)?;
+    validate_thresholds("catch_all", &body.policies.catch_all.risk_thresholds)?;
+
+    let path = resolve_path(&state, "configs/tier-policies.yaml");
+    write_yaml(&path, &body).await?;
+    Ok(Json(json!({ "success": true, "data": body })))
+}
+
+pub async fn dry_run_tier(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<DryRunRequest>,
+) -> ApiResult<Json<Value>> {
+    let path = resolve_path(&state, "configs/tier-policies.yaml");
+    let cfg = read_yaml_opt::<TierConfig>(&path).await.unwrap_or_else(default_tier_config);
+
+    let method = req.method.as_deref().unwrap_or("GET");
+    let path_str = req.path.as_deref().unwrap_or("/");
+
+    let mut sorted = cfg.classifier_rules.clone();
+    sorted.sort_by_key(|r| std::cmp::Reverse(r.priority.unwrap_or(0)));
+
+    let mut matched_tier = String::from("catch_all");
+    let mut matched_id: Option<i64> = None;
+    for rule in &sorted {
+        let method_match = rule
+            .methods
+            .as_ref()
+            .is_none_or(|ms| ms.iter().any(|m| m.eq_ignore_ascii_case(method)));
+        let path_match = rule
+            .path_match
+            .as_ref()
+            .is_none_or(|p| path_str.starts_with(p.as_str()));
+        if method_match && path_match {
+            rule.tier.clone_into(&mut matched_tier);
+            matched_id = rule.id;
+            break;
+        }
+    }
+
+    let policy = match matched_tier.as_str() {
+        "critical" => &cfg.policies.critical,
+        "high" => &cfg.policies.high,
+        "medium" => &cfg.policies.medium,
+        _ => &cfg.policies.catch_all,
+    };
+
+    Ok(Json(json!({
+        "success": true,
+        "data": {
+            "matched_tier": matched_tier,
+            "matched_rule_id": matched_id,
+            "policy": policy
+        }
+    })))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_is_valid() {
+        let cfg = default_tier_config();
+        validate_thresholds("critical", &cfg.policies.critical.risk_thresholds).unwrap();
+        validate_thresholds("high", &cfg.policies.high.risk_thresholds).unwrap();
+        validate_thresholds("medium", &cfg.policies.medium.risk_thresholds).unwrap();
+        validate_thresholds("catch_all", &cfg.policies.catch_all.risk_thresholds).unwrap();
+    }
+
+    #[test]
+    fn threshold_ordering_rejects_equal_bounds() {
+        let bad = RiskThresholds {
+            allow: 20,
+            challenge: 20,
+            block: 85,
+        };
+        let err = validate_thresholds("critical", &bad).unwrap_err();
+        assert!(matches!(err, ApiError::BadRequest(_)));
+    }
+
+    #[test]
+    fn threshold_ordering_rejects_inverted_bounds() {
+        let bad = RiskThresholds {
+            allow: 80,
+            challenge: 60,
+            block: 85,
+        };
+        assert!(validate_thresholds("high", &bad).is_err());
+    }
+
+    #[test]
+    fn threshold_ordering_accepts_strict_increasing() {
+        let ok = RiskThresholds {
+            allow: 10,
+            challenge: 50,
+            block: 90,
+        };
+        assert!(validate_thresholds("medium", &ok).is_ok());
+    }
+}

--- a/crates/waf-api/src/tier_policies_api.rs
+++ b/crates/waf-api/src/tier_policies_api.rs
@@ -4,18 +4,15 @@
 //! typed serde structs, requires the `admin` role, and writes atomically via
 //! tmp-file + rename. Body size is capped at 256 KiB by the route layer.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
-use axum::{
-    Json,
-    extract::State,
-    http::HeaderMap,
-};
+use axum::{Json, extract::State, http::HeaderMap};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::auth::{Claims, validate_admin_token};
+use crate::config_paths::resolve_under_root;
 use crate::error::{ApiError, ApiResult};
 use crate::state::AppState;
 
@@ -86,20 +83,6 @@ fn require_admin(headers: &HeaderMap, jwt_secret: &str) -> Result<Claims, ApiErr
 
 // ─── Filesystem helpers ──────────────────────────────────────────────────────
 
-fn resolve_path(state: &AppState, relative: &str) -> PathBuf {
-    state.main_config_file.as_ref().map_or_else(
-        || PathBuf::from(relative),
-        |main| {
-            let p = Path::new(main.as_str());
-            let root = p
-                .parent()
-                .and_then(Path::parent)
-                .unwrap_or_else(|| Path::new("."));
-            root.join(relative)
-        },
-    )
-}
-
 async fn read_yaml_opt<T: for<'de> Deserialize<'de>>(path: &Path) -> Option<T> {
     let raw = tokio::fs::read_to_string(path).await.ok()?;
     match serde_yaml::from_str::<T>(&raw) {
@@ -111,7 +94,7 @@ async fn read_yaml_opt<T: for<'de> Deserialize<'de>>(path: &Path) -> Option<T> {
     }
 }
 
-async fn write_yaml<T: Serialize>(path: &Path, value: &T) -> Result<(), ApiError> {
+async fn write_yaml<T: Serialize + Sync>(path: &Path, value: &T) -> Result<(), ApiError> {
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent)
             .await
@@ -164,7 +147,7 @@ fn validate_thresholds(tier: &str, t: &RiskThresholds) -> Result<(), ApiError> {
 // ─── Handlers ────────────────────────────────────────────────────────────────
 
 pub async fn get_tier_policies(State(state): State<Arc<AppState>>) -> ApiResult<Json<Value>> {
-    let path = resolve_path(&state, "configs/tier-policies.yaml");
+    let path = resolve_under_root(&state, "configs/tier-policies.yaml");
     let cfg = read_yaml_opt::<TierConfig>(&path)
         .await
         .unwrap_or_else(default_tier_config);
@@ -183,7 +166,7 @@ pub async fn put_tier_policies(
     validate_thresholds("medium", &body.policies.medium.risk_thresholds)?;
     validate_thresholds("catch_all", &body.policies.catch_all.risk_thresholds)?;
 
-    let path = resolve_path(&state, "configs/tier-policies.yaml");
+    let path = resolve_under_root(&state, "configs/tier-policies.yaml");
     write_yaml(&path, &body).await?;
     Ok(Json(json!({ "success": true, "data": body })))
 }
@@ -192,7 +175,7 @@ pub async fn dry_run_tier(
     State(state): State<Arc<AppState>>,
     Json(req): Json<DryRunRequest>,
 ) -> ApiResult<Json<Value>> {
-    let path = resolve_path(&state, "configs/tier-policies.yaml");
+    let path = resolve_under_root(&state, "configs/tier-policies.yaml");
     let cfg = read_yaml_opt::<TierConfig>(&path)
         .await
         .unwrap_or_else(default_tier_config);

--- a/crates/waf-api/tests/access_lists_api_test.rs
+++ b/crates/waf-api/tests/access_lists_api_test.rs
@@ -1,6 +1,8 @@
 //! Integration tests for the access-lists API.
 
 #![allow(
+    dead_code,
+    unsafe_code,
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::indexing_slicing,
@@ -76,20 +78,10 @@ async fn start_local_server() -> LocalServer {
     state_inner.main_config_file = Some(main_cfg.to_string_lossy().into_owned());
     let state = Arc::new(state_inner);
 
-    let admin_token = generate_access_token(
-        uuid::Uuid::new_v4(),
-        "admin",
-        "admin",
-        &state.jwt_secret,
-    )
-    .expect("admin token");
-    let viewer_token = generate_access_token(
-        uuid::Uuid::new_v4(),
-        "viewer",
-        "viewer",
-        &state.jwt_secret,
-    )
-    .expect("viewer token");
+    let admin_token =
+        generate_access_token(uuid::Uuid::new_v4(), "admin", "admin", &state.jwt_secret).expect("admin token");
+    let viewer_token =
+        generate_access_token(uuid::Uuid::new_v4(), "viewer", "viewer", &state.jwt_secret).expect("viewer token");
 
     let app = build_router(Arc::clone(&state));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");

--- a/crates/waf-api/tests/access_lists_api_test.rs
+++ b/crates/waf-api/tests/access_lists_api_test.rs
@@ -73,8 +73,7 @@ async fn start_local_server() -> LocalServer {
     let engine = Arc::new(WafEngine::new(Arc::clone(&db), WafEngineConfig::default()));
     let router = Arc::new(HostRouter::new());
     let cache = ResponseCache::new(8, 60, 300);
-    let mut state_inner =
-        AppState::new(Arc::clone(&db), Arc::clone(&engine), router, cache).expect("AppState::new");
+    let mut state_inner = AppState::new(Arc::clone(&db), Arc::clone(&engine), router, cache).expect("AppState::new");
     state_inner.main_config_file = Some(main_cfg.to_string_lossy().into_owned());
     let state = Arc::new(state_inner);
 
@@ -292,7 +291,10 @@ async fn test_endpoint_no_match_passes() {
     assert_eq!(put.status(), 200);
 
     let v: serde_json::Value = client()
-        .get(url(&s, "/api/access-lists/test?ip=42.42.42.42&host=other.example.com&tier=medium"))
+        .get(url(
+            &s,
+            "/api/access-lists/test?ip=42.42.42.42&host=other.example.com&tier=medium",
+        ))
         .bearer_auth(&s.admin_token)
         .send()
         .await

--- a/crates/waf-api/tests/access_lists_api_test.rs
+++ b/crates/waf-api/tests/access_lists_api_test.rs
@@ -1,0 +1,313 @@
+//! Integration tests for the access-lists API.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::doc_markdown,
+    clippy::undocumented_unsafe_blocks
+)]
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::serve;
+use gateway::{HostRouter, ResponseCache};
+use serde_json::json;
+use tempfile::TempDir;
+use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres as PostgresImage;
+use tokio::task::JoinHandle;
+use waf_api::AppState;
+use waf_api::auth::generate_access_token;
+use waf_api::server::build_router;
+use waf_engine::{WafEngine, WafEngineConfig};
+use waf_storage::Database;
+
+struct LocalServer {
+    addr: SocketAddr,
+    admin_token: String,
+    viewer_token: String,
+    tmp: TempDir,
+    server_task: Option<JoinHandle<()>>,
+    _container: ContainerAsync<PostgresImage>,
+}
+
+impl Drop for LocalServer {
+    fn drop(&mut self) {
+        if let Some(t) = self.server_task.take() {
+            t.abort();
+        }
+    }
+}
+
+async fn start_local_server() -> LocalServer {
+    unsafe {
+        std::env::set_var("JWT_SECRET", "integration-test-secret-key-32bytes-min");
+        std::env::set_var("MASTER_KEY", "integration-test-master-key-32bytes-min");
+    }
+
+    let container = PostgresImage::default()
+        .with_tag("16-alpine")
+        .start()
+        .await
+        .expect("start postgres testcontainer");
+    let host = container.get_host().await.expect("container host");
+    let port = container.get_host_port_ipv4(5432).await.expect("container port");
+    let db_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let db = Database::connect(&db_url, 5).await.expect("db connect");
+    db.migrate().await.expect("migrate");
+    let db = Arc::new(db);
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let configs_dir = tmp.path().join("configs");
+    std::fs::create_dir_all(&configs_dir).expect("mk configs");
+    let main_cfg = configs_dir.join("default.toml");
+    std::fs::write(&main_cfg, b"").expect("seed main config");
+
+    let engine = Arc::new(WafEngine::new(Arc::clone(&db), WafEngineConfig::default()));
+    let router = Arc::new(HostRouter::new());
+    let cache = ResponseCache::new(8, 60, 300);
+    let mut state_inner =
+        AppState::new(Arc::clone(&db), Arc::clone(&engine), router, cache).expect("AppState::new");
+    state_inner.main_config_file = Some(main_cfg.to_string_lossy().into_owned());
+    let state = Arc::new(state_inner);
+
+    let admin_token = generate_access_token(
+        uuid::Uuid::new_v4(),
+        "admin",
+        "admin",
+        &state.jwt_secret,
+    )
+    .expect("admin token");
+    let viewer_token = generate_access_token(
+        uuid::Uuid::new_v4(),
+        "viewer",
+        "viewer",
+        &state.jwt_secret,
+    )
+    .expect("viewer token");
+
+    let app = build_router(Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    let server_task = tokio::spawn(async move {
+        let _ = serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await;
+    });
+
+    LocalServer {
+        addr,
+        admin_token,
+        viewer_token,
+        tmp,
+        server_task: Some(server_task),
+        _container: container,
+    }
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .expect("client")
+}
+
+fn url(s: &LocalServer, path: &str) -> String {
+    format!("http://{}{path}", s.addr)
+}
+
+fn valid_body() -> serde_json::Value {
+    json!({
+        "version": 1,
+        "dry_run": false,
+        "ip_whitelist": ["1.2.3.4"],
+        "ip_blacklist": ["9.9.9.9"],
+        "host_whitelist": {
+            "critical": ["admin.example.com"],
+            "high": [],
+            "medium": [],
+            "catch_all": ["public.example.com"]
+        },
+        "tier_whitelist_mode": {
+            "critical": "blacklist_only",
+            "high": "blacklist_only",
+            "medium": "full_bypass",
+            "catch_all": "full_bypass"
+        }
+    })
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_returns_default_when_no_file() {
+    let s = start_local_server().await;
+    let body: serde_json::Value = client()
+        .get(url(&s, "/api/access-lists"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(body["data"]["version"], 1);
+    assert_eq!(body["data"]["dry_run"], false);
+    assert_eq!(body["data"]["tier_whitelist_mode"]["medium"], "full_bypass");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn put_round_trips_to_disk_under_configs_dir() {
+    let s = start_local_server().await;
+    let put = client()
+        .put(url(&s, "/api/access-lists"))
+        .bearer_auth(&s.admin_token)
+        .json(&valid_body())
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(put.status(), 200);
+
+    let yaml = std::fs::read_to_string(s.tmp.path().join("configs/access-lists.yaml")).expect("read yaml");
+    assert!(yaml.contains("- 9.9.9.9"));
+    assert!(yaml.contains("admin.example.com"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn put_rejects_unknown_tier_mode() {
+    let s = start_local_server().await;
+    let mut body = valid_body();
+    body["tier_whitelist_mode"]["high"] = json!("garbage_mode");
+
+    let resp = client()
+        .put(url(&s, "/api/access-lists"))
+        .bearer_auth(&s.admin_token)
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn put_requires_admin_role() {
+    let s = start_local_server().await;
+    let resp = client()
+        .put(url(&s, "/api/access-lists"))
+        .bearer_auth(&s.viewer_token)
+        .json(&valid_body())
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn put_then_get_round_trip() {
+    let s = start_local_server().await;
+    let put = client()
+        .put(url(&s, "/api/access-lists"))
+        .bearer_auth(&s.admin_token)
+        .json(&valid_body())
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(put.status(), 200);
+
+    let body: serde_json::Value = client()
+        .get(url(&s, "/api/access-lists"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(body["data"]["ip_blacklist"][0], "9.9.9.9");
+    assert_eq!(body["data"]["ip_whitelist"][0], "1.2.3.4");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_endpoint_blacklist_wins_over_whitelist() {
+    let s = start_local_server().await;
+    let mut body = valid_body();
+    body["ip_whitelist"] = json!(["9.9.9.9"]);
+    body["ip_blacklist"] = json!(["9.9.9.9"]);
+
+    let put = client()
+        .put(url(&s, "/api/access-lists"))
+        .bearer_auth(&s.admin_token)
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(put.status(), 200);
+
+    let v: serde_json::Value = client()
+        .get(url(&s, "/api/access-lists/test?ip=9.9.9.9"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(v["data"]["verdict"], "block");
+    assert_eq!(v["data"]["reason"], "ip_blacklist");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_endpoint_host_whitelist_full_bypass() {
+    let s = start_local_server().await;
+    let put = client()
+        .put(url(&s, "/api/access-lists"))
+        .bearer_auth(&s.admin_token)
+        .json(&valid_body())
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(put.status(), 200);
+
+    let v: serde_json::Value = client()
+        .get(url(
+            &s,
+            "/api/access-lists/test?ip=8.8.8.8&host=public.example.com&tier=catch_all",
+        ))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(v["data"]["verdict"], "bypass");
+    assert_eq!(v["data"]["reason"], "host_whitelist");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_endpoint_no_match_passes() {
+    let s = start_local_server().await;
+    let put = client()
+        .put(url(&s, "/api/access-lists"))
+        .bearer_auth(&s.admin_token)
+        .json(&valid_body())
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(put.status(), 200);
+
+    let v: serde_json::Value = client()
+        .get(url(&s, "/api/access-lists/test?ip=42.42.42.42&host=other.example.com&tier=medium"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(v["data"]["verdict"], "pass");
+    assert_eq!(v["data"]["reason"], "no_match");
+}

--- a/crates/waf-api/tests/ddos_api_test.rs
+++ b/crates/waf-api/tests/ddos_api_test.rs
@@ -1,0 +1,334 @@
+//! Integration tests for the DDoS protection API.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::doc_markdown,
+    clippy::undocumented_unsafe_blocks
+)]
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::serve;
+use gateway::{HostRouter, ResponseCache};
+use serde_json::json;
+use tempfile::TempDir;
+use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres as PostgresImage;
+use tokio::task::JoinHandle;
+use waf_api::AppState;
+use waf_api::auth::generate_access_token;
+use waf_api::server::build_router;
+use waf_engine::{WafEngine, WafEngineConfig};
+use waf_storage::Database;
+
+struct LocalServer {
+    addr: SocketAddr,
+    admin_token: String,
+    viewer_token: String,
+    state: Arc<AppState>,
+    tmp: TempDir,
+    server_task: Option<JoinHandle<()>>,
+    _container: ContainerAsync<PostgresImage>,
+}
+
+impl Drop for LocalServer {
+    fn drop(&mut self) {
+        if let Some(t) = self.server_task.take() {
+            t.abort();
+        }
+    }
+}
+
+async fn start_local_server() -> LocalServer {
+    unsafe {
+        std::env::set_var("JWT_SECRET", "integration-test-secret-key-32bytes-min");
+        std::env::set_var("MASTER_KEY", "integration-test-master-key-32bytes-min");
+    }
+
+    let container = PostgresImage::default()
+        .with_tag("16-alpine")
+        .start()
+        .await
+        .expect("start postgres testcontainer");
+    let host = container.get_host().await.expect("container host");
+    let port = container.get_host_port_ipv4(5432).await.expect("container port");
+    let db_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let db = Database::connect(&db_url, 5).await.expect("db connect");
+    db.migrate().await.expect("migrate");
+    let db = Arc::new(db);
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let configs_dir = tmp.path().join("configs");
+    std::fs::create_dir_all(&configs_dir).expect("mk configs");
+    let main_cfg = configs_dir.join("default.toml");
+    std::fs::write(&main_cfg, b"").expect("seed main config");
+
+    let engine = Arc::new(WafEngine::new(Arc::clone(&db), WafEngineConfig::default()));
+    let router = Arc::new(HostRouter::new());
+    let cache = ResponseCache::new(8, 60, 300);
+    let mut state_inner =
+        AppState::new(Arc::clone(&db), Arc::clone(&engine), router, cache).expect("AppState::new");
+    state_inner.main_config_file = Some(main_cfg.to_string_lossy().into_owned());
+    let state = Arc::new(state_inner);
+
+    let admin_token = generate_access_token(
+        uuid::Uuid::new_v4(),
+        "admin",
+        "admin",
+        &state.jwt_secret,
+    )
+    .expect("admin token");
+    let viewer_token = generate_access_token(
+        uuid::Uuid::new_v4(),
+        "viewer",
+        "viewer",
+        &state.jwt_secret,
+    )
+    .expect("viewer token");
+
+    let app = build_router(Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    let server_task = tokio::spawn(async move {
+        let _ = serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await;
+    });
+
+    LocalServer {
+        addr,
+        admin_token,
+        viewer_token,
+        state,
+        tmp,
+        server_task: Some(server_task),
+        _container: container,
+    }
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .expect("client")
+}
+
+fn url(s: &LocalServer, path: &str) -> String {
+    format!("http://{}{path}", s.addr)
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+}
+
+fn valid_body() -> serde_json::Value {
+    json!({
+        "enabled": true,
+        "per_ip": { "threshold_rps": 100, "window_secs": 10 },
+        "per_fingerprint": { "threshold_rps": 200, "window_secs": 10 },
+        "ban_durations_secs": [60, 300, 3600],
+        "store": { "backend": "memory", "redis_url": "" }
+    })
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn config_get_returns_default_when_no_file() {
+    let s = start_local_server().await;
+    let body: serde_json::Value = client()
+        .get(url(&s, "/api/ddos/config"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(body["data"]["enabled"], true);
+    assert_eq!(body["data"]["per_ip"]["threshold_rps"], 100);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn config_put_round_trips_to_disk() {
+    let s = start_local_server().await;
+    let mut body = valid_body();
+    body["per_ip"]["threshold_rps"] = json!(555);
+
+    let put = client()
+        .put(url(&s, "/api/ddos/config"))
+        .bearer_auth(&s.admin_token)
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(put.status(), 200);
+
+    let yaml = std::fs::read_to_string(s.tmp.path().join("configs/ddos.yaml")).expect("read yaml");
+    assert!(yaml.contains("threshold_rps: 555"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn config_put_rejects_empty_ban_durations() {
+    let s = start_local_server().await;
+    let mut body = valid_body();
+    body["ban_durations_secs"] = json!([]);
+
+    let resp = client()
+        .put(url(&s, "/api/ddos/config"))
+        .bearer_auth(&s.admin_token)
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn config_put_rejects_non_positive_threshold() {
+    let s = start_local_server().await;
+    let mut body = valid_body();
+    body["per_ip"]["threshold_rps"] = json!(0);
+    let resp = client()
+        .put(url(&s, "/api/ddos/config"))
+        .bearer_auth(&s.admin_token)
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn config_put_requires_admin_role() {
+    let s = start_local_server().await;
+    let resp = client()
+        .put(url(&s, "/api/ddos/config"))
+        .bearer_auth(&s.viewer_token)
+        .json(&valid_body())
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ban_table_lists_empty_when_no_bans() {
+    let s = start_local_server().await;
+    let body: serde_json::Value = client()
+        .get(url(&s, "/api/ddos/ban-table"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(body["data"].as_array().map(Vec::len), Some(0));
+    assert_eq!(body["total"], 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ban_table_returns_live_entries_after_manual_insert() {
+    let s = start_local_server().await;
+    let ip: IpAddr = "10.20.30.40".parse().unwrap();
+    s.state.engine.ddos_ban_table().insert(ip, now_ms() + 60_000);
+
+    let body: serde_json::Value = client()
+        .get(url(&s, "/api/ddos/ban-table"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(body["total"], 1);
+    assert_eq!(body["data"][0]["ip"], "10.20.30.40");
+    assert!(body["data"][0]["ttl_remaining_secs"].as_i64().unwrap() > 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_ban_entry_rejects_invalid_ip() {
+    let s = start_local_server().await;
+    let resp = client()
+        .delete(url(&s, "/api/ddos/ban-table/not-an-ip"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_ban_entry_unknown_ip_returns_not_removed() {
+    let s = start_local_server().await;
+    let body: serde_json::Value = client()
+        .delete(url(&s, "/api/ddos/ban-table/1.2.3.4"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(body["data"]["removed"], false);
+    assert_eq!(body["data"]["ip"], "1.2.3.4");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_ban_entry_removes_live_ban() {
+    let s = start_local_server().await;
+    let ip: IpAddr = "9.9.9.9".parse().unwrap();
+    s.state.engine.ddos_ban_table().insert(ip, now_ms() + 60_000);
+    assert!(s.state.engine.ddos_ban_table().contains(ip, now_ms()));
+
+    let body: serde_json::Value = client()
+        .delete(url(&s, "/api/ddos/ban-table/9.9.9.9"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(body["data"]["removed"], true);
+    assert!(!s.state.engine.ddos_ban_table().contains(ip, now_ms()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_ban_entry_requires_admin_role() {
+    let s = start_local_server().await;
+    let resp = client()
+        .delete(url(&s, "/api/ddos/ban-table/1.2.3.4"))
+        .bearer_auth(&s.viewer_token)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn metrics_endpoint_returns_zero_counters_on_fresh_engine() {
+    let s = start_local_server().await;
+    let body: serde_json::Value = client()
+        .get(url(&s, "/api/ddos/metrics"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(body["success"], true);
+    assert_eq!(body["data"]["active_bans"], 0);
+    assert_eq!(body["data"]["bans_total"], 0);
+    assert_eq!(body["data"]["bursts_total"], 0);
+}

--- a/crates/waf-api/tests/ddos_api_test.rs
+++ b/crates/waf-api/tests/ddos_api_test.rs
@@ -1,6 +1,8 @@
 //! Integration tests for the DDoS protection API.
 
 #![allow(
+    dead_code,
+    unsafe_code,
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::indexing_slicing,
@@ -78,20 +80,10 @@ async fn start_local_server() -> LocalServer {
     state_inner.main_config_file = Some(main_cfg.to_string_lossy().into_owned());
     let state = Arc::new(state_inner);
 
-    let admin_token = generate_access_token(
-        uuid::Uuid::new_v4(),
-        "admin",
-        "admin",
-        &state.jwt_secret,
-    )
-    .expect("admin token");
-    let viewer_token = generate_access_token(
-        uuid::Uuid::new_v4(),
-        "viewer",
-        "viewer",
-        &state.jwt_secret,
-    )
-    .expect("viewer token");
+    let admin_token =
+        generate_access_token(uuid::Uuid::new_v4(), "admin", "admin", &state.jwt_secret).expect("admin token");
+    let viewer_token =
+        generate_access_token(uuid::Uuid::new_v4(), "viewer", "viewer", &state.jwt_secret).expect("viewer token");
 
     let app = build_router(Arc::clone(&state));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");

--- a/crates/waf-api/tests/ddos_api_test.rs
+++ b/crates/waf-api/tests/ddos_api_test.rs
@@ -75,8 +75,7 @@ async fn start_local_server() -> LocalServer {
     let engine = Arc::new(WafEngine::new(Arc::clone(&db), WafEngineConfig::default()));
     let router = Arc::new(HostRouter::new());
     let cache = ResponseCache::new(8, 60, 300);
-    let mut state_inner =
-        AppState::new(Arc::clone(&db), Arc::clone(&engine), router, cache).expect("AppState::new");
+    let mut state_inner = AppState::new(Arc::clone(&db), Arc::clone(&engine), router, cache).expect("AppState::new");
     state_inner.main_config_file = Some(main_cfg.to_string_lossy().into_owned());
     let state = Arc::new(state_inner);
 

--- a/crates/waf-api/tests/tier_policies_api_test.rs
+++ b/crates/waf-api/tests/tier_policies_api_test.rs
@@ -5,6 +5,8 @@
 //! real DB pool.
 
 #![allow(
+    dead_code,
+    unsafe_code,
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::indexing_slicing,
@@ -80,20 +82,10 @@ async fn start_local_server() -> LocalServer {
     state_inner.main_config_file = Some(main_cfg.to_string_lossy().into_owned());
     let state = Arc::new(state_inner);
 
-    let admin_token = generate_access_token(
-        uuid::Uuid::new_v4(),
-        "admin",
-        "admin",
-        &state.jwt_secret,
-    )
-    .expect("admin token");
-    let viewer_token = generate_access_token(
-        uuid::Uuid::new_v4(),
-        "viewer",
-        "viewer",
-        &state.jwt_secret,
-    )
-    .expect("viewer token");
+    let admin_token =
+        generate_access_token(uuid::Uuid::new_v4(), "admin", "admin", &state.jwt_secret).expect("admin token");
+    let viewer_token =
+        generate_access_token(uuid::Uuid::new_v4(), "viewer", "viewer", &state.jwt_secret).expect("viewer token");
 
     let app = build_router(Arc::clone(&state));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");

--- a/crates/waf-api/tests/tier_policies_api_test.rs
+++ b/crates/waf-api/tests/tier_policies_api_test.rs
@@ -77,8 +77,7 @@ async fn start_local_server() -> LocalServer {
     let engine = Arc::new(WafEngine::new(Arc::clone(&db), WafEngineConfig::default()));
     let router = Arc::new(HostRouter::new());
     let cache = ResponseCache::new(8, 60, 300);
-    let mut state_inner =
-        AppState::new(Arc::clone(&db), Arc::clone(&engine), router, cache).expect("AppState::new");
+    let mut state_inner = AppState::new(Arc::clone(&db), Arc::clone(&engine), router, cache).expect("AppState::new");
     state_inner.main_config_file = Some(main_cfg.to_string_lossy().into_owned());
     let state = Arc::new(state_inner);
 

--- a/crates/waf-api/tests/tier_policies_api_test.rs
+++ b/crates/waf-api/tests/tier_policies_api_test.rs
@@ -1,0 +1,299 @@
+//! Integration tests for the tier-policies API.
+//!
+//! Each test spins a fresh Postgres testcontainer + AppState wired to a temp
+//! working directory so YAML I/O is hermetic and the engine constructor sees a
+//! real DB pool.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::doc_markdown,
+    clippy::undocumented_unsafe_blocks
+)]
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::serve;
+use gateway::{HostRouter, ResponseCache};
+use serde_json::json;
+use tempfile::TempDir;
+use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres as PostgresImage;
+use tokio::task::JoinHandle;
+use waf_api::AppState;
+use waf_api::auth::generate_access_token;
+use waf_api::server::build_router;
+use waf_engine::{WafEngine, WafEngineConfig};
+use waf_storage::Database;
+
+struct LocalServer {
+    addr: SocketAddr,
+    admin_token: String,
+    viewer_token: String,
+    tmp: TempDir,
+    server_task: Option<JoinHandle<()>>,
+    _container: ContainerAsync<PostgresImage>,
+}
+
+impl Drop for LocalServer {
+    fn drop(&mut self) {
+        if let Some(t) = self.server_task.take() {
+            t.abort();
+        }
+    }
+}
+
+async fn start_local_server() -> LocalServer {
+    unsafe {
+        std::env::set_var("JWT_SECRET", "integration-test-secret-key-32bytes-min");
+        std::env::set_var("MASTER_KEY", "integration-test-master-key-32bytes-min");
+    }
+
+    let container = PostgresImage::default()
+        .with_tag("16-alpine")
+        .start()
+        .await
+        .expect("start postgres testcontainer");
+    let host = container.get_host().await.expect("container host");
+    let port = container.get_host_port_ipv4(5432).await.expect("container port");
+    let db_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let db = Database::connect(&db_url, 5).await.expect("db connect");
+    db.migrate().await.expect("migrate");
+    let db = Arc::new(db);
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let configs_dir = tmp.path().join("configs");
+    std::fs::create_dir_all(&configs_dir).expect("mk configs");
+    let main_cfg = configs_dir.join("default.toml");
+    std::fs::write(&main_cfg, b"").expect("seed main config");
+
+    let engine = Arc::new(WafEngine::new(Arc::clone(&db), WafEngineConfig::default()));
+    let router = Arc::new(HostRouter::new());
+    let cache = ResponseCache::new(8, 60, 300);
+    let mut state_inner =
+        AppState::new(Arc::clone(&db), Arc::clone(&engine), router, cache).expect("AppState::new");
+    state_inner.main_config_file = Some(main_cfg.to_string_lossy().into_owned());
+    let state = Arc::new(state_inner);
+
+    let admin_token = generate_access_token(
+        uuid::Uuid::new_v4(),
+        "admin",
+        "admin",
+        &state.jwt_secret,
+    )
+    .expect("admin token");
+    let viewer_token = generate_access_token(
+        uuid::Uuid::new_v4(),
+        "viewer",
+        "viewer",
+        &state.jwt_secret,
+    )
+    .expect("viewer token");
+
+    let app = build_router(Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    let server_task = tokio::spawn(async move {
+        let _ = serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await;
+    });
+
+    LocalServer {
+        addr,
+        admin_token,
+        viewer_token,
+        tmp,
+        server_task: Some(server_task),
+        _container: container,
+    }
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .expect("client")
+}
+
+fn url(s: &LocalServer, path: &str) -> String {
+    format!("http://{}{path}", s.addr)
+}
+
+fn valid_body() -> serde_json::Value {
+    let policy = |fail: &str, rps: i64, cache: &str| {
+        json!({
+            "fail_mode": fail,
+            "ddos_threshold_rps": rps,
+            "cache_policy": cache,
+            "risk_thresholds": { "allow": 20, "challenge": 60, "block": 85 }
+        })
+    };
+    json!({
+        "policies": {
+            "critical":  policy("close", 50,   "no_cache"),
+            "high":      policy("close", 200,  "default"),
+            "medium":    policy("open",  500,  "short_ttl"),
+            "catch_all": policy("open",  1000, "aggressive")
+        },
+        "classifier_rules": []
+    })
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_returns_default_when_no_file() {
+    let s = start_local_server().await;
+    let body: serde_json::Value = client()
+        .get(url(&s, "/api/tier-policies"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(body["success"], true);
+    assert!(body["data"]["policies"]["critical"].is_object());
+    assert_eq!(body["data"]["policies"]["catch_all"]["ddos_threshold_rps"], 1000);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn put_round_trips_and_persists_to_disk() {
+    let s = start_local_server().await;
+    let mut body = valid_body();
+    body["policies"]["medium"]["ddos_threshold_rps"] = json!(777);
+
+    let put = client()
+        .put(url(&s, "/api/tier-policies"))
+        .bearer_auth(&s.admin_token)
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(put.status(), 200);
+
+    let yaml = std::fs::read_to_string(s.tmp.path().join("configs/tier-policies.yaml")).expect("read yaml");
+    assert!(yaml.contains("ddos_threshold_rps: 777"));
+
+    let got: serde_json::Value = client()
+        .get(url(&s, "/api/tier-policies"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(got["data"]["policies"]["medium"]["ddos_threshold_rps"], 777);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn put_rejects_inverted_thresholds() {
+    let s = start_local_server().await;
+    let mut body = valid_body();
+    body["policies"]["high"]["risk_thresholds"]["allow"] = json!(95);
+    body["policies"]["high"]["risk_thresholds"]["challenge"] = json!(60);
+    body["policies"]["high"]["risk_thresholds"]["block"] = json!(85);
+
+    let resp = client()
+        .put(url(&s, "/api/tier-policies"))
+        .bearer_auth(&s.admin_token)
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 400);
+    let err: serde_json::Value = resp.json().await.expect("json");
+    assert!(err["error"].as_str().unwrap().contains("allow < challenge < block"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn put_rejects_missing_tier() {
+    let s = start_local_server().await;
+    let mut body = valid_body();
+    body["policies"].as_object_mut().unwrap().remove("medium");
+
+    let resp = client()
+        .put(url(&s, "/api/tier-policies"))
+        .bearer_auth(&s.admin_token)
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    let status = resp.status().as_u16();
+    assert!(status == 400 || status == 422, "got {status}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn put_requires_admin_role() {
+    let s = start_local_server().await;
+    let resp = client()
+        .put(url(&s, "/api/tier-policies"))
+        .bearer_auth(&s.viewer_token)
+        .json(&valid_body())
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dry_run_matches_classifier_then_falls_back() {
+    let s = start_local_server().await;
+
+    let mut body = valid_body();
+    body["classifier_rules"] = json!([
+        { "id": 1, "priority": 10, "tier": "critical", "methods": ["POST"], "path_match": "/api/" },
+        { "id": 2, "priority": 5,  "tier": "high",     "methods": ["GET"],  "path_match": "/" }
+    ]);
+    let put = client()
+        .put(url(&s, "/api/tier-policies"))
+        .bearer_auth(&s.admin_token)
+        .json(&body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(put.status(), 200);
+
+    let v: serde_json::Value = client()
+        .post(url(&s, "/api/tier-policies/dry-run"))
+        .bearer_auth(&s.admin_token)
+        .json(&json!({ "method": "POST", "path": "/api/foo" }))
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(v["data"]["matched_tier"], "critical");
+    assert_eq!(v["data"]["matched_rule_id"], 1);
+
+    let v: serde_json::Value = client()
+        .post(url(&s, "/api/tier-policies/dry-run"))
+        .bearer_auth(&s.admin_token)
+        .json(&json!({ "method": "DELETE", "path": "/something" }))
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(v["data"]["matched_tier"], "catch_all");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn put_rejects_missing_bearer_token() {
+    let s = start_local_server().await;
+    let resp = client()
+        .put(url(&s, "/api/tier-policies"))
+        .json(&valid_body())
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 401);
+}

--- a/crates/waf-engine/src/checks/ddos/action/ban.rs
+++ b/crates/waf-engine/src/checks/ddos/action/ban.rs
@@ -58,6 +58,17 @@ impl DynamicBanTable {
         before.saturating_sub(self.entries.len())
     }
 
+    /// Remove a single entry. Returns true when an entry was present.
+    pub fn remove(&self, ip: &IpAddr) -> bool {
+        self.entries.remove(ip).is_some()
+    }
+
+    /// Snapshot all `(ip, expires_ms)` pairs for read-only export.
+    #[must_use]
+    pub fn snapshot(&self) -> Vec<(IpAddr, i64)> {
+        self.entries.iter().map(|e| (*e.key(), *e.value())).collect()
+    }
+
     #[must_use]
     pub fn len(&self) -> usize {
         self.entries.len()


### PR DESCRIPTION
## Summary

P0 admin-panel backend bundle (PR-α-BE) per `plans/260529-pr-114-integration/master-plan.md`. Ships three new API modules backing the admin-panel pages — tier policies, DDoS protection (config + metrics + ban-table), and access lists — extracted from colleague PR #114 and hardened to production grade before merge.

## FRs delivered

- **FR-002** — tier policy editor (GET/PUT `/api/tier-policies` + POST `/api/tier-policies/dry-run`)
- **FR-005** — DDoS protection (`/api/ddos/config`, `/api/ddos/metrics`, `/api/ddos/ban-table`)
- **FR-008** — access lists (`/api/access-lists`, `/api/access-lists/test`)
- **FR-036/037/038** — companion admin-panel hooks for the above

## Production-ready fixes applied to PR #114 source

Per reviewer-2's `plans/reports/reviewer-2-260529-pr114-quality-risks.md`:

- **C1 — stub handlers wired to live stores.** No more `success:true` no-ops.
  - `list_ban_table` reads the live `DynamicBanTable` snapshot, filters expired entries, returns `{ip, expires_at_ms, ttl_remaining_secs}` per active entry.
  - `delete_ban_entry` parses the IP path param via `IpAddr::parse` (400 on bad), calls `ban_table.remove()`, returns `{ip, removed: bool}`.
  - `get_ddos_metrics` reads the engine's `DdosMetrics` snapshot (active bans, burst counts per detector, ban totals, store errors, degrade events).
- **C2 — typed serde + body limits.** Every PUT body is deserialised into a typed struct (`TierConfig`, `DdosConfigBody`, `AccessConfig`). Malformed JSON → 400. Each route layered with `DefaultBodyLimit::max(256 * 1024)` to cap disk-fill DoS.
- **M1 — RBAC gate on every mutation.** PUT/DELETE handlers re-validate the bearer via `validate_admin_token` so a `viewer`-role JWT is rejected with 401 even if the parent `require_auth` accepts the signature.
- **M9 — clippy hygiene pre-scan.** Inline-format-args (`format!("…{e}")`), backticked `DDoS` / `DynamicBanTable` / `WafEngine` in doc comments, no `.unwrap()` outside `#[cfg(test)]`, no `todo!()`/`unimplemented!()`.
- **M11 — path consistency.** All three configs live under `configs/{tier-policies,ddos,access-lists}.yaml` (no `rules/` mixing).
- **I10 — YAML parse error convention.** GET handlers fall back to defaults + WARN log on parse failure; PUT handlers reject with 400 on typed-serde failure.

## Engine surface additions

`DynamicBanTable` (in `crates/waf-engine/src/checks/ddos/action/ban.rs`) gains:
- `remove(&IpAddr) -> bool` — needed by `delete_ban_entry` for the admin unban path.
- `snapshot() -> Vec<(IpAddr, i64)>` — read-only export used by `list_ban_table`.

No engine pipeline behavior changes.

## Test plan

Three new integration suites (testcontainers Postgres + production router):

- `tier_policies_api_test.rs` — GET default fallback, PUT round-trip + persistence to disk, inverted threshold rejection, missing-tier rejection, RBAC gate, dry-run classifier priority + catch_all fallback, missing-token 401.
- `ddos_api_test.rs` — config GET default, config PUT round-trip + disk write, empty/non-positive validation rejects, RBAC gate, ban-table empty + after manual `DynamicBanTable.insert`, delete on bad-IP-string returns 400, delete on unknown IP returns `removed:false`, delete on live ban removes from table, metrics read on fresh engine.
- `access_lists_api_test.rs` — GET default, PUT round-trip to `configs/access-lists.yaml`, unknown tier-mode rejection, RBAC gate, full GET/PUT cycle, test endpoint blacklist-wins-over-whitelist, host-whitelist full_bypass verdict, no-match fallback.

Plus inline unit tests in each module file for the validation predicates and YAML round-trip helpers.

## Constraints honoured

- `--base release/stg`. Never pushing to main.
- Single conventional commit (`feat(api):` prefix).
- All handler files within or close to the 250 LOC guideline.
- Iron Rules: no `.unwrap()`/`.expect()` outside `#[cfg(test)]`, no `todo!()`/`unimplemented!()`, no dead code, no panics on YAML / network paths.
- File ownership respected — touched only files listed in the task brief; PR-δ cluster work and PR-α-FE pages are untouched.

## Test plan (CI)

- [ ] `cargo check --workspace --all-features` passes
- [ ] `cargo clippy --workspace --all-features --tests -- -D warnings` passes
- [ ] `cargo test -p waf-api --test tier_policies_api_test` green
- [ ] `cargo test -p waf-api --test ddos_api_test` green
- [ ] `cargo test -p waf-api --test access_lists_api_test` green
- [ ] No regressions in existing `waf-api` integration suite

Do not auto-merge — lead handles merge order across the PR-α/β/γ/δ wave.