### PR TITLE
fix(ci): provision admin-TLS cert dir so cluster admin API serves HTTPS

### DIFF
--- a/.github/workflows/scripts/deploy-external-worker.sh
+++ b/.github/workflows/scripts/deploy-external-worker.sh
@@ -20,6 +20,16 @@ chmod +x "$TMP"
 install -o miniwaf -g miniwaf -m 0755 "$TMP" /opt/mini-waf/bin/mini-waf.new
 mv -f /opt/mini-waf/bin/mini-waf.new /opt/mini-waf/bin/mini-waf
 
+# Admin API TLS now defaults on (auto self-signed). The auto cert dir falls back
+# to /var/lib/prx-waf/admin-tls, which this non-root (miniwaf) service can't
+# create — the admin API then fails to start and the health check below times
+# out. The cluster admin API is HTTP on loopback/internal by design, so pin TLS
+# off when the node config hasn't set [api.tls] explicitly.
+CFG=/opt/mini-waf/configs/prod.toml
+if [ -f "$CFG" ] && ! grep -q '^\[api\.tls\]' "$CFG"; then
+  printf '\n[api.tls]\nenabled = false\n' >>"$CFG"
+fi
+
 systemctl restart mini-waf
 
 # Bounded health gate (~30s). --connect-timeout caps a half-open socket while

--- a/.github/workflows/scripts/deploy-external-worker.sh
+++ b/.github/workflows/scripts/deploy-external-worker.sh
@@ -20,23 +20,22 @@ chmod +x "$TMP"
 install -o miniwaf -g miniwaf -m 0755 "$TMP" /opt/mini-waf/bin/mini-waf.new
 mv -f /opt/mini-waf/bin/mini-waf.new /opt/mini-waf/bin/mini-waf
 
-# Admin API TLS now defaults on (auto self-signed). The auto cert dir falls back
-# to /var/lib/prx-waf/admin-tls, which this non-root (miniwaf) service can't
-# create — the admin API then fails to start and the health check below times
-# out. The cluster admin API is HTTP on loopback/internal by design, so pin TLS
-# off when the node config hasn't set [api.tls] explicitly.
-CFG=/opt/mini-waf/configs/prod.toml
-if [ -f "$CFG" ] && ! grep -q '^\[api\.tls\]' "$CFG"; then
-  printf '\n[api.tls]\nenabled = false\n' >>"$CFG"
-fi
+# Admin API TLS is on by default (auto self-signed). Auto mode persists the cert
+# under /var/lib/prx-waf/admin-tls; the non-root service user can't create that
+# path itself, so pre-create it owned by the service user. Without this the admin
+# API fails to bootstrap TLS and never binds 9527.
+mkdir -p /var/lib/prx-waf/admin-tls
+chown miniwaf:miniwaf /var/lib/prx-waf/admin-tls
+chmod 0700 /var/lib/prx-waf/admin-tls
 
 systemctl restart mini-waf
 
 # Bounded health gate (~30s). --connect-timeout caps a half-open socket while
-# the process is still binding 9527, so no single probe can stall. Exit on the
-# first success so the remote shell returns promptly and the SSH session closes.
+# the process is still binding 9527, so no single probe can stall. Admin API
+# serves HTTPS (self-signed) so probe over TLS with -k. Exit on the first
+# success so the remote shell returns promptly and the SSH session closes.
 for _ in $(seq 1 15); do
-  if curl -fsS --connect-timeout 3 --max-time 5 http://127.0.0.1:9527/health >/dev/null 2>&1; then
+  if curl -fsSk --connect-timeout 3 --max-time 5 https://127.0.0.1:9527/health >/dev/null 2>&1; then
     echo "external worker deploy OK: __SHA__"
     exit 0
   fi

--- a/.github/workflows/scripts/deploy-on-vm.sh
+++ b/.github/workflows/scripts/deploy-on-vm.sh
@@ -17,6 +17,16 @@ chmod +x "$TMP"
 install -o miniwaf -g miniwaf -m 0755 "$TMP" /opt/mini-waf/bin/mini-waf.new
 mv -f /opt/mini-waf/bin/mini-waf.new /opt/mini-waf/bin/mini-waf
 
+# Admin API TLS now defaults on (auto self-signed). The auto cert dir falls back
+# to /var/lib/prx-waf/admin-tls, which this non-root (miniwaf) service can't
+# create — the admin API then fails to start and the health check below times
+# out. The cluster admin API is HTTP on loopback/internal by design, so pin TLS
+# off when the node config hasn't set [api.tls] explicitly.
+CFG=/opt/mini-waf/configs/prod.toml
+if [ -f "$CFG" ] && ! grep -q '^\[api\.tls\]' "$CFG"; then
+  printf '\n[api.tls]\nenabled = false\n' >>"$CFG"
+fi
+
 systemctl restart mini-waf
 sleep 6
 systemctl is-active mini-waf

--- a/.github/workflows/scripts/deploy-on-vm.sh
+++ b/.github/workflows/scripts/deploy-on-vm.sh
@@ -17,22 +17,22 @@ chmod +x "$TMP"
 install -o miniwaf -g miniwaf -m 0755 "$TMP" /opt/mini-waf/bin/mini-waf.new
 mv -f /opt/mini-waf/bin/mini-waf.new /opt/mini-waf/bin/mini-waf
 
-# Admin API TLS now defaults on (auto self-signed). The auto cert dir falls back
-# to /var/lib/prx-waf/admin-tls, which this non-root (miniwaf) service can't
-# create — the admin API then fails to start and the health check below times
-# out. The cluster admin API is HTTP on loopback/internal by design, so pin TLS
-# off when the node config hasn't set [api.tls] explicitly.
-CFG=/opt/mini-waf/configs/prod.toml
-if [ -f "$CFG" ] && ! grep -q '^\[api\.tls\]' "$CFG"; then
-  printf '\n[api.tls]\nenabled = false\n' >>"$CFG"
-fi
+# Admin API TLS is on by default (auto self-signed). Auto mode persists the cert
+# under /var/lib/prx-waf/admin-tls; the non-root service user can't create that
+# path itself, so pre-create it owned by the service user. Without this the admin
+# API fails to bootstrap TLS and never binds 9527.
+mkdir -p /var/lib/prx-waf/admin-tls
+chown miniwaf:miniwaf /var/lib/prx-waf/admin-tls
+chmod 0700 /var/lib/prx-waf/admin-tls
 
 systemctl restart mini-waf
 sleep 6
 systemctl is-active mini-waf
 
+# Admin API serves HTTPS (self-signed) once TLS bootstraps, so probe over TLS
+# and skip cert verification for the loopback self-signed cert.
 for i in 1 2 3 4 5; do
-  if curl -fsS --max-time 5 http://127.0.0.1:9527/health >/dev/null; then
+  if curl -fsSk --max-time 5 https://127.0.0.1:9527/health >/dev/null; then
     break
   fi
   if [ "$i" = 5 ]; then


### PR DESCRIPTION
## Problem

Deploy to test cluster started failing at "Wait for SSM" after the admin-panel HTTPS change (#161). On every cluster node the new binary logs:

```
ERROR waf: API server error: bootstrap admin TLS material
```

The admin API never binds 9527, so the post-deploy health check times out and the deploy goes red.

## Root cause

`[api.tls] enabled` now defaults to **true** (`crates/waf-common/src/config.rs:354`) with mode `auto`. Auto mode persists the self-signed cert under `/var/lib/prx-waf/admin-tls` (`crates/waf-api/src/tls.rs`). The cluster service runs as non-root **miniwaf** and can't create under `/var/lib`, so `create_dir_all` fails and the admin API crashes.

This is the **admin-API TLS cert** (`[api.tls]`, port 9527, auto self-signed) — a separate subsystem from the **cluster mTLS** cert (`[cluster.crypto]`, QUIC 16851, CA-signed node certs). The cluster mTLS was never affected; nodes kept handshaking and joining the cluster normally.

## Fix — make admin HTTPS work (not disable it)

The deploy scripts run as root on each node. Before restart:

1. Pre-create `/var/lib/prx-waf/admin-tls` owned by the `miniwaf` service user (mode 0700) so the app can persist its auto-generated cert there. The app's `create_dir_all` then succeeds and TLS bootstraps.
2. Probe the post-deploy health check over **HTTPS** with `-k` (the loopback cert is self-signed).

Admin HTTPS stays enabled exactly as the feature intends — the cluster simply gets the writable cert dir the non-root service needs.

- `.github/workflows/scripts/deploy-on-vm.sh` (AWS nodes via SSM)
- `.github/workflows/scripts/deploy-external-worker.sh` (external node via SSH)

## Verification

- `bash -n` clean on both scripts
- on a real cluster node: the `mkdir -p` + `chown miniwaf` + `chmod 0700` sequence yields `drwx------ miniwaf miniwaf`, and the `miniwaf` user can write a cert file into it (`WRITABLE_BY_MINIWAF`)
- the app's auto-mode cert generation + HTTPS serving is covered by existing unit/integration tests (`crates/waf-api/src/tls.rs`, `crates/waf-api/tests/admin_tls_integration.rs`)
- bash/config-only change, so Rust CI (ci / coverage / sec-audit) is unaffected
- full HTTPS end-to-end is exercised by the deploy-cluster run on merge

## Notes

- Admin UI access becomes `https://<node>:9527` with a self-signed cert (browser will warn / use `-k`). For the public AWS node the auto cert's SANs cover loopback + interface IPs but not the public IP, so a browser hitting the public IP also sees a SAN warning. To get a clean cert, set `[api.tls] mode = "provided"` with a CA-issued cert or add the public IP to `extra_sans` — follow-up, out of scope here.
- The separate single-EC2 deploy (`release.yaml`) still health-checks over HTTP; not part of the cluster deploy, flagged for a follow-up.
