### PR TITLE
fix(ci): build SSM preflight params with jq to survive quoting

### DIFF
--- a/.github/workflows/deploy-cluster.yml
+++ b/.github/workflows/deploy-cluster.yml
@@ -113,11 +113,12 @@ jobs:
           set -euo pipefail
           IFS=',' read -ra IDS_ARR <<<"${TARGET_IDS}"
           PROBE='echo "arch=$(uname -m) glibc=$(ldd --version 2>/dev/null | head -1 | grep -oE "[0-9]+\.[0-9]+$")"'
+          PARAMS=$(jq -n --arg c "$PROBE" '{commands:[$c]}')
           BAD=0
           for IID in "${IDS_ARR[@]}"; do
             CID=$(aws ssm send-command --instance-ids "$IID" \
               --document-name AWS-RunShellScript \
-              --parameters "commands=[\"$PROBE\"]" \
+              --parameters "$PARAMS" \
               --query 'Command.CommandId' --output text)
             for _ in $(seq 1 20); do
               ST=$(aws ssm get-command-invocation --command-id "$CID" --instance-id "$IID" \


### PR DESCRIPTION
The arch preflight (PR #162) passed the probe via AWS CLI shorthand `commands=["..."]`, but the probe string has nested quotes + shell substitutions that the shorthand parser rejects. Build the params JSON with jq instead (same as the deploy dispatch step). Unblocks the cluster recovery deploy.