### PR TITLE
ci: drop --locked from deploy build to match repo CI convention

### DIFF
--- a/.github/workflows/deploy-cluster.yml
+++ b/.github/workflows/deploy-cluster.yml
@@ -75,7 +75,7 @@ jobs:
           shared-key: deploy-cluster
 
       - name: Build prx-waf release
-        run: cargo build --release -p prx-waf --locked
+        run: cargo build --release -p prx-waf
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
## Summary

Manual deploy from `release/stg` failed at the build step: \`cargo build --release -p prx-waf --locked\` aborted with *"cannot update the lock file because --locked was passed"* because release/stg's \`Cargo.lock\` has drifted from the vendored pingora \`[patch]\`.

The repo's own \`ci.yml\` Build job uses \`cargo build --workspace --release\` with **no** \`--locked\`, so ordinary CI passes on the same commit. The deploy workflow was stricter than the project's convention for no benefit.

Drop \`--locked\` so the deploy build matches CI on every allowed branch. Lock integrity is still enforced by \`ci.yml\` on PRs; the deploy job just needs a working binary.

## Test plan

- [ ] Merge → main push deploy succeeds (unchanged).
- [ ] After porting to release/stg: manual workflow_dispatch from release/stg builds + deploys both nodes.