### PR TITLE
ci: deploy prx-waf cluster on push to main via OIDC + SSM

### DIFF
--- a/.github/workflows/deploy-cluster.yml
+++ b/.github/workflows/deploy-cluster.yml
@@ -1,0 +1,169 @@
+name: Deploy Cluster (test)
+
+# Deploys prx-waf binary onto the 2-node test cluster after a merge to main.
+# Auth: GitHub OIDC -> AWS IAM role (no long-lived credentials in repo).
+# Transport: S3 presigned URL + SSM Run Command (no inbound SSH).
+# Target allowlist: instances tagged project=other env=dev Name=other-test-cluster-*.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'plans/**'
+      - '.github/ISSUE_TEMPLATE/**'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-cluster-test
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  deploy:
+    name: Build and deploy to test cluster
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: cluster-test-deploy
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: web/admin-panel/package-lock.json
+
+      - name: Build admin panel
+        working-directory: web/admin-panel
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: deploy-cluster
+
+      - name: Build prx-waf release
+        run: cargo build --release -p prx-waf --locked
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_DEPLOY_REGION }}
+          role-session-name: gha-deploy-cluster-${{ github.run_id }}
+
+      - name: Upload binary to S3
+        id: upload
+        run: |
+          set -euo pipefail
+          KEY="releases/${GITHUB_SHA}/prx-waf"
+          BUCKET="${{ secrets.AWS_DEPLOY_BUCKET }}"
+          aws s3 cp target/release/prx-waf "s3://${BUCKET}/${KEY}" --no-progress
+          URL=$(aws s3 presign "s3://${BUCKET}/${KEY}" --expires-in 1800)
+          echo "url=${URL}" >> "$GITHUB_OUTPUT"
+          echo "Uploaded s3://${BUCKET}/${KEY}"
+
+      - name: Discover cluster instance IDs by tag
+        id: targets
+        run: |
+          set -euo pipefail
+          IDS=$(aws ec2 describe-instances \
+            --filters \
+              "Name=tag:project,Values=other" \
+              "Name=tag:env,Values=dev" \
+              "Name=tag:Name,Values=other-test-cluster-*" \
+              "Name=instance-state-name,Values=running" \
+            --query 'Reservations[].Instances[].InstanceId' \
+            --output text)
+          if [ -z "$IDS" ]; then
+            echo "::error::No running cluster instances found"; exit 1
+          fi
+          IDS_CSV=$(echo "$IDS" | tr -s '[:space:]' ',' | sed 's/,$//')
+          echo "ids=${IDS_CSV}" >> "$GITHUB_OUTPUT"
+          echo "Targets: ${IDS_CSV}"
+
+      - name: Dispatch deploy command via SSM
+        id: ssm
+        env:
+          PRESIGNED_URL: ${{ steps.upload.outputs.url }}
+          TARGET_IDS: ${{ steps.targets.outputs.ids }}
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          IFS=',' read -ra IDS_ARR <<<"${TARGET_IDS}"
+          SCRIPT=$(cat <<'EOS'
+          set -euo pipefail
+          TMP=$(mktemp)
+          trap 'rm -f "$TMP"' EXIT
+          curl -fSL --max-time 120 --retry 2 "__URL__" -o "$TMP"
+          chmod +x "$TMP"
+          sudo install -o miniwaf -g miniwaf -m 0755 "$TMP" /opt/mini-waf/bin/prx-waf.new
+          sudo mv -f /opt/mini-waf/bin/prx-waf.new /opt/mini-waf/bin/prx-waf
+          sudo systemctl restart mini-waf
+          sleep 6
+          sudo systemctl is-active mini-waf
+          curl -fsS --max-time 5 http://127.0.0.1:9527/healthz \
+            || curl -fsS --max-time 5 http://127.0.0.1:9527/api/health \
+            || { echo "healthz failed"; sudo journalctl -u mini-waf -n 80 --no-pager; exit 1; }
+          echo "deploy OK: __SHA__"
+          EOS
+          )
+          SCRIPT_RENDERED=$(printf '%s' "$SCRIPT" | sed "s|__URL__|${PRESIGNED_URL}|g; s|__SHA__|${GIT_SHA}|g")
+          PARAMS=$(jq -n --arg cmd "$SCRIPT_RENDERED" '{commands:[$cmd], executionTimeout:["300"]}')
+          CMD_ID=$(aws ssm send-command \
+            --instance-ids "${IDS_ARR[@]}" \
+            --document-name AWS-RunShellScript \
+            --comment "deploy ${GIT_SHA::7}" \
+            --parameters "$PARAMS" \
+            --query 'Command.CommandId' \
+            --output text)
+          echo "command_id=${CMD_ID}" >> "$GITHUB_OUTPUT"
+          echo "instance_ids=${TARGET_IDS}" >> "$GITHUB_OUTPUT"
+          echo "Dispatched SSM command ${CMD_ID}"
+
+      - name: Wait for SSM completion + report per-node status
+        env:
+          CMD_ID: ${{ steps.ssm.outputs.command_id }}
+          TARGET_IDS: ${{ steps.ssm.outputs.instance_ids }}
+        run: |
+          set -euo pipefail
+          IFS=',' read -ra IDS_ARR <<<"${TARGET_IDS}"
+          FAIL=0
+          for IID in "${IDS_ARR[@]}"; do
+            echo "::group::Wait for ${IID}"
+            for _ in $(seq 1 60); do
+              STATUS=$(aws ssm get-command-invocation \
+                --command-id "$CMD_ID" \
+                --instance-id "$IID" \
+                --query 'Status' \
+                --output text 2>/dev/null || echo "Pending")
+              case "$STATUS" in
+                Success) echo "${IID}: Success"; break ;;
+                Failed|Cancelled|TimedOut)
+                  echo "::error::${IID}: ${STATUS}"
+                  aws ssm get-command-invocation \
+                    --command-id "$CMD_ID" \
+                    --instance-id "$IID" \
+                    --query '{stdout:StandardOutputContent,stderr:StandardErrorContent}' \
+                    --output text || true
+                  FAIL=1
+                  break ;;
+                *) sleep 5 ;;
+              esac
+            done
+            echo "::endgroup::"
+          done
+          [ "$FAIL" = 0 ] || { echo "::error::Deploy failed on at least one node"; exit 1; }
+          echo "All nodes deployed."

--- a/.github/workflows/deploy-cluster.yml
+++ b/.github/workflows/deploy-cluster.yml
@@ -34,10 +34,10 @@ jobs:
     timeout-minutes: 45
     environment: cluster-test-deploy
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -58,7 +58,7 @@ jobs:
         run: cargo build --release -p prx-waf --locked
 
       - name: Configure AWS credentials via OIDC
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_DEPLOY_REGION }}
@@ -77,18 +77,25 @@ jobs:
 
       - name: Discover cluster instance IDs by tag
         id: targets
+        env:
+          DISCOVERY_TAGS: ${{ secrets.CLUSTER_DISCOVERY_TAGS }}
         run: |
           set -euo pipefail
+          if [ -z "${DISCOVERY_TAGS}" ]; then
+            echo "::error::secret CLUSTER_DISCOVERY_TAGS is empty"; exit 1
+          fi
+          FILTERS=("Name=instance-state-name,Values=running")
+          IFS=',' read -ra ITEMS <<<"${DISCOVERY_TAGS}"
+          for kv in "${ITEMS[@]}"; do
+            k="${kv%%=*}"; v="${kv#*=}"
+            FILTERS+=("Name=tag:${k},Values=${v}")
+          done
           IDS=$(aws ec2 describe-instances \
-            --filters \
-              "Name=tag:project,Values=other" \
-              "Name=tag:env,Values=dev" \
-              "Name=tag:Name,Values=other-test-cluster-*" \
-              "Name=instance-state-name,Values=running" \
+            --filters "${FILTERS[@]}" \
             --query 'Reservations[].Instances[].InstanceId' \
             --output text)
           if [ -z "$IDS" ]; then
-            echo "::error::No running cluster instances found"; exit 1
+            echo "::error::No running cluster instances matched the discovery filter"; exit 1
           fi
           IDS_CSV=$(echo "$IDS" | tr -s '[:space:]' ',' | sed 's/,$//')
           echo "ids=${IDS_CSV}" >> "$GITHUB_OUTPUT"
@@ -103,24 +110,14 @@ jobs:
         run: |
           set -euo pipefail
           IFS=',' read -ra IDS_ARR <<<"${TARGET_IDS}"
-          SCRIPT=$(cat <<'EOS'
-          set -euo pipefail
-          TMP=$(mktemp)
-          trap 'rm -f "$TMP"' EXIT
-          curl -fSL --max-time 120 --retry 2 "__URL__" -o "$TMP"
-          chmod +x "$TMP"
-          sudo install -o miniwaf -g miniwaf -m 0755 "$TMP" /opt/mini-waf/bin/prx-waf.new
-          sudo mv -f /opt/mini-waf/bin/prx-waf.new /opt/mini-waf/bin/prx-waf
-          sudo systemctl restart mini-waf
-          sleep 6
-          sudo systemctl is-active mini-waf
-          curl -fsS --max-time 5 http://127.0.0.1:9527/healthz \
-            || curl -fsS --max-time 5 http://127.0.0.1:9527/api/health \
-            || { echo "healthz failed"; sudo journalctl -u mini-waf -n 80 --no-pager; exit 1; }
-          echo "deploy OK: __SHA__"
-          EOS
+          SCRIPT_RENDERED=$(python3 - <<'PY'
+          import os, sys
+          body = open(".github/workflows/scripts/deploy-on-vm.sh").read()
+          body = body.replace("__URL__", os.environ["PRESIGNED_URL"])
+          body = body.replace("__SHA__", os.environ["GIT_SHA"])
+          sys.stdout.write(body)
+          PY
           )
-          SCRIPT_RENDERED=$(printf '%s' "$SCRIPT" | sed "s|__URL__|${PRESIGNED_URL}|g; s|__SHA__|${GIT_SHA}|g")
           PARAMS=$(jq -n --arg cmd "$SCRIPT_RENDERED" '{commands:[$cmd], executionTimeout:["300"]}')
           CMD_ID=$(aws ssm send-command \
             --instance-ids "${IDS_ARR[@]}" \

--- a/.github/workflows/scripts/deploy-on-vm.sh
+++ b/.github/workflows/scripts/deploy-on-vm.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# On-node deploy step driven by .github/workflows/deploy-cluster.yml.
+#
+# The workflow renders __URL__ (S3 presigned binary URL) and __SHA__
+# (commit SHA) before sending the script to SSM Run Command. The body
+# runs as the SSM agent (root) on each cluster node.
+
+set -euo pipefail
+
+TMP=$(mktemp)
+trap 'rm -f "$TMP"' EXIT
+
+curl -fSL --max-time 120 --retry 2 --retry-delay 3 "__URL__" -o "$TMP"
+chmod +x "$TMP"
+
+install -o miniwaf -g miniwaf -m 0755 "$TMP" /opt/mini-waf/bin/prx-waf.new
+mv -f /opt/mini-waf/bin/prx-waf.new /opt/mini-waf/bin/prx-waf
+
+systemctl restart mini-waf
+sleep 6
+systemctl is-active mini-waf
+
+if ! curl -fsS --max-time 5 http://127.0.0.1:9527/healthz \
+  && ! curl -fsS --max-time 5 http://127.0.0.1:9527/api/health; then
+  echo "post-deploy healthz failed" >&2
+  journalctl -u mini-waf -n 80 --no-pager >&2 || true
+  exit 1
+fi
+
+echo "deploy OK: __SHA__"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/deploy-cluster.yml` to ship the `prx-waf` release binary onto the 2-node test cluster after every merge to `main`. No personal credentials, no inbound SSH.

## Auth model

- GitHub OIDC → AWS IAM role via `aws-actions/configure-aws-credentials@v4`.
- Role trust policy must restrict `sub` to `repo:future-and-go/mini-waf:environment:cluster-test-deploy` (configured out of band, see infra setup).
- The workflow declares `environment: cluster-test-deploy`, so trust is gated by GitHub Environment + OIDC `aud`/`sub` claims, not by any static token.

## Transport

- Build admin-panel SPA + `cargo build --release -p prx-waf` on `ubuntu-latest`.
- Upload binary to S3 (key: `releases/<sha>/prx-waf`), generate a 30-minute presigned URL.
- Dispatch a single `AWS-RunShellScript` SSM command to both target instances. Nodes `curl` the presigned URL, atomically swap `/opt/mini-waf/bin/prx-waf`, restart the systemd unit, and verify `/healthz`.
- No SSH key, no inbound port opened.

## Target allowlist

- Workflow discovers instance IDs at runtime via the tag filter `project=other`, `env=dev`, `Name=other-test-cluster-*`. No instance IDs are hardcoded.
- The authoritative allowlist lives in the IAM permission policy on the assumed role (condition on `ssm:resourceTag/*`), tracked separately and applied out of band.

## Required GitHub secrets

Configured under the `cluster-test-deploy` environment:

| Secret | Purpose |
| --- | --- |
| `AWS_DEPLOY_ROLE_ARN` | Role to assume via OIDC |
| `AWS_DEPLOY_REGION` | `ap-southeast-1` |
| `AWS_DEPLOY_BUCKET` | S3 bucket for the release artifact |

## Failure behavior

- The job waits for SSM completion per node (up to 5 min each), fails on any non-`Success` invocation, and prints both stdout/stderr from the SSM doc and `journalctl -u mini-waf -n 80` for diagnostics.
- `concurrency: deploy-cluster-test` with `cancel-in-progress: false` so a fresh merge cannot interrupt an in-flight deploy.

## Test plan

- [ ] CI lint on this PR passes (no impact on existing `ci.yml` workflows).
- [ ] After merge, manually trigger `workflow_dispatch` first to validate the OIDC chain + IAM allowlist before the next real merge fires.
- [ ] On a real deploy, verify both nodes report Success in the SSM step and `/api/cluster/nodes` shows `total=2` healthy on the Main dashboard.