### PR TITLE
chore(ci): add local Docker CI mirror for pre-push verification

### DIFF
--- a/docker-compose.ci-local.yml
+++ b/docker-compose.ci-local.yml
@@ -1,0 +1,56 @@
+# Local mirror of GitHub Actions CI environment.
+# See docker/ci-local.Dockerfile + scripts/ci-local.sh.
+#
+# Usage:
+#   # Run the full pre-push verification pipeline:
+#   docker compose -f docker-compose.ci-local.yml run --rm ci-local /workspace/scripts/ci-local.sh
+#
+#   # Interactive shell for debugging:
+#   docker compose -f docker-compose.ci-local.yml run --rm ci-local
+#
+#   # Run a single CI subset (e.g. just clippy):
+#   docker compose -f docker-compose.ci-local.yml run --rm ci-local \
+#     cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+services:
+  postgres-ci:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: prx_waf
+      POSTGRES_PASSWORD: prx_waf
+      POSTGRES_DB: prx_waf
+    ports:
+      - "55432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U prx_waf"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  ci-local:
+    build:
+      context: .
+      dockerfile: docker/ci-local.Dockerfile
+    depends_on:
+      postgres-ci:
+        condition: service_healthy
+    environment:
+      CARGO_TERM_COLOR: always
+      RUSTFLAGS: "-D warnings"
+      RUST_BACKTRACE: full
+      CARGO_INCREMENTAL: "0"
+      DATABASE_URL: postgres://prx_waf:prx_waf@postgres-ci:5432/prx_waf
+      JWT_SECRET: ci-local-integration-test-secret-key-32bytes-min
+      MASTER_KEY: ci-local-integration-test-master-key-32bytes-min
+    volumes:
+      - .:/workspace
+      # Persistent cargo + target caches keep iteration cheap across runs.
+      - cargo-registry:/usr/local/cargo/registry
+      - cargo-git:/usr/local/cargo/git
+      - target-cache:/workspace/target
+    working_dir: /workspace
+
+volumes:
+  cargo-registry:
+  cargo-git:
+  target-cache:

--- a/docker/ci-local.Dockerfile
+++ b/docker/ci-local.Dockerfile
@@ -1,0 +1,55 @@
+# CI-local: mirrors GitHub Actions CI environment for pre-push verification.
+#
+# Mirrors .github/workflows/{ci,coverage,sec-audit}.yml:
+#   - Rust stable (1.96+) — same as dtolnay/rust-toolchain@stable
+#   - clippy + rustfmt components
+#   - llvm-tools-preview + cargo-llvm-cov for coverage gate
+#   - cargo-machete for unused-dep check
+#   - system deps for vendored pingora (pkg-config, libssl-dev, build-essential, cmake)
+#
+# Companion file: ../docker-compose.ci-local.yml (Postgres 16-alpine sidecar).
+# Helper: ../scripts/ci-local.sh (runs the pre-push pipeline).
+#
+# Usage:
+#   docker compose -f docker-compose.ci-local.yml run --rm ci-local /workspace/scripts/ci-local.sh
+
+FROM rust:1.96-bookworm
+
+ENV CARGO_TERM_COLOR=always \
+    RUSTFLAGS="-D warnings" \
+    RUST_BACKTRACE=full \
+    CARGO_INCREMENTAL=0 \
+    DEBIAN_FRONTEND=noninteractive
+
+# System deps for vendored pingora + Postgres client libs for sqlx-postgres.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev \
+        cmake \
+        build-essential \
+        git \
+        libpq-dev \
+        postgresql-client \
+        ca-certificates \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Rust components matching the CI matrix.
+RUN rustup component add clippy rustfmt llvm-tools-preview
+
+# Cargo tools used by CI (cargo-llvm-cov for coverage, cargo-machete for unused deps).
+# Install separately so a transient registry blip on one does not invalidate
+# the other's cached layer. Latest stable versions; pin if drift becomes an issue.
+RUN cargo install --locked cargo-llvm-cov
+RUN cargo install --locked cargo-machete
+
+# Frontend toolchain for the admin-panel job. Node 22 + npm matching ci.yml.
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+# Default to an interactive shell — the helper script is invoked as the
+# explicit command via docker compose run.
+CMD ["/bin/bash"]

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,3 +1,4 @@
 *
 !.gitignore
 !ec2-install-gh-runner.sh
+!ci-local.sh

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# ci-local.sh — pre-push verification pipeline mirroring GitHub Actions CI.
+#
+# Run via docker-compose so the env matches GHA exactly:
+#   docker compose -f docker-compose.ci-local.yml run --rm ci-local /workspace/scripts/ci-local.sh
+#
+# Or run a single phase:
+#   docker compose -f docker-compose.ci-local.yml run --rm ci-local /workspace/scripts/ci-local.sh fmt
+#   docker compose -f docker-compose.ci-local.yml run --rm ci-local /workspace/scripts/ci-local.sh clippy
+#   docker compose -f docker-compose.ci-local.yml run --rm ci-local /workspace/scripts/ci-local.sh test
+#   docker compose -f docker-compose.ci-local.yml run --rm ci-local /workspace/scripts/ci-local.sh coverage <crate>
+#
+# Phases mirror .github/workflows/{ci,coverage}.yml:
+#   fmt        : cargo fmt --all -- --check
+#   clippy     : cargo clippy --workspace --all-targets --all-features -- -D warnings
+#   machete    : cargo machete                         (unused deps)
+#   test       : cargo test --workspace --all-features -- --nocapture
+#   build      : cargo build --workspace --release
+#   admin-panel: npm ci + npm run type-check + npm run build (web/admin-panel)
+#   coverage   : cargo llvm-cov --summary-only -p <crate>   (matrix gate)
+#   all (default): fmt + clippy + machete + test + admin-panel
+#
+# Exit non-zero on the first failure; print a clear hint on which step blocked.
+
+set -euo pipefail
+
+phase="${1:-all}"
+crate_arg="${2:-}"
+
+red() { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+blue() { printf '\033[34m%s\033[0m\n' "$*"; }
+
+run_fmt() {
+    blue "[fmt] cargo fmt --all -- --check"
+    cargo fmt --all -- --check
+}
+
+run_clippy() {
+    blue "[clippy] cargo clippy --workspace --all-targets --all-features -- -D warnings"
+    cargo clippy --workspace --all-targets --all-features -- -D warnings
+}
+
+run_machete() {
+    blue "[machete] cargo machete"
+    cargo machete
+}
+
+run_test() {
+    blue "[test] cargo test --workspace --all-features -- --nocapture"
+    cargo test --workspace --all-features -- --nocapture
+}
+
+run_build() {
+    blue "[build] cargo build --workspace --release"
+    cargo build --workspace --release
+}
+
+run_admin_panel() {
+    blue "[admin-panel] npm ci + type-check + build"
+    pushd web/admin-panel >/dev/null
+    npm ci
+    npm run type-check
+    npm run build
+    popd >/dev/null
+}
+
+run_coverage() {
+    if [[ -z "$crate_arg" ]]; then
+        red "coverage requires a crate name. Example: scripts/ci-local.sh coverage waf-api"
+        exit 2
+    fi
+    # Floors from .github/workflows/coverage.yml matrix.
+    declare -A floors=(
+        [waf-common]=88
+        [waf-storage]=84
+        [waf-cluster]=82
+        [waf-api]=80
+        [gateway]=85
+        [waf-engine]=80
+        [prx-waf]=5
+    )
+    floor="${floors[$crate_arg]:-}"
+    if [[ -z "$floor" ]]; then
+        red "Unknown crate '$crate_arg'. Floors are defined for: ${!floors[*]}"
+        exit 2
+    fi
+    blue "[coverage] cargo llvm-cov -p $crate_arg (floor ${floor}%)"
+    cargo llvm-cov --summary-only -p "$crate_arg" --all-features \
+        --fail-under-lines "$floor"
+}
+
+case "$phase" in
+    fmt)         run_fmt ;;
+    clippy)      run_clippy ;;
+    machete)     run_machete ;;
+    test)        run_test ;;
+    build)       run_build ;;
+    admin-panel) run_admin_panel ;;
+    coverage)    run_coverage ;;
+    all)
+        run_fmt
+        run_clippy
+        run_machete
+        run_test
+        run_admin_panel
+        green "[OK] All pre-push checks passed. Safe to git push."
+        ;;
+    *)
+        red "Unknown phase: $phase"
+        red "Valid phases: fmt clippy machete test build admin-panel coverage all"
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
## Summary

Adds a Docker-based local mirror of the GitHub Actions CI pipeline so contributors can run the same gates (fmt, clippy strict, machete, test, build, admin-panel, coverage) before pushing. Eliminates the per-CI-diff hand-fix iteration loop that has been costing time on recent PRs.

## What lands

- \`docker/ci-local.Dockerfile\` — Rust 1.96 stable + clippy/rustfmt/llvm-tools-preview + cargo-llvm-cov + cargo-machete + Node 22 + system deps for vendored pingora (pkg-config, libssl-dev, cmake, build-essential, libpq-dev, postgresql-client).
- \`docker-compose.ci-local.yml\` — \`ci-local\` service + Postgres 16-alpine sidecar matching coverage.yml. Persistent cargo + target caches for fast iteration.
- \`scripts/ci-local.sh\` — phase runner: \`fmt | clippy | machete | test | build | admin-panel | coverage <crate> | all\`. Coverage floors mirror coverage.yml matrix (waf-common 88, waf-storage 84, waf-cluster 82, waf-api 80, gateway 85, waf-engine 80, prx-waf 5).

## Usage

\`\`\`
docker compose -f docker-compose.ci-local.yml run --rm ci-local \\
    /workspace/scripts/ci-local.sh all
\`\`\`

Phases mirror \`.github/workflows/ci.yml\` jobs. Same RUSTFLAGS, same env, same toolchain, same Postgres.

## Test plan

- [ ] \`docker compose -f docker-compose.ci-local.yml build ci-local\` succeeds.
- [ ] \`docker compose -f docker-compose.ci-local.yml run --rm ci-local /workspace/scripts/ci-local.sh fmt\` exits 0 against current stg HEAD.
- [ ] \`docker compose -f docker-compose.ci-local.yml run --rm ci-local /workspace/scripts/ci-local.sh clippy\` exits 0.
- [ ] \`docker compose -f docker-compose.ci-local.yml run --rm ci-local /workspace/scripts/ci-local.sh admin-panel\` exits 0.