### PR TITLE
ci: drop --locked from deploy build to match repo CI convention

### DIFF
--- a/.github/workflows/deploy-cluster.yml
+++ b/.github/workflows/deploy-cluster.yml
@@ -75,7 +75,7 @@ jobs:
           shared-key: deploy-cluster
 
       - name: Build prx-waf release
-        run: cargo build --release -p prx-waf --locked
+        run: cargo build --release -p prx-waf
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
## Summary

Mirrors the same one-line fix going into `main`. release/stg's \`Cargo.lock\` has drifted from the vendored pingora \`[patch]\`, so \`cargo build --release -p prx-waf --locked\` aborts on manual deploy. The repo's \`ci.yml\` Build job omits \`--locked\` and passes on the same commit, so the deploy build should match that convention.

## Test plan

- [ ] CI passes.
- [ ] After merge: workflow_dispatch from release/stg builds + deploys both nodes; smoke `/health` passes.