### PR TITLE
feat(api,storage): IP reputation editor (FR-042)

### DIFF
--- a/crates/waf-api/src/auth.rs
+++ b/crates/waf-api/src/auth.rs
@@ -60,6 +60,16 @@ pub fn validate_access_token(token: &str, secret: &str) -> anyhow::Result<Claims
     Ok(data.claims)
 }
 
+/// Validate a JWT and require the `admin` role. Signature/expiry are checked
+/// first; a structurally valid token for a non-admin role is rejected.
+pub fn validate_admin_token(token: &str, secret: &str) -> anyhow::Result<Claims> {
+    let claims = validate_access_token(token, secret)?;
+    if claims.role != "admin" {
+        anyhow::bail!("admin role required");
+    }
+    Ok(claims)
+}
+
 pub fn hash_token(token: &str) -> String {
     let mut h = Sha256::new();
     h.update(token.as_bytes());
@@ -280,6 +290,30 @@ mod tests {
     #[test]
     fn token_hash_deterministic() {
         assert_eq!(hash_token("abc"), hash_token("abc"));
+    }
+
+    #[test]
+    fn validate_admin_token_accepts_admin_role() {
+        let user_id = uuid::Uuid::new_v4();
+        let secret = "admin-gate-secret";
+        let token = generate_access_token(user_id, "alice", "admin", secret).unwrap();
+        let claims = validate_admin_token(&token, secret).expect("admin claims");
+        assert_eq!(claims.role, "admin");
+    }
+
+    #[test]
+    fn validate_admin_token_rejects_non_admin_role() {
+        let user_id = uuid::Uuid::new_v4();
+        let secret = "admin-gate-secret";
+        let token = generate_access_token(user_id, "carol", "viewer", secret).unwrap();
+        let err = validate_admin_token(&token, secret).expect_err("viewer must be denied");
+        assert!(err.to_string().contains("admin role required"));
+    }
+
+    #[test]
+    fn validate_admin_token_rejects_invalid_token() {
+        let result = validate_admin_token("not-a-jwt", "any-secret");
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/waf-api/src/lib.rs
+++ b/crates/waf-api/src/lib.rs
@@ -18,6 +18,7 @@ pub mod notifications;
 pub mod panel_api;
 pub mod plugins;
 pub mod relay_api;
+pub mod reputation_api;
 pub mod risk_api;
 pub mod rule_sources_api;
 pub mod rules_api;

--- a/crates/waf-api/src/reputation_api.rs
+++ b/crates/waf-api/src/reputation_api.rs
@@ -1,0 +1,250 @@
+//! IP reputation editor API — FR-042 / #60.6.
+//!
+//! Operator-curated allow/block list with score, provenance and expiry.
+//! Storage lives in `reputation_list` (migration 0018); the API boundary
+//! validates `ip` via `IpAddr::parse`, clamps `score` to ±100, and rejects
+//! `expires_at` values in the past. PUT/POST/DELETE require an admin JWT.
+
+use std::net::IpAddr;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+    http::HeaderMap,
+};
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::auth::{Claims, validate_admin_token};
+use crate::error::{ApiError, ApiResult};
+use crate::state::AppState;
+use waf_storage::models::{CreateReputationEntry, ReputationQuery, UpdateReputationEntry};
+
+/// Max body size for reputation POST/PUT requests (64 KiB).
+pub const MAX_BODY_BYTES: usize = 64 * 1024;
+
+const VALID_SOURCES: &[&str] = &["manual", "crowdsec", "community", "feed"];
+const MIN_SCORE: i32 = -100;
+const MAX_SCORE: i32 = 100;
+/// Hard cap on the per-request page size so a misbehaving client cannot
+/// drain the whole list in one shot.
+const MAX_LIMIT: i64 = 500;
+
+// ─── Typed request models ────────────────────────────────────────────────────
+#[derive(Debug, Deserialize)]
+pub struct CreateRequest {
+    pub ip: String,
+    pub score: i32,
+    pub source: String,
+    pub expires_at: DateTime<Utc>,
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct UpdateRequest {
+    pub score: Option<i32>,
+    pub source: Option<String>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct ListQuery {
+    pub ip_prefix: Option<String>,
+    pub source: Option<String>,
+    pub min_score: Option<i32>,
+    pub max_score: Option<i32>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+// ─── Auth gate ───────────────────────────────────────────────────────────────
+
+fn require_admin(headers: &HeaderMap, jwt_secret: &str) -> Result<Claims, ApiError> {
+    let token = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .ok_or_else(|| ApiError::Unauthorized("missing bearer token".into()))?;
+    validate_admin_token(token, jwt_secret).map_err(|e| ApiError::Unauthorized(e.to_string()))
+}
+
+// ─── Validation helpers ──────────────────────────────────────────────────────
+
+fn validate_ip(ip: &str) -> Result<IpAddr, ApiError> {
+    let parsed = IpAddr::from_str(ip).map_err(|e| ApiError::BadRequest(format!("ip parse: {e}")))?;
+    if parsed.is_unspecified() {
+        return Err(ApiError::BadRequest("ip must not be the unspecified address".into()));
+    }
+    Ok(parsed)
+}
+
+fn validate_source(source: &str) -> Result<(), ApiError> {
+    if VALID_SOURCES.contains(&source) {
+        Ok(())
+    } else {
+        Err(ApiError::BadRequest(format!(
+            "source must be one of {VALID_SOURCES:?}; got {source:?}"
+        )))
+    }
+}
+
+fn validate_score(score: i32) -> Result<(), ApiError> {
+    if (MIN_SCORE..=MAX_SCORE).contains(&score) {
+        Ok(())
+    } else {
+        Err(ApiError::BadRequest(format!(
+            "score must be in [{MIN_SCORE}, {MAX_SCORE}]; got {score}"
+        )))
+    }
+}
+
+fn validate_expiry(expires_at: DateTime<Utc>) -> Result<(), ApiError> {
+    if expires_at <= Utc::now() {
+        return Err(ApiError::BadRequest("expires_at must be in the future".into()));
+    }
+    Ok(())
+}
+
+fn clamp_limit_value(limit: i64) -> i64 {
+    limit.clamp(1, MAX_LIMIT)
+}
+
+// ─── Handlers ────────────────────────────────────────────────────────────────
+
+pub async fn list_reputation(State(state): State<Arc<AppState>>, Query(q): Query<ListQuery>) -> ApiResult<Json<Value>> {
+    let query = ReputationQuery {
+        ip_prefix: q.ip_prefix,
+        source: q.source,
+        min_score: q.min_score,
+        max_score: q.max_score,
+        limit: q.limit.map(clamp_limit_value),
+        offset: q.offset.filter(|o| *o >= 0),
+    };
+    let (data, total) = state
+        .db
+        .list_reputation_entries(&query)
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("list_reputation_entries: {e}")))?;
+    Ok(Json(json!({ "success": true, "data": data, "total": total })))
+}
+
+pub async fn upsert_reputation(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<CreateRequest>,
+) -> ApiResult<Json<Value>> {
+    require_admin(&headers, &state.jwt_secret)?;
+    let _ = validate_ip(&body.ip)?;
+    validate_source(&body.source)?;
+    validate_score(body.score)?;
+    validate_expiry(body.expires_at)?;
+
+    let req = CreateReputationEntry {
+        ip: body.ip,
+        score: body.score,
+        source: body.source,
+        expires_at: body.expires_at,
+        notes: body.notes,
+    };
+    let row = state
+        .db
+        .upsert_reputation_entry(&req)
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("upsert_reputation_entry: {e}")))?;
+    Ok(Json(json!({ "success": true, "data": row })))
+}
+
+pub async fn update_reputation(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(id): Path<i64>,
+    Json(body): Json<UpdateRequest>,
+) -> ApiResult<Json<Value>> {
+    require_admin(&headers, &state.jwt_secret)?;
+    body.score.map(validate_score).transpose()?;
+    body.source.as_deref().map(validate_source).transpose()?;
+    body.expires_at.map(validate_expiry).transpose()?;
+    let req = UpdateReputationEntry {
+        score: body.score,
+        source: body.source.as_deref(),
+        expires_at: body.expires_at,
+        notes: body.notes.as_deref(),
+    };
+    let row = state
+        .db
+        .update_reputation_entry(id, &req)
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("update_reputation_entry: {e}")))?
+        .ok_or_else(|| ApiError::NotFound(format!("reputation entry {id} not found")))?;
+    Ok(Json(json!({ "success": true, "data": row })))
+}
+
+pub async fn delete_reputation(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path(id): Path<i64>,
+) -> ApiResult<Json<Value>> {
+    require_admin(&headers, &state.jwt_secret)?;
+    let removed = state
+        .db
+        .delete_reputation_entry(id)
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("delete_reputation_entry: {e}")))?;
+    if removed {
+        Ok(Json(json!({ "success": true })))
+    } else {
+        Err(ApiError::NotFound(format!("reputation entry {id} not found")))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_ip_accepts_specified_addresses_only() {
+        for ok in ["1.2.3.4", "2001:db8::1"] {
+            assert!(validate_ip(ok).is_ok(), "{ok} should accept");
+        }
+        for err in ["0.0.0.0", "::", "not-an-ip", ""] {
+            assert!(validate_ip(err).is_err(), "{err} should reject");
+        }
+    }
+
+    #[test]
+    fn validate_source_round_trip() {
+        for s in VALID_SOURCES {
+            assert!(validate_source(s).is_ok());
+        }
+        assert!(validate_source("nonsense").is_err());
+    }
+
+    #[test]
+    fn validate_score_boundary() {
+        assert!(validate_score(MIN_SCORE).is_ok());
+        assert!(validate_score(MAX_SCORE).is_ok());
+        assert!(validate_score(MIN_SCORE - 1).is_err());
+        assert!(validate_score(MAX_SCORE + 1).is_err());
+    }
+
+    #[test]
+    fn validate_expiry_rejects_past() {
+        assert!(validate_expiry(Utc::now() - chrono::Duration::hours(1)).is_err());
+        assert!(validate_expiry(Utc::now() + chrono::Duration::hours(1)).is_ok());
+    }
+
+    #[test]
+    fn clamp_limit_value_caps_at_max() {
+        assert_eq!(clamp_limit_value(MAX_LIMIT + 1_000), MAX_LIMIT);
+        assert_eq!(clamp_limit_value(0), 1);
+        assert_eq!(clamp_limit_value(50), 50);
+    }
+}

--- a/crates/waf-api/src/server.rs
+++ b/crates/waf-api/src/server.rs
@@ -7,7 +7,9 @@ use axum::http::{
     header::{AUTHORIZATION, CONTENT_TYPE},
 };
 use axum::{
-    Router, middleware,
+    Router,
+    extract::DefaultBodyLimit,
+    middleware,
     response::Redirect,
     routing::{delete, get, patch, post},
 };
@@ -52,6 +54,7 @@ use crate::notifications::{
 use crate::panel_api::{get_panel_config, put_panel_config};
 use crate::plugins::{delete_plugin, disable_plugin, enable_plugin, list_plugins, upload_plugin};
 use crate::relay_api::{get_relay_config, get_relay_intel_status, put_relay_config, refresh_relay_intel, test_relay};
+use crate::reputation_api::{delete_reputation, list_reputation, update_reputation, upsert_reputation};
 use crate::risk_api::{
     clear_risk_actor, credit_risk_actor, get_risk_config, get_risk_metrics, list_risk_actors, put_risk_config,
 };
@@ -306,6 +309,19 @@ pub fn build_router(state: Arc<AppState>, tls_enabled: bool) -> Router {
         .route("/api/geoip/rules", get(list_geo_rules).post(create_geo_rule))
         .route("/api/geoip/rules/{id}", patch(patch_geo_rule).delete(delete_geo_rule))
         .route("/api/geoip/lookup", post(lookup_ip))
+        // FR-042 IP reputation editor (#60.6)
+        .route(
+            "/api/reputation",
+            get(list_reputation)
+                .post(upsert_reputation)
+                .layer(DefaultBodyLimit::max(crate::reputation_api::MAX_BODY_BYTES)),
+        )
+        .route(
+            "/api/reputation/{id}",
+            axum::routing::put(update_reputation)
+                .delete(delete_reputation)
+                .layer(DefaultBodyLimit::max(crate::reputation_api::MAX_BODY_BYTES)),
+        )
         .layer(middleware::from_fn_with_state(state.clone(), require_auth))
         .layer(middleware::from_fn_with_state(
             state.clone(),

--- a/crates/waf-api/tests/common/mod.rs
+++ b/crates/waf-api/tests/common/mod.rs
@@ -431,6 +431,13 @@ pub fn client() -> reqwest::Client {
         .expect("build reqwest client")
 }
 
+/// Mint a viewer-role JWT against the test server's secret. Used by tests
+/// that assert RBAC paths (401 for viewer on PUT/POST/PATCH/DELETE).
+#[must_use]
+pub fn issue_viewer_token(s: &TestServer) -> String {
+    generate_access_token(uuid::Uuid::new_v4(), "viewer", "viewer", &s.state.jwt_secret).expect("viewer token")
+}
+
 /// Host code used by [`seed_one_of_each`] and shared across stats integration
 /// tests. Tests that filter by host_code (`?host_code=h1`) MUST use this
 /// constant so a single rename here doesn't silently turn assertions into

--- a/crates/waf-api/tests/reputation_api_test.rs
+++ b/crates/waf-api/tests/reputation_api_test.rs
@@ -1,0 +1,250 @@
+//! Integration tests for the IP reputation editor API.
+
+#![allow(
+    dead_code,
+    unsafe_code,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::doc_markdown,
+    clippy::undocumented_unsafe_blocks
+)]
+
+mod common;
+
+use chrono::{Duration, Utc};
+use common::{TestServer, client, issue_viewer_token, start_test_server, url_for};
+use serde_json::json;
+
+fn valid_body() -> serde_json::Value {
+    json!({
+        "ip": "203.0.113.42",
+        "score": -75,
+        "source": "manual",
+        "expires_at": (Utc::now() + Duration::hours(24)).to_rfc3339(),
+        "notes": "abuse report"
+    })
+}
+
+async fn upsert(s: &TestServer, body: &serde_json::Value) -> serde_json::Value {
+    let resp = client()
+        .post(url_for(s.addr, "/api/reputation"))
+        .bearer_auth(&s.admin_token)
+        .json(body)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 200, "POST /api/reputation expected 200");
+    resp.json().await.expect("json")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_returns_empty_initially() {
+    let s = start_test_server().await;
+    let body: serde_json::Value = client()
+        .get(url_for(s.addr, "/api/reputation"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(body["total"], 0);
+    assert_eq!(body["data"], json!([]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_then_list_returns_entry() {
+    let s = start_test_server().await;
+    let created = upsert(&s, &valid_body()).await;
+    let id = created["data"]["id"].as_i64().expect("id");
+    assert!(id > 0);
+    assert_eq!(created["data"]["ip"], "203.0.113.42");
+    assert_eq!(created["data"]["score"], -75);
+
+    let body: serde_json::Value = client()
+        .get(url_for(s.addr, "/api/reputation"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(body["total"], 1);
+    assert_eq!(body["data"][0]["ip"], "203.0.113.42");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_same_ip_and_source_collapses_via_unique() {
+    let s = start_test_server().await;
+    let first = upsert(&s, &valid_body()).await;
+    let first_id = first["data"]["id"].as_i64().expect("id");
+
+    let mut second = valid_body();
+    second["score"] = json!(50); // change score, keep ip+source
+    let second_resp = upsert(&s, &second).await;
+    assert_eq!(
+        second_resp["data"]["id"].as_i64(),
+        Some(first_id),
+        "UNIQUE must collapse"
+    );
+    assert_eq!(second_resp["data"]["score"], 50);
+
+    let listing: serde_json::Value = client()
+        .get(url_for(s.addr, "/api/reputation"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(listing["total"], 1, "must still be one row after UPSERT");
+}
+
+/// Every API-boundary rejection case folded into one test so the harness
+/// spins up Postgres once. Each `(label, mutation)` covers one validation
+/// path; if any case slips past the 400 we get the label in the panic.
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_rejects_each_boundary_violation() {
+    let s = start_test_server().await;
+    let past = json!((Utc::now() - Duration::hours(1)).to_rfc3339());
+    #[allow(clippy::type_complexity)]
+    let cases: &[(&str, &dyn Fn(&mut serde_json::Value))] = &[
+        ("garbage ip", &|b| b["ip"] = json!("not-an-ip")),
+        ("unspecified v4 ip", &|b| b["ip"] = json!("0.0.0.0")),
+        ("unspecified v6 ip", &|b| b["ip"] = json!("::")),
+        ("score above max", &|b| b["score"] = json!(150)),
+        ("score below min", &|b| b["score"] = json!(-150)),
+        ("unknown source", &|b| b["source"] = json!("typo_source")),
+        ("expiry in past", &|b| b["expires_at"] = past.clone()),
+    ];
+    for (label, mutate) in cases {
+        let mut bad = valid_body();
+        mutate(&mut bad);
+        let resp = client()
+            .post(url_for(s.addr, "/api/reputation"))
+            .bearer_auth(&s.admin_token)
+            .json(&bad)
+            .send()
+            .await
+            .expect("send");
+        assert_eq!(resp.status(), 400, "{label}: expected 400, got {}", resp.status());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_requires_admin_role() {
+    let s = start_test_server().await;
+    let viewer = issue_viewer_token(&s);
+    let resp = client()
+        .post(url_for(s.addr, "/api/reputation"))
+        .bearer_auth(&viewer)
+        .json(&valid_body())
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_unknown_id_returns_404() {
+    let s = start_test_server().await;
+    let resp = client()
+        .put(url_for(s.addr, "/api/reputation/99999"))
+        .bearer_auth(&s.admin_token)
+        .json(&json!({ "score": 25 }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 404);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_applies_partial_patch() {
+    let s = start_test_server().await;
+    let created = upsert(&s, &valid_body()).await;
+    let id = created["data"]["id"].as_i64().expect("id");
+
+    let resp = client()
+        .put(url_for(s.addr, &format!("/api/reputation/{id}")))
+        .bearer_auth(&s.admin_token)
+        .json(&json!({ "score": 10, "notes": "updated" }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.expect("json");
+    assert_eq!(body["data"]["score"], 10);
+    assert_eq!(body["data"]["notes"], "updated");
+    // Untouched field stays.
+    assert_eq!(body["data"]["source"], "manual");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_removes_entry_and_repeat_is_404() {
+    let s = start_test_server().await;
+    let created = upsert(&s, &valid_body()).await;
+    let id = created["data"]["id"].as_i64().expect("id");
+
+    let first = client()
+        .delete(url_for(s.addr, &format!("/api/reputation/{id}")))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(first.status(), 200);
+
+    let again = client()
+        .delete(url_for(s.addr, &format!("/api/reputation/{id}")))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(again.status(), 404);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_requires_admin_role() {
+    let s = start_test_server().await;
+    let created = upsert(&s, &valid_body()).await;
+    let id = created["data"]["id"].as_i64().expect("id");
+    let viewer = issue_viewer_token(&s);
+
+    let resp = client()
+        .delete(url_for(s.addr, &format!("/api/reputation/{id}")))
+        .bearer_auth(&viewer)
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_filters_by_source_and_score_range() {
+    let s = start_test_server().await;
+    let body_a = valid_body();
+    let _ = upsert(&s, &body_a).await;
+
+    let mut body_b = valid_body();
+    body_b["ip"] = json!("198.51.100.1");
+    body_b["source"] = json!("crowdsec");
+    body_b["score"] = json!(80);
+    let _ = upsert(&s, &body_b).await;
+
+    let body: serde_json::Value = client()
+        .get(url_for(s.addr, "/api/reputation?source=crowdsec&min_score=50"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(body["total"], 1);
+    assert_eq!(body["data"][0]["ip"], "198.51.100.1");
+}

--- a/crates/waf-storage/src/models.rs
+++ b/crates/waf-storage/src/models.rs
@@ -842,3 +842,58 @@ pub struct StatsFilter {
     pub host_code: Option<String>,
     pub action: Option<String>,
 }
+
+// ─── IP reputation list (FR-042) ─────────────────────────────────────────────
+
+/// Operator-curated reputation entry persisted in the `reputation_list` table.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct ReputationEntry {
+    pub id: i64,
+    pub ip: String,
+    pub score: i32,
+    pub source: String,
+    pub expires_at: DateTime<Utc>,
+    pub notes: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Insert/upsert payload for a reputation entry.
+///
+/// Bounded to score ±100 and one of the four sources by the `reputation_list`
+/// CHECK constraints; the API boundary additionally rejects unknown values
+/// with 400 before reaching this layer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateReputationEntry {
+    pub ip: String,
+    pub score: i32,
+    pub source: String,
+    pub expires_at: DateTime<Utc>,
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+/// Partial-update payload. Each field is optional so PATCH-style requests
+/// only touch the columns the caller specified.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct UpdateReputationEntry<'a> {
+    #[serde(default)]
+    pub score: Option<i32>,
+    #[serde(default)]
+    pub source: Option<&'a str>,
+    #[serde(default)]
+    pub expires_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub notes: Option<&'a str>,
+}
+
+/// Filters for `GET /api/reputation` — all optional, treated as AND.
+#[derive(Debug, Clone, Default)]
+pub struct ReputationQuery {
+    pub ip_prefix: Option<String>,
+    pub source: Option<String>,
+    pub min_score: Option<i32>,
+    pub max_score: Option<i32>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}

--- a/crates/waf-storage/src/repo.rs
+++ b/crates/waf-storage/src/repo.rs
@@ -7,12 +7,13 @@ use crate::error::StorageError;
 use crate::models::{
     AdminUser, AllowIp, AllowUrl, AttackLog, AttackLogQuery, AuditLogEntry, AuditLogQuery, BlockIp, BlockUrl,
     CategoryTimeSeriesPoint, Certificate, CreateAdminUser, CreateCertificate, CreateCrowdSecEvent, CreateCustomRule,
-    CreateHost, CreateIpRule, CreateLbBackend, CreateNotificationConfig, CreateSecurityEvent, CreateSensitivePattern,
-    CreateTunnel, CreateUrlRule, CreateWasmPlugin, CrowdSecConfigRow, CrowdSecEventQuery, CrowdSecEventRow, CustomRule,
-    EndpointHeatmap, GeoDistEntry, GeoStats, HeatmapCell, HeatmapFilter, Host, HotlinkConfig, LbBackend,
-    NotificationConfig, NotificationLog, RecentEvent, RefreshToken, SecurityEvent, SecurityEventQuery,
-    SensitivePattern, StatsFilter, StatsOverview, TimeSeriesPoint, TopEntry, TunnelRow, UpdateCertificatePem,
-    UpdateCustomRule, UpdateHost, UpdateSensitivePattern, UpsertCrowdSecConfig, UpsertHotlinkConfig, WasmPluginRow,
+    CreateHost, CreateIpRule, CreateLbBackend, CreateNotificationConfig, CreateReputationEntry, CreateSecurityEvent,
+    CreateSensitivePattern, CreateTunnel, CreateUrlRule, CreateWasmPlugin, CrowdSecConfigRow, CrowdSecEventQuery,
+    CrowdSecEventRow, CustomRule, EndpointHeatmap, GeoDistEntry, GeoStats, HeatmapCell, HeatmapFilter, Host,
+    HotlinkConfig, LbBackend, NotificationConfig, NotificationLog, RecentEvent, RefreshToken, ReputationEntry,
+    ReputationQuery, SecurityEvent, SecurityEventQuery, SensitivePattern, StatsFilter, StatsOverview, TimeSeriesPoint,
+    TopEntry, TunnelRow, UpdateCertificatePem, UpdateCustomRule, UpdateHost, UpdateReputationEntry,
+    UpdateSensitivePattern, UpsertCrowdSecConfig, UpsertHotlinkConfig, WasmPluginRow,
 };
 
 impl Database {
@@ -2201,5 +2202,113 @@ impl Database {
         .await?;
 
         Ok((rows, total))
+    }
+
+    // ─── IP reputation list (FR-042) ─────────────────────────────────────────
+
+    /// List reputation entries matching the optional AND-filters in `query`.
+    /// Returns `(entries, total_unpaginated_count)` so the FE can render
+    /// pagination controls without a second round-trip.
+    pub async fn list_reputation_entries(
+        &self,
+        query: &ReputationQuery,
+    ) -> Result<(Vec<ReputationEntry>, i64), StorageError> {
+        let mut count_qb: QueryBuilder<sqlx::Postgres> =
+            QueryBuilder::new("SELECT COUNT(*) FROM reputation_list WHERE 1 = 1");
+        let mut list_qb: QueryBuilder<sqlx::Postgres> = QueryBuilder::new("SELECT * FROM reputation_list WHERE 1 = 1");
+
+        for qb in [&mut count_qb, &mut list_qb] {
+            if let Some(prefix) = &query.ip_prefix {
+                qb.push(" AND ip LIKE ").push_bind(format!("{prefix}%"));
+            }
+            if let Some(src) = &query.source {
+                qb.push(" AND source = ").push_bind(src);
+            }
+            if let Some(min) = query.min_score {
+                qb.push(" AND score >= ").push_bind(min);
+            }
+            if let Some(max) = query.max_score {
+                qb.push(" AND score <= ").push_bind(max);
+            }
+        }
+
+        let total: i64 = count_qb.build_query_scalar().fetch_one(&self.pool).await?;
+
+        list_qb.push(" ORDER BY updated_at DESC");
+        if let Some(limit) = query.limit {
+            list_qb.push(" LIMIT ").push_bind(limit);
+        }
+        if let Some(offset) = query.offset {
+            list_qb.push(" OFFSET ").push_bind(offset);
+        }
+        let rows = list_qb
+            .build_query_as::<ReputationEntry>()
+            .fetch_all(&self.pool)
+            .await?;
+        Ok((rows, total))
+    }
+
+    /// Insert a new reputation entry, or update the existing row matching
+    /// `(ip, source)` via the table's UNIQUE constraint. Returns the
+    /// post-write row.
+    pub async fn upsert_reputation_entry(&self, req: &CreateReputationEntry) -> Result<ReputationEntry, StorageError> {
+        let now = chrono::Utc::now();
+        let row = sqlx::query_as::<_, ReputationEntry>(
+            r"INSERT INTO reputation_list (ip, score, source, expires_at, notes, created_at, updated_at)
+               VALUES ($1, $2, $3, $4, $5, $6, $6)
+               ON CONFLICT (ip, source) DO UPDATE
+                   SET score      = EXCLUDED.score,
+                       expires_at = EXCLUDED.expires_at,
+                       notes      = EXCLUDED.notes,
+                       updated_at = EXCLUDED.updated_at
+               RETURNING *",
+        )
+        .bind(&req.ip)
+        .bind(req.score)
+        .bind(&req.source)
+        .bind(req.expires_at)
+        .bind(&req.notes)
+        .bind(now)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    /// Apply a partial update to the entry with the given id. Returns `Ok(None)`
+    /// when no row matched.
+    pub async fn update_reputation_entry(
+        &self,
+        id: i64,
+        req: &UpdateReputationEntry<'_>,
+    ) -> Result<Option<ReputationEntry>, StorageError> {
+        let mut qb: QueryBuilder<sqlx::Postgres> = QueryBuilder::new("UPDATE reputation_list SET updated_at = NOW()");
+        if let Some(score) = req.score {
+            qb.push(", score = ").push_bind(score);
+        }
+        if let Some(source) = req.source {
+            qb.push(", source = ").push_bind(source);
+        }
+        if let Some(exp) = req.expires_at {
+            qb.push(", expires_at = ").push_bind(exp);
+        }
+        if let Some(notes) = req.notes {
+            qb.push(", notes = ").push_bind(notes);
+        }
+        qb.push(" WHERE id = ").push_bind(id).push(" RETURNING *");
+        let row = qb
+            .build_query_as::<ReputationEntry>()
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row)
+    }
+
+    /// Delete the entry with the given id. Returns `true` when a row was
+    /// removed.
+    pub async fn delete_reputation_entry(&self, id: i64) -> Result<bool, StorageError> {
+        let res = sqlx::query("DELETE FROM reputation_list WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(res.rows_affected() > 0)
     }
 }

--- a/crates/waf-storage/tests/repo_reputation_test.rs
+++ b/crates/waf-storage/tests/repo_reputation_test.rs
@@ -1,0 +1,235 @@
+//! Integration tests for the reputation_list repo methods (FR-042).
+
+#![allow(
+    dead_code,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::doc_markdown
+)]
+
+#[path = "common/mod.rs"]
+mod common;
+
+use chrono::{Duration, Utc};
+use waf_storage::models::{CreateReputationEntry, ReputationQuery, UpdateReputationEntry};
+
+use common::start_postgres;
+
+fn make_entry(ip: &str, source: &str, score: i32) -> CreateReputationEntry {
+    CreateReputationEntry {
+        ip: ip.to_owned(),
+        score,
+        source: source.to_owned(),
+        expires_at: Utc::now() + Duration::hours(48),
+        notes: Some("integration test".to_owned()),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_list_returns_zero_total() {
+    let fx = start_postgres().await;
+    let (rows, total) = fx
+        .db
+        .list_reputation_entries(&ReputationQuery::default())
+        .await
+        .expect("list empty");
+    assert!(rows.is_empty());
+    assert_eq!(total, 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_round_trips_via_list() {
+    let fx = start_postgres().await;
+    let created = fx
+        .db
+        .upsert_reputation_entry(&make_entry("203.0.113.1", "manual", -50))
+        .await
+        .expect("upsert");
+    assert_eq!(created.ip, "203.0.113.1");
+    assert_eq!(created.score, -50);
+
+    let (rows, total) = fx
+        .db
+        .list_reputation_entries(&ReputationQuery::default())
+        .await
+        .expect("list after upsert");
+    assert_eq!(total, 1);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, created.id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_collapses_same_ip_and_source() {
+    let fx = start_postgres().await;
+    let first = fx
+        .db
+        .upsert_reputation_entry(&make_entry("203.0.113.7", "manual", -25))
+        .await
+        .expect("first");
+    let second = fx
+        .db
+        .upsert_reputation_entry(&make_entry("203.0.113.7", "manual", 75))
+        .await
+        .expect("second");
+    assert_eq!(first.id, second.id, "UNIQUE(ip, source) must collapse");
+    assert_eq!(second.score, 75);
+
+    let (_, total) = fx
+        .db
+        .list_reputation_entries(&ReputationQuery::default())
+        .await
+        .expect("list");
+    assert_eq!(total, 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_distinct_sources_for_same_ip_keeps_both() {
+    let fx = start_postgres().await;
+    let _ = fx
+        .db
+        .upsert_reputation_entry(&make_entry("198.51.100.1", "manual", 50))
+        .await
+        .expect("manual");
+    let _ = fx
+        .db
+        .upsert_reputation_entry(&make_entry("198.51.100.1", "crowdsec", 90))
+        .await
+        .expect("crowdsec");
+    let (_, total) = fx
+        .db
+        .list_reputation_entries(&ReputationQuery::default())
+        .await
+        .expect("list");
+    assert_eq!(total, 2);
+}
+
+/// Exercise each filter on a shared seed set so we pay the testcontainer
+/// startup cost once instead of three times. Asserts that each filter
+/// narrows the row set as expected and that the unfiltered list returns
+/// all rows.
+#[tokio::test(flavor = "multi_thread")]
+async fn list_filters_narrow_the_seed_set() {
+    let fx = start_postgres().await;
+    let seed = [
+        ("198.51.100.10", "manual", -80),
+        ("198.51.100.11", "manual", 25),
+        ("198.51.100.12", "crowdsec", 90),
+        ("203.0.113.5", "manual", 10),
+    ];
+    for (ip, src, score) in seed {
+        let _ = fx
+            .db
+            .upsert_reputation_entry(&make_entry(ip, src, score))
+            .await
+            .expect("seed");
+    }
+    let by_source = fx
+        .db
+        .list_reputation_entries(&ReputationQuery {
+            source: Some("crowdsec".to_owned()),
+            ..Default::default()
+        })
+        .await
+        .expect("source filter");
+    assert_eq!(by_source.1, 1);
+    assert_eq!(by_source.0[0].source, "crowdsec");
+
+    let by_score = fx
+        .db
+        .list_reputation_entries(&ReputationQuery {
+            min_score: Some(0),
+            max_score: Some(50),
+            ..Default::default()
+        })
+        .await
+        .expect("score range");
+    assert_eq!(by_score.1, 2);
+
+    let by_prefix = fx
+        .db
+        .list_reputation_entries(&ReputationQuery {
+            ip_prefix: Some("203.0.113.".to_owned()),
+            ..Default::default()
+        })
+        .await
+        .expect("prefix");
+    assert_eq!(by_prefix.1, 1);
+    assert_eq!(by_prefix.0[0].ip, "203.0.113.5");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_paginates_via_limit_offset() {
+    let fx = start_postgres().await;
+    for i in 0..5u8 {
+        let _ = fx
+            .db
+            .upsert_reputation_entry(&make_entry(&format!("203.0.113.{i}"), "manual", i32::from(i)))
+            .await
+            .expect("seed");
+    }
+    let query = ReputationQuery {
+        limit: Some(2),
+        offset: Some(1),
+        ..Default::default()
+    };
+    let (rows, total) = fx.db.list_reputation_entries(&query).await.expect("paginated");
+    assert_eq!(total, 5);
+    assert_eq!(rows.len(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_partial_patches_only_named_fields() {
+    let fx = start_postgres().await;
+    let created = fx
+        .db
+        .upsert_reputation_entry(&make_entry("203.0.113.99", "manual", 10))
+        .await
+        .expect("seed");
+
+    let patch = UpdateReputationEntry {
+        score: Some(33),
+        notes: Some("updated"),
+        ..Default::default()
+    };
+    let updated = fx
+        .db
+        .update_reputation_entry(created.id, &patch)
+        .await
+        .expect("update")
+        .expect("row");
+    assert_eq!(updated.score, 33);
+    assert_eq!(updated.notes.as_deref(), Some("updated"));
+    assert_eq!(updated.source, "manual", "untouched fields preserved");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn update_unknown_id_returns_none() {
+    let fx = start_postgres().await;
+    let res = fx
+        .db
+        .update_reputation_entry(
+            99_999,
+            &UpdateReputationEntry {
+                score: Some(50),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("update unknown");
+    assert!(res.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_removes_and_is_idempotent() {
+    let fx = start_postgres().await;
+    let created = fx
+        .db
+        .upsert_reputation_entry(&make_entry("203.0.113.123", "manual", 0))
+        .await
+        .expect("seed");
+    let first = fx.db.delete_reputation_entry(created.id).await.expect("delete");
+    assert!(first);
+    let second = fx.db.delete_reputation_entry(created.id).await.expect("delete again");
+    assert!(!second);
+}

--- a/migrations/0018_reputation_list.sql
+++ b/migrations/0018_reputation_list.sql
@@ -1,0 +1,22 @@
+-- FR-042 / #60.6 — IP reputation editor.
+--
+-- Operator-curated list of IPs with a score in [-100, 100] and a provenance
+-- tag (manual / crowdsec / community / feed). Soft-expiry via expires_at so
+-- entries clean themselves up; unique on (ip, source) so the same source
+-- cannot double-publish for the same IP.
+
+CREATE TABLE IF NOT EXISTS reputation_list (
+    id          BIGSERIAL PRIMARY KEY,
+    ip          TEXT NOT NULL,
+    score       INTEGER NOT NULL CHECK (score BETWEEN -100 AND 100),
+    source      VARCHAR(32) NOT NULL
+                CHECK (source IN ('manual', 'crowdsec', 'community', 'feed')),
+    expires_at  TIMESTAMPTZ NOT NULL,
+    notes       TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (ip, source)
+);
+
+CREATE INDEX IF NOT EXISTS reputation_list_ip_idx      ON reputation_list (ip);
+CREATE INDEX IF NOT EXISTS reputation_list_expires_idx ON reputation_list (expires_at);


### PR DESCRIPTION
## What

Ports the **IP Reputation editor (FR-042)** from `release/stg` onto `main`. It gives operators a CRUD admin API over a curated IP-reputation list, persisted in a new `reputation_list` table. This is net-new functionality — `main` had zero reputation-editor code (verified: 0 references in `waf-storage/src/repo.rs` on `main` vs 12 on `release/stg`).

## Why this feature (selection rationale)

Scanned every commit on `release/stg` not yet on `main` (49 commits). Findings:

- **Security fix wave (#71–87, #127–136)** — already on `main` from prior cherry-pick waves. Verified by code, not commit message (e.g. regex `size_limit(1<<20)`, `trusted_proxies` fail-secure, non-UTF-8 body handling all present on `main`).
- **sensitive-pattern mutations** — already on `main`.
- **IP reputation editor (#60.6)** — **genuinely missing**, and self-contained: one new API module + one migration, mostly additive elsewhere, 19 feature tests. Lowest-risk, highest-value discrete feature to port.
- Larger admin-panel feature sets (tier policies / DDoS pages / device-fp / challenge endpoints) are bigger, UI-coupled, and better split into their own PRs later.

## What's in it

| Area | Change |
|------|--------|
| `migrations/0018_reputation_list.sql` | New table: `UNIQUE(ip, source)`, `CHECK` on score range + source enum |
| `waf-storage` (`models.rs`, `repo.rs`) | `ReputationEntry` model + repo CRUD (upsert/list/update/delete) |
| `waf-api/reputation_api.rs` | New module: `GET/POST /api/reputation`, `PUT/DELETE /api/reputation/{id}` |
| `waf-api/server.rs` | Route registration with `DefaultBodyLimit` (64 KiB) |
| `waf-api/auth.rs` | `validate_admin_token()` admin-role gate (feature dependency) |

**Security posture:** all mutations require an admin-role JWT; 64 KiB body cap; score clamped to ±100; expiry must be in the future; source constrained by DB `CHECK`.

## Adaptations made porting to `main`

`main` and `release/stg` have diverged, so a raw cherry-pick conflicted in 2 registration points. Resolved as:

1. **`auth.rs`** — added `validate_admin_token()` (`validate_access_token` + `role == "admin"` check). It did not exist on `main`; it is the admin gate the whole feature relies on. Ported faithfully with 3 focused unit tests.
2. **`tests/common/mod.rs`** — added `issue_viewer_token()` helper (mints a viewer-role JWT) so the RBAC-rejection tests compile on `main`.
3. **`server.rs`** — registered reputation routes alongside `main`'s existing `geoip`/`risk` routes. **Deliberately did NOT** pull in `release/stg`'s unrelated `/api/geoip/rules` → `/api/geo-rules` rename — out of scope and would break `main`'s geo handlers/tests.

## Verification

Run locally before opening:

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p waf-api -p waf-storage --tests -- -D warnings` — clean
- `cargo check -p waf-storage -p waf-api --tests` — clean
- Tests (real Postgres testcontainer), all green:
  - `auth` unit: 16 passed (incl. 3 new admin-gate)
  - `repo_reputation_test`: 9 passed
  - `reputation_api_test`: 10 passed

## Migration note

`0018` is the next free migration slot on `main` (`main` tops out at `0017`, `0013–0017` identical on both branches) — no numbering collision.

## Not merging

Opening **ready-to-merge** for review; leaving the merge decision to a maintainer.

Closes #60.6
