### PR TITLE
ci: deploy to external cluster worker over SSH

### DIFF
--- a/.github/workflows/deploy-cluster.yml
+++ b/.github/workflows/deploy-cluster.yml
@@ -183,4 +183,36 @@ jobs:
             echo "::endgroup::"
           done
           [ "$FAIL" = 0 ] || { echo "::error::Deploy failed on at least one node"; exit 1; }
-          echo "All nodes deployed."
+          echo "All AWS nodes deployed."
+
+      - name: Deploy to external worker (SSH)
+        env:
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          WORKER_HOST: ${{ secrets.EXTERNAL_WORKER_HOST }}
+          WORKER_USER: ${{ secrets.EXTERNAL_WORKER_USER }}
+          PRESIGNED_URL: ${{ steps.upload.outputs.url }}
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${WORKER_HOST:-}" ]; then
+            echo "No external worker configured (EXTERNAL_WORKER_HOST empty); skipping."
+            exit 0
+          fi
+          KEYF=$(mktemp)
+          trap 'rm -f "$KEYF"' EXIT
+          printf '%s\n' "$SSH_KEY" > "$KEYF"
+          chmod 600 "$KEYF"
+          SCRIPT_RENDERED=$(python3 - <<'PY'
+          import os, sys
+          body = open(".github/workflows/scripts/deploy-external-worker.sh").read()
+          body = body.replace("__URL__", os.environ["PRESIGNED_URL"])
+          body = body.replace("__SHA__", os.environ["GIT_SHA"])
+          sys.stdout.write(body)
+          PY
+          )
+          ssh -i "$KEYF" \
+            -o StrictHostKeyChecking=no \
+            -o UserKnownHostsFile=/dev/null \
+            -o ConnectTimeout=15 \
+            "${WORKER_USER:-root}@${WORKER_HOST}" 'bash -s' <<<"$SCRIPT_RENDERED"
+          echo "External worker deployed."

--- a/.github/workflows/scripts/deploy-external-worker.sh
+++ b/.github/workflows/scripts/deploy-external-worker.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# On-node deploy step for the external (non-AWS) cluster worker, driven over
+# SSH by .github/workflows/deploy-cluster.yml. The external worker cannot be
+# reached via SSM, so the workflow pipes this script to `ssh ... bash -s`.
+#
+# The workflow renders __URL__ (S3 presigned binary URL) and __SHA__ (commit
+# SHA) before sending the script. It runs as root on the worker.
+#
+# NOTE: the binary is installed at /opt/mini-waf/bin/mini-waf — the path the
+# systemd unit actually executes on this node.
+
+set -euo pipefail
+
+TMP=$(mktemp)
+trap 'rm -f "$TMP"' EXIT
+
+curl -fSL --max-time 180 --retry 3 --retry-delay 3 "__URL__" -o "$TMP"
+chmod +x "$TMP"
+
+install -o miniwaf -g miniwaf -m 0755 "$TMP" /opt/mini-waf/bin/mini-waf.new
+mv -f /opt/mini-waf/bin/mini-waf.new /opt/mini-waf/bin/mini-waf
+
+systemctl restart mini-waf
+
+for i in 1 2 3 4 5; do
+  if curl -fsS --max-time 5 http://127.0.0.1:9527/health >/dev/null; then
+    break
+  fi
+  if [ "$i" = 5 ]; then
+    echo "post-deploy /health failed after 5 tries" >&2
+    journalctl -u mini-waf -n 80 --no-pager >&2 || true
+    exit 1
+  fi
+  sleep 2
+done
+
+echo "external worker deploy OK: __SHA__"


### PR DESCRIPTION
## Summary

Mirrors the main-branch change so manual `release/stg` deploys also reach the non-AWS cluster worker. Adds the SSH deploy step + `deploy-external-worker.sh` (installs to `/opt/mini-waf/bin/mini-waf`, smoke-checks `/health`). Uses a dedicated CI deploy key from the `cluster-test-deploy` environment secrets; no personal key. No-op when no external worker is configured.

See the main PR for the full notes on the two pre-existing AWS-deploy issues (install path + missing valkey build feature) flagged for follow-up.

## Test plan

- [ ] CI passes.
- [ ] After merge: manual workflow_dispatch from release/stg deploys all three nodes; `/api/cluster/nodes` shows `total=3`.