### PR TITLE
fix(ci): use correct /health endpoint in deploy smoke check

### DIFF
--- a/.github/workflows/scripts/deploy-on-vm.sh
+++ b/.github/workflows/scripts/deploy-on-vm.sh
@@ -20,11 +20,16 @@ systemctl restart mini-waf
 sleep 6
 systemctl is-active mini-waf
 
-if ! curl -fsS --max-time 5 http://127.0.0.1:9527/healthz \
-  && ! curl -fsS --max-time 5 http://127.0.0.1:9527/api/health; then
-  echo "post-deploy healthz failed" >&2
-  journalctl -u mini-waf -n 80 --no-pager >&2 || true
-  exit 1
-fi
+for i in 1 2 3 4 5; do
+  if curl -fsS --max-time 5 http://127.0.0.1:9527/health >/dev/null; then
+    break
+  fi
+  if [ "$i" = 5 ]; then
+    echo "post-deploy /health failed after 5 tries" >&2
+    journalctl -u mini-waf -n 80 --no-pager >&2 || true
+    exit 1
+  fi
+  sleep 2
+done
 
 echo "deploy OK: __SHA__"


### PR DESCRIPTION
## Summary

First post-merge deploy run (run id 26635871661) reported failure even though the binary swap, systemctl restart, and cluster mTLS join all succeeded on both nodes. The on-node smoke check probed \`/healthz\` and \`/api/health\`; the waf-api router exposes the health endpoint at \`/health\` (\`crates/waf-api/src/server.rs:95\`), so both probes 404'd and tripped the failure path.

Fixes the script and adds a short retry loop (5 x 2s) so the smoke check rides out the brief window between \`systemctl restart\` returning and axum starting to accept connections.

## Test plan

- [ ] Merge → push triggers deploy-cluster.yml run.
- [ ] Run succeeds; both nodes report Success in the SSM step.
- [ ] /api/cluster/nodes on Main still reports total=2 healthy.