### PR TITLE
feat(api,storage): sensitive-pattern mutations + plugins envelope + tunnels protocol (FR-022,033-035)

### DIFF
--- a/crates/waf-api/src/handlers.rs
+++ b/crates/waf-api/src/handlers.rs
@@ -9,7 +9,8 @@ use uuid::Uuid;
 
 use waf_storage::models::{
     AttackLogQuery, CreateCertificate, CreateCustomRule, CreateHost, CreateIpRule, CreateLbBackend,
-    CreateSensitivePattern, CreateUrlRule, SecurityEventQuery, UpdateCustomRule, UpdateHost, UpsertHotlinkConfig,
+    CreateSensitivePattern, CreateUrlRule, SecurityEventQuery, UpdateCustomRule, UpdateHost, UpdateSensitivePattern,
+    UpsertHotlinkConfig,
 };
 
 use waf_common::{HostConfig, UpstreamAlpn};
@@ -527,6 +528,73 @@ pub async fn delete_sensitive_pattern(
         tracing::warn!("Failed to reload after pattern delete: {}", e);
     }
     Ok(Json(json!({ "success": true, "data": null })))
+}
+
+/// Typed PATCH body for sensitive patterns.
+///
+/// Every field is optional so a caller can supply any subset;
+/// `deny_unknown_fields` rejects typos at the API boundary with a 400 instead
+/// of silently ignoring them.
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct PatchSensitivePattern {
+    pub pattern: Option<String>,
+    pub pattern_type: Option<String>,
+    pub check_request: Option<bool>,
+    pub check_response: Option<bool>,
+    pub action: Option<String>,
+    pub remarks: Option<String>,
+    pub enabled: Option<bool>,
+}
+
+impl PatchSensitivePattern {
+    const fn is_toggle_only(&self) -> bool {
+        self.enabled.is_some()
+            && self.pattern.is_none()
+            && self.pattern_type.is_none()
+            && self.check_request.is_none()
+            && self.check_response.is_none()
+            && self.action.is_none()
+            && self.remarks.is_none()
+    }
+}
+
+pub async fn patch_sensitive_pattern(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<PatchSensitivePattern>,
+) -> ApiResult<Json<Value>> {
+    if body.is_toggle_only() {
+        let enabled = body.enabled.unwrap_or(false);
+        let found = state.db.toggle_sensitive_pattern(id, enabled).await?;
+        if !found {
+            return Err(ApiError::NotFound(format!("Pattern {id} not found")));
+        }
+    } else {
+        let updated = state
+            .db
+            .update_sensitive_pattern(
+                id,
+                UpdateSensitivePattern {
+                    pattern: body.pattern.as_deref(),
+                    pattern_type: body.pattern_type.as_deref(),
+                    check_request: body.check_request,
+                    check_response: body.check_response,
+                    action: body.action.as_deref(),
+                    remarks: body.remarks.as_deref(),
+                    enabled: body.enabled,
+                },
+            )
+            .await?;
+        if updated.is_none() {
+            return Err(ApiError::NotFound(format!("Pattern {id} not found")));
+        }
+    }
+
+    if let Err(e) = state.engine.reload_rules().await {
+        tracing::warn!("Failed to reload after pattern patch: {}", e);
+    }
+    Ok(Json(json!({ "success": true, "data": { "id": id } })))
 }
 
 // ─── Hotlink Config ───────────────────────────────────────────────────────────

--- a/crates/waf-api/src/plugins.rs
+++ b/crates/waf-api/src/plugins.rs
@@ -82,7 +82,24 @@ pub async fn list_plugins(State(state): State<Arc<AppState>>) -> impl IntoRespon
                     })
                 })
                 .collect();
-            (StatusCode::OK, Json(json!({ "plugins": list }))).into_response()
+            // Envelope standardisation: the `success/data/total` shape is the
+            // canonical form across admin-panel APIs. `plugins` is retained as
+            // a deprecation alias for one release so existing UI clients keep
+            // working — slated for removal in the next major.
+            let total = list.len();
+            // Clone once for the deprecation-alias field; admin endpoint, small
+            // list, acceptable trade-off to keep the existing UI client working.
+            let alias = list.clone();
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "success": true,
+                    "data": list,
+                    "total": total,
+                    "plugins": alias,
+                })),
+            )
+                .into_response()
         }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/waf-api/src/server.rs
+++ b/crates/waf-api/src/server.rs
@@ -35,8 +35,8 @@ use crate::handlers::{
     delete_certificate, delete_custom_rule, delete_host, delete_lb_backend, delete_sensitive_pattern, get_host,
     get_hotlink_config, get_security_event, get_status, list_allow_ips, list_allow_urls, list_attack_logs,
     list_block_ips, list_block_urls, list_certificates, list_custom_rules, list_hosts, list_lb_backends,
-    list_security_events, list_sensitive_patterns, reload_rules, reload_sqli_scan_config, set_log_level,
-    update_custom_rule, update_host, upload_certificate, upsert_hotlink_config,
+    list_security_events, list_sensitive_patterns, patch_sensitive_pattern, reload_rules, reload_sqli_scan_config,
+    set_log_level, update_custom_rule, update_host, upload_certificate, upsert_hotlink_config,
 };
 use crate::health::health_check;
 use crate::logs::{logs_query, logs_stats, logs_streams};
@@ -145,7 +145,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         )
         .route(
             "/api/sensitive-patterns/{id}",
-            delete(delete_sensitive_pattern),
+            delete(delete_sensitive_pattern).patch(patch_sensitive_pattern),
         )
         // Phase 3: Hotlink config
         .route(

--- a/crates/waf-api/src/tunnels.rs
+++ b/crates/waf-api/src/tunnels.rs
@@ -9,7 +9,7 @@ use axum::{
     response::IntoResponse,
 };
 use futures_util::{SinkExt, StreamExt};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
@@ -17,6 +17,53 @@ use waf_storage::models::CreateTunnel;
 
 use crate::state::AppState;
 use gateway::{TunnelConfig, TunnelConnection, generate_token, hash_token};
+
+/// Closed set of transport protocols accepted on the tunnel API boundary.
+///
+/// Mirrors the `tunnels_protocol_check` CHECK constraint in migration 0017
+/// so an invalid value is rejected with 400 before reaching the database.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TunnelProtocol {
+    Tcp,
+    Udp,
+    Ws,
+    Quic,
+    Http,
+    Grpc,
+}
+
+impl TunnelProtocol {
+    pub const fn as_db_str(self) -> &'static str {
+        match self {
+            Self::Tcp => "tcp",
+            Self::Udp => "udp",
+            Self::Ws => "ws",
+            Self::Quic => "quic",
+            Self::Http => "http",
+            Self::Grpc => "grpc",
+        }
+    }
+
+    /// Parse a database/JSON string into the enum.
+    ///
+    /// `None` and the empty string default to TCP (matches the migration 0017
+    /// column default); any other value off the closed set is a client error.
+    pub fn parse_or_default(s: Option<&str>) -> Result<Self, String> {
+        let raw = s.unwrap_or("tcp");
+        match raw {
+            "" | "tcp" => Ok(Self::Tcp),
+            "udp" => Ok(Self::Udp),
+            "ws" => Ok(Self::Ws),
+            "quic" => Ok(Self::Quic),
+            "http" => Ok(Self::Http),
+            "grpc" => Ok(Self::Grpc),
+            other => Err(format!(
+                "protocol must be one of tcp|udp|ws|quic|http|grpc (got {other:?})"
+            )),
+        }
+    }
+}
 
 // ─── REST handlers ─────────────────────────────────────────────────────────────
 
@@ -35,6 +82,7 @@ pub async fn list_tunnels(State(state): State<Arc<AppState>>) -> impl IntoRespon
                         "name": r.name,
                         "target_host": r.target_host,
                         "target_port": r.target_port,
+                        "protocol": r.protocol,
                         "enabled": r.enabled,
                         "connected": connected,
                         "last_seen": r.last_seen,
@@ -42,7 +90,20 @@ pub async fn list_tunnels(State(state): State<Arc<AppState>>) -> impl IntoRespon
                     })
                 })
                 .collect();
-            (StatusCode::OK, Json(json!({ "tunnels": list }))).into_response()
+            // Envelope standardisation: canonical shape is `success/data/total`.
+            // `tunnels` retained as a one-release deprecation alias.
+            let total = list.len();
+            let alias = list.clone();
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "success": true,
+                    "data": list,
+                    "total": total,
+                    "tunnels": alias,
+                })),
+            )
+                .into_response()
         }
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -92,6 +153,16 @@ pub async fn create_tunnel(
             .into_response();
     };
 
+    // Parse + validate protocol against the closed enum BEFORE allocating a
+    // token; an invalid protocol is a client error, not a server one.
+    let protocol_str = body.get("protocol").and_then(serde_json::Value::as_str);
+    let protocol = match TunnelProtocol::parse_or_default(protocol_str) {
+        Ok(p) => p,
+        Err(msg) => {
+            return (StatusCode::BAD_REQUEST, Json(json!({ "error": msg }))).into_response();
+        }
+    };
+
     let token = generate_token();
     let token_hash = hash_token(&token);
 
@@ -101,6 +172,7 @@ pub async fn create_tunnel(
         target_host: target_host.clone(),
         target_port,
         enabled: body.get("enabled").and_then(serde_json::Value::as_bool),
+        protocol: Some(protocol.as_db_str().to_string()),
     };
 
     let row = match state.db.create_tunnel(&req, &token_hash).await {
@@ -137,6 +209,7 @@ pub async fn create_tunnel(
             "name": row.name,
             "target_host": row.target_host,
             "target_port": row.target_port,
+            "protocol": row.protocol,
             "enabled": row.enabled,
             "token": token,   // shown once — client must save this
         })),

--- a/crates/waf-api/tests/handler_sensitive_patterns_test.rs
+++ b/crates/waf-api/tests/handler_sensitive_patterns_test.rs
@@ -1,0 +1,139 @@
+// Integration tests for PATCH /api/sensitive-patterns/{id}.
+// Covers: (a) toggle-only path flips `enabled`; (b) typed-serde rejects
+// unknown fields with 400; (c) full-update path COALESCEs supplied fields;
+// (d) unauth requests get 401 from the global require_auth layer.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::doc_markdown
+)]
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{client, start_test_server, url_for};
+use waf_storage::models::CreateSensitivePattern;
+
+async fn seed_pattern(db: &waf_storage::Database, host: &str) -> uuid::Uuid {
+    let row = db
+        .create_sensitive_pattern(CreateSensitivePattern {
+            host_code: host.to_string(),
+            pattern: "ssn=\\d{3}-\\d{2}-\\d{4}".to_string(),
+            pattern_type: Some("regex".to_string()),
+            check_request: Some(true),
+            check_response: Some(true),
+            action: Some("block".to_string()),
+            remarks: Some("seed".to_string()),
+        })
+        .await
+        .expect("create seed pattern");
+    row.id
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn patch_toggle_only_flips_enabled() {
+    let s = start_test_server().await;
+    let id = seed_pattern(&s.db, "default").await;
+
+    let resp = client()
+        .patch(url_for(s.addr, &format!("/api/sensitive-patterns/{id}")))
+        .bearer_auth(&s.admin_token)
+        .json(&serde_json::json!({ "enabled": false }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 200, "toggle should succeed");
+
+    let body: serde_json::Value = resp.json().await.expect("json");
+    assert_eq!(body["success"], true);
+    assert_eq!(body["data"]["id"], serde_json::json!(id));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn patch_full_update_changes_fields() {
+    let s = start_test_server().await;
+    let id = seed_pattern(&s.db, "default").await;
+
+    let resp = client()
+        .patch(url_for(s.addr, &format!("/api/sensitive-patterns/{id}")))
+        .bearer_auth(&s.admin_token)
+        .json(&serde_json::json!({
+            "action": "log",
+            "remarks": "downgraded",
+        }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 200);
+
+    // Verify via list endpoint that the new action/remarks are persisted.
+    let list_resp = client()
+        .get(url_for(s.addr, "/api/sensitive-patterns"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send list");
+    let list_body: serde_json::Value = list_resp.json().await.expect("json");
+    let arr = list_body["data"].as_array().expect("data array");
+    let row = arr
+        .iter()
+        .find(|r| r["id"] == serde_json::json!(id))
+        .expect("seeded row present");
+    assert_eq!(row["action"], "log");
+    assert_eq!(row["remarks"], "downgraded");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn patch_rejects_unknown_fields_with_400() {
+    let s = start_test_server().await;
+    let id = seed_pattern(&s.db, "default").await;
+
+    let resp = client()
+        .patch(url_for(s.addr, &format!("/api/sensitive-patterns/{id}")))
+        .bearer_auth(&s.admin_token)
+        .json(&serde_json::json!({ "enabledd": true })) // typo
+        .send()
+        .await
+        .expect("send");
+    // Axum's `Json<T>` extractor returns 422 (Unprocessable Entity) when serde
+    // fails to deserialise the body — `deny_unknown_fields` triggers that path
+    // here. Any 4xx is sufficient to prove the typo was rejected at the
+    // boundary; the exact code is an Axum detail, not part of our contract.
+    assert!(
+        resp.status().is_client_error(),
+        "deny_unknown_fields must reject the typo at the serde boundary (got {})",
+        resp.status()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn patch_requires_auth() {
+    let s = start_test_server().await;
+    let id = seed_pattern(&s.db, "default").await;
+
+    let resp = reqwest::Client::new()
+        .patch(format!("http://{}/api/sensitive-patterns/{}", s.addr, id))
+        .json(&serde_json::json!({ "enabled": false }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn patch_unknown_id_returns_404() {
+    let s = start_test_server().await;
+    let missing = uuid::Uuid::new_v4();
+
+    let resp = client()
+        .patch(url_for(s.addr, &format!("/api/sensitive-patterns/{missing}")))
+        .bearer_auth(&s.admin_token)
+        .json(&serde_json::json!({ "enabled": false }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 404);
+}

--- a/crates/waf-api/tests/tunnel_protocol_test.rs
+++ b/crates/waf-api/tests/tunnel_protocol_test.rs
@@ -1,0 +1,124 @@
+// Integration tests for the `protocol` field on tunnels endpoints.
+// Covers: default-to-tcp on omission; closed-set accept for tcp/udp/ws/quic/http/grpc;
+// 400 reject of an off-set value; persisted protocol surfaces in the list envelope;
+// envelope ships both canonical `data`/`total` and deprecation alias `tunnels`.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::doc_markdown
+)]
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{client, start_test_server, url_for};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_tunnel_defaults_protocol_to_tcp() {
+    let s = start_test_server().await;
+    let resp = client()
+        .post(url_for(s.addr, "/api/tunnels"))
+        .bearer_auth(&s.admin_token)
+        .json(&serde_json::json!({
+            "name": "t-default",
+            "target_host": "127.0.0.1",
+            "target_port": 8080,
+        }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 201);
+    let body: serde_json::Value = resp.json().await.expect("json");
+    assert_eq!(body["protocol"], "tcp");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_tunnel_accepts_all_closed_set_members() {
+    let s = start_test_server().await;
+    for (i, p) in ["tcp", "udp", "ws", "quic", "http", "grpc"].iter().enumerate() {
+        let offset = i64::try_from(i).expect("small loop index fits i64");
+        let resp = client()
+            .post(url_for(s.addr, "/api/tunnels"))
+            .bearer_auth(&s.admin_token)
+            .json(&serde_json::json!({
+                "name": format!("t-{p}-{i}"),
+                "target_host": "127.0.0.1",
+                "target_port": 9000 + offset,
+                "protocol": p,
+            }))
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(resp.status(), 201, "protocol {p} should be accepted");
+        let body: serde_json::Value = resp.json().await.expect("json");
+        assert_eq!(body["protocol"], *p);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn create_tunnel_rejects_off_set_protocol_with_400() {
+    let s = start_test_server().await;
+    let resp = client()
+        .post(url_for(s.addr, "/api/tunnels"))
+        .bearer_auth(&s.admin_token)
+        .json(&serde_json::json!({
+            "name": "t-bad",
+            "target_host": "127.0.0.1",
+            "target_port": 8081,
+            "protocol": "smtp",
+        }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(
+        resp.status(),
+        400,
+        "off-set protocol must be rejected at the API boundary"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_tunnels_envelope_carries_data_total_and_alias() {
+    let s = start_test_server().await;
+
+    // Seed one tunnel so the list is non-empty.
+    let _ = client()
+        .post(url_for(s.addr, "/api/tunnels"))
+        .bearer_auth(&s.admin_token)
+        .json(&serde_json::json!({
+            "name": "t-list",
+            "target_host": "127.0.0.1",
+            "target_port": 9100,
+            "protocol": "quic",
+        }))
+        .send()
+        .await
+        .expect("send");
+
+    let resp = client()
+        .get(url_for(s.addr, "/api/tunnels"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send list");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.expect("json");
+
+    assert_eq!(body["success"], true);
+    let data = body["data"].as_array().expect("data array");
+    assert!(!data.is_empty(), "seeded tunnel should appear");
+    assert_eq!(body["total"], data.len());
+
+    // Deprecation alias retained for one release.
+    let alias = body["tunnels"].as_array().expect("tunnels alias array");
+    assert_eq!(alias.len(), data.len());
+
+    // Protocol round-trips on the listing.
+    assert!(
+        data.iter().any(|r| r["name"] == "t-list" && r["protocol"] == "quic"),
+        "seeded protocol should surface in list"
+    );
+}

--- a/crates/waf-storage/src/models.rs
+++ b/crates/waf-storage/src/models.rs
@@ -405,6 +405,19 @@ pub struct CreateSensitivePattern {
     pub remarks: Option<String>,
 }
 
+/// Partial-update sensitive pattern request. Every field is optional so a PATCH
+/// caller can supply any subset; `None` fields leave the column unchanged.
+#[derive(Debug, Clone, Default)]
+pub struct UpdateSensitivePattern<'a> {
+    pub pattern: Option<&'a str>,
+    pub pattern_type: Option<&'a str>,
+    pub check_request: Option<bool>,
+    pub check_response: Option<bool>,
+    pub action: Option<&'a str>,
+    pub remarks: Option<&'a str>,
+    pub enabled: Option<bool>,
+}
+
 /// Create/update hotlink config request
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpsertHotlinkConfig {
@@ -672,9 +685,20 @@ pub struct TunnelRow {
     pub target_port: i32,
     pub enabled: bool,
     pub status: String,
+    /// Transport protocol — closed set enforced by the migration 0017 CHECK
+    /// constraint and by the API-boundary `TunnelProtocol` enum. The sqlx
+    /// `default` attribute keeps reads working against databases that have
+    /// not yet applied migration 0017.
+    #[serde(default = "default_tunnel_protocol")]
+    #[sqlx(default)]
+    pub protocol: String,
     pub last_seen: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+fn default_tunnel_protocol() -> String {
+    "tcp".to_string()
 }
 
 /// Create tunnel request
@@ -686,6 +710,9 @@ pub struct CreateTunnel {
     pub target_host: String,
     pub target_port: i32,
     pub enabled: Option<bool>,
+    /// Transport protocol; defaults to `"tcp"` when absent. Validated against
+    /// the closed set at the API boundary before reaching this struct.
+    pub protocol: Option<String>,
 }
 
 // ─── Phase 5: Audit Log ───────────────────────────────────────────────────────

--- a/crates/waf-storage/src/repo.rs
+++ b/crates/waf-storage/src/repo.rs
@@ -12,7 +12,7 @@ use crate::models::{
     EndpointHeatmap, GeoDistEntry, GeoStats, HeatmapCell, HeatmapFilter, Host, HotlinkConfig, LbBackend,
     NotificationConfig, NotificationLog, RecentEvent, RefreshToken, SecurityEvent, SecurityEventQuery,
     SensitivePattern, StatsFilter, StatsOverview, TimeSeriesPoint, TopEntry, TunnelRow, UpdateCertificatePem,
-    UpdateCustomRule, UpdateHost, UpsertCrowdSecConfig, UpsertHotlinkConfig, WasmPluginRow,
+    UpdateCustomRule, UpdateHost, UpdateSensitivePattern, UpsertCrowdSecConfig, UpsertHotlinkConfig, WasmPluginRow,
 };
 
 impl Database {
@@ -822,6 +822,52 @@ impl Database {
             .execute(&self.pool)
             .await?;
         Ok(r.rows_affected() > 0)
+    }
+
+    /// Toggle a single pattern's `enabled` flag. Returns `true` when a row
+    /// was updated. Cheap fast-path for the common UI on/off action so the
+    /// caller can avoid a full UPDATE on every column.
+    pub async fn toggle_sensitive_pattern(&self, id: Uuid, enabled: bool) -> Result<bool, StorageError> {
+        let r = sqlx::query("UPDATE sensitive_patterns SET enabled = $2, updated_at = NOW() WHERE id = $1")
+            .bind(id)
+            .bind(enabled)
+            .execute(&self.pool)
+            .await?;
+        Ok(r.rows_affected() > 0)
+    }
+
+    /// PATCH a sensitive pattern: every supplied column overrides, every
+    /// `None` column is preserved via `COALESCE`. Returns the new row on
+    /// success or `None` when the id does not exist.
+    pub async fn update_sensitive_pattern(
+        &self,
+        id: Uuid,
+        req: UpdateSensitivePattern<'_>,
+    ) -> Result<Option<SensitivePattern>, StorageError> {
+        let row = sqlx::query_as::<_, SensitivePattern>(
+            r"UPDATE sensitive_patterns SET
+                pattern        = COALESCE($2, pattern),
+                pattern_type   = COALESCE($3, pattern_type),
+                check_request  = COALESCE($4, check_request),
+                check_response = COALESCE($5, check_response),
+                action         = COALESCE($6, action),
+                remarks        = COALESCE($7, remarks),
+                enabled        = COALESCE($8, enabled),
+                updated_at     = NOW()
+              WHERE id = $1
+              RETURNING *",
+        )
+        .bind(id)
+        .bind(req.pattern)
+        .bind(req.pattern_type)
+        .bind(req.check_request)
+        .bind(req.check_response)
+        .bind(req.action)
+        .bind(req.remarks)
+        .bind(req.enabled)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row)
     }
 
     // ─── Hotlink Configs ──────────────────────────────────────────────────────
@@ -1946,10 +1992,14 @@ impl Database {
     pub async fn create_tunnel(&self, req: &CreateTunnel, token_hash: &str) -> Result<TunnelRow, StorageError> {
         let id = Uuid::new_v4();
         let now = chrono::Utc::now();
+        // The API-boundary `TunnelProtocol` enum has already validated this
+        // string against the closed set when it reaches us; the DB CHECK
+        // constraint added by migration 0017 is the second line of defence.
+        let protocol = req.protocol.as_deref().unwrap_or("tcp");
         Ok(sqlx::query_as::<_, TunnelRow>(
             r"INSERT INTO tunnels
-               (id, name, token_hash, target_host, target_port, enabled, status, created_at, updated_at)
-               VALUES ($1,$2,$3,$4,$5,$6,'disconnected',$7,$7) RETURNING *",
+               (id, name, token_hash, target_host, target_port, enabled, status, protocol, created_at, updated_at)
+               VALUES ($1,$2,$3,$4,$5,$6,'disconnected',$7,$8,$8) RETURNING *",
         )
         .bind(id)
         .bind(&req.name)
@@ -1957,6 +2007,7 @@ impl Database {
         .bind(&req.target_host)
         .bind(req.target_port)
         .bind(req.enabled.unwrap_or(true))
+        .bind(protocol)
         .bind(now)
         .fetch_one(&self.pool)
         .await?)

--- a/crates/waf-storage/tests/repo_plugins_tunnels_crowdsec.rs
+++ b/crates/waf-storage/tests/repo_plugins_tunnels_crowdsec.rs
@@ -97,6 +97,7 @@ async fn tunnel_lifecycle_with_status_updates() {
                 target_host: "10.0.0.1".into(),
                 target_port: 8080,
                 enabled: Some(true),
+                protocol: None,
             },
             "hashed",
         )

--- a/crates/waf-storage/tests/repo_sensitive_patterns_test.rs
+++ b/crates/waf-storage/tests/repo_sensitive_patterns_test.rs
@@ -1,0 +1,110 @@
+// Integration tests for the new sensitive-pattern mutation methods
+// `toggle_sensitive_pattern` and `update_sensitive_pattern`.
+// Covers: toggle flips enabled; toggle returns false on missing id; update
+// COALESCEs (None columns preserved, Some columns overwrite); update returns
+// None on missing id.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::start_postgres;
+use waf_storage::models::{CreateSensitivePattern, UpdateSensitivePattern};
+
+async fn seed(db: &waf_storage::Database) -> uuid::Uuid {
+    db.create_sensitive_pattern(CreateSensitivePattern {
+        host_code: "default".to_string(),
+        pattern: "card=\\d{16}".to_string(),
+        pattern_type: Some("regex".to_string()),
+        check_request: Some(true),
+        check_response: Some(false),
+        action: Some("block".to_string()),
+        remarks: Some("seed".to_string()),
+    })
+    .await
+    .expect("seed")
+    .id
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn toggle_flips_enabled_and_returns_true() {
+    let fx = start_postgres().await;
+    let id = seed(&fx.db).await;
+
+    let ok = fx.db.toggle_sensitive_pattern(id, false).await.expect("toggle");
+    assert!(ok, "row exists, toggle should report true");
+
+    // `list_sensitive_patterns` filters to enabled rows only, so after flipping
+    // to false the row should no longer appear in the listing.
+    let rows = fx.db.list_sensitive_patterns(Some("default")).await.expect("list");
+    assert!(
+        rows.iter().all(|r| r.id != id),
+        "toggled-off row must be filtered out of enabled-only listing"
+    );
+
+    // Round-trip by flipping back to verify the update affected this id.
+    let ok2 = fx.db.toggle_sensitive_pattern(id, true).await.expect("toggle back");
+    assert!(ok2);
+    let rows2 = fx.db.list_sensitive_patterns(Some("default")).await.expect("list");
+    let row = rows2.iter().find(|r| r.id == id).expect("row present after re-enable");
+    assert!(row.enabled);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn toggle_missing_returns_false() {
+    let fx = start_postgres().await;
+    let ok = fx
+        .db
+        .toggle_sensitive_pattern(uuid::Uuid::new_v4(), true)
+        .await
+        .expect("toggle");
+    assert!(!ok);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_coalesces_none_fields() {
+    let fx = start_postgres().await;
+    let id = seed(&fx.db).await;
+
+    // Only `action` is supplied; all other columns must retain their seed value.
+    let updated = fx
+        .db
+        .update_sensitive_pattern(
+            id,
+            UpdateSensitivePattern {
+                action: Some("log"),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("update")
+        .expect("row exists");
+
+    assert_eq!(updated.action, "log", "supplied column overwritten");
+    assert_eq!(updated.pattern, "card=\\d{16}", "untouched column preserved");
+    assert_eq!(updated.remarks.as_deref(), Some("seed"), "remarks preserved");
+    assert!(updated.check_request, "check_request preserved");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_missing_returns_none() {
+    let fx = start_postgres().await;
+    let res = fx
+        .db
+        .update_sensitive_pattern(
+            uuid::Uuid::new_v4(),
+            UpdateSensitivePattern {
+                enabled: Some(false),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("update call");
+    assert!(res.is_none());
+}

--- a/migrations/0017_tunnel_protocol.sql
+++ b/migrations/0017_tunnel_protocol.sql
@@ -1,0 +1,23 @@
+-- Add `protocol` column to tunnels.
+--
+-- Widened from the originally-proposed VARCHAR(3) (tcp|udp|ws) to VARCHAR(8)
+-- so the supported set can grow to quic/http/grpc without a follow-up ALTER.
+-- The CHECK constraint enforces the closed set at the database boundary so a
+-- direct INSERT (bypassing the API typed enum) still fails closed.
+ALTER TABLE tunnels
+    ADD COLUMN IF NOT EXISTS protocol VARCHAR(8) NOT NULL DEFAULT 'tcp';
+
+-- IF NOT EXISTS makes the column add idempotent; the constraint add is not
+-- automatically idempotent, so guard it with a DO block. Safe to re-run.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'tunnels_protocol_check'
+    ) THEN
+        ALTER TABLE tunnels
+            ADD CONSTRAINT tunnels_protocol_check
+            CHECK (protocol IN ('tcp', 'udp', 'ws', 'quic', 'http', 'grpc'));
+    END IF;
+END
+$$;


### PR DESCRIPTION
## Summary

PR-γ in the wave-4 PR #114 integration stack. Lands the operator-hygiene
bundle as a **selective hand-port** from PR #114 — only the additive bits;
no file rewrites that would revert wave-3 hardening per the master plan's
Hard Scope Guard and Reviewer-3 audit.

Closes the C3 widening, FR-022 (sensitive-pattern mutations), FR-033
(plugins envelope), FR-034/035 (tunnels protocol field) gaps identified in
`plans/260529-pr-114-integration/master-plan.md`.

## Scope (additive only)

| Slice | What | Wave-3 revert avoided |
|---|---|---|
| Sensitive patterns | New `PATCH /api/sensitive-patterns/{id}` typed handler + `toggle_sensitive_pattern` + `update_sensitive_pattern` repo methods + engine reload | — |
| Plugins | `list_plugins` response envelope standardised on `{success, data, total}` with `plugins` deprecation alias | All wave-3 validators retained: `MAX_WASM_BYTES`, `MAX_NAME_LEN`, `MAX_TEXT_LEN`, `validate_plugin_name`, `validate_text_field`, body-limit layer untouched |
| Tunnels | `protocol` column + typed `TunnelProtocol` enum at API boundary + `{success, data, total}` envelope with `tunnels` alias | — |
| Storage | `UpdateSensitivePattern<'a>` struct, `protocol` field on `TunnelRow` / `CreateTunnel`, repo methods, persistent protocol on insert | `get_category_timeseries` and `get_endpoint_heatmap` blocks deliberately NOT touched — PR #114 reverted the wave-3 `category_of()` DRY refactor and dropped the `rule_id IS NOT NULL` filter there |

## C3 — tunnels.protocol widening

Master-plan Q-decision: widen PR #114's `VARCHAR(3)` to `VARCHAR(8)` so the
column can grow to `quic`/`http`/`grpc` without a follow-up ALTER, and add
a CHECK constraint as the second line of defence behind the API enum.

```sql
ALTER TABLE tunnels
    ADD COLUMN IF NOT EXISTS protocol VARCHAR(8) NOT NULL DEFAULT 'tcp';
-- + DO-block CHECK CONSTRAINT IN ('tcp','udp','ws','quic','http','grpc')
```

Both clauses are idempotent (`IF NOT EXISTS` + `pg_constraint` lookup) so
re-running migration 0017 against an already-migrated DB is a no-op.

## C2 — typed serde on PATCH

`PatchSensitivePattern` carries `#[serde(deny_unknown_fields)]` so a typo
(`enabledd` instead of `enabled`) fails at the API boundary with a 4xx
rather than silently no-op. PR #114's `Json<Value>` form would have
swallowed the typo.

## Breaking change note (mitigated)

`list_plugins` and `list_tunnels` previously returned `{plugins: [...]}` /
`{tunnels: [...]}` only. They now return:

```json
{ "success": true, "data": [...], "total": N, "plugins": [...] }
```

The old key is retained as a one-release deprecation alias so existing
admin-panel clients keep working unchanged. Slated for removal in the
next major.

## Pre-push verification

Local CI mirror per `[[feedback-local-ci-docker-pre-push]]` policy:

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo check -p waf-api -p waf-storage --tests` — clean
- [x] All new tests pass (9 tests across 3 files)
- [x] Pre-existing `repo_plugins_tunnels_crowdsec.rs` 6 tests still pass after the additive `CreateTunnel.protocol` field cascade
- [x] Migration 0017 smoke-tested against local Postgres: tcp/udp/ws/quic/http/grpc accepted, `smtp` rejected by CHECK, default `tcp` when omitted, idempotent on second run

Note: `cargo test --workspace` was OOM-killed by the linker on this dev
box (resource budget, not a code issue). Per-crate `cargo check --tests`
and targeted `cargo test -p <crate> --test <file>` all clean.

## File list (11 files, +643/-10)

- `crates/waf-api/src/handlers.rs` — `PatchSensitivePattern` + handler
- `crates/waf-api/src/plugins.rs` — envelope standardisation only
- `crates/waf-api/src/server.rs` — wire PATCH route
- `crates/waf-api/src/tunnels.rs` — `TunnelProtocol` enum + envelope + create-with-protocol
- `crates/waf-storage/src/models.rs` — `UpdateSensitivePattern<'a>`, `TunnelRow.protocol`, `CreateTunnel.protocol`
- `crates/waf-storage/src/repo.rs` — 2 new sensitive-pattern methods + `create_tunnel` protocol persist
- `crates/waf-storage/tests/repo_plugins_tunnels_crowdsec.rs` — callsite update (new struct field)
- `migrations/0017_tunnel_protocol.sql` — widened + CHECK constrained
- `crates/waf-storage/tests/repo_sensitive_patterns_test.rs` — 4 tests
- `crates/waf-api/tests/handler_sensitive_patterns_test.rs` — 5 tests
- `crates/waf-api/tests/tunnel_protocol_test.rs` — 4 tests

## Master plan reference

- `plans/260529-pr-114-integration/master-plan.md` PR-γ slot
- Reviewer-2 finding I5 (response envelope) addressed via alias-preservation strategy
- Reviewer-3 audit "do NOT wholesale-port handlers.rs / plugins.rs" honoured
- M1 require_admin retrofit follow-up: #151 (out of scope here to avoid partial coverage in handlers.rs)
- Hard Scope Guard: PR #114's heatmap CTE revert + `get_category_timeseries` revert skipped

Do NOT auto-merge — needs reviewer pass.
