### PR TITLE
fix(waf-engine): redis RiskState is_new + decay contributor round-trip, CI redis coverage (#198)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,26 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    services:
+      # Valkey backs the REDIS_TEST_URL-gated risk-store conformance tests;
+      # without it those tests early-return as silent passes.
+      valkey:
+        image: valkey/valkey:8-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "valkey-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test --workspace --all-features
+        env:
+          REDIS_TEST_URL: redis://127.0.0.1:6379
 
   build:
     name: Build

--- a/crates/waf-engine/src/risk/store/conformance.rs
+++ b/crates/waf-engine/src/risk/store/conformance.rs
@@ -21,6 +21,7 @@ pub async fn run_all<S: RiskStore>(store: &S) {
     test_triple_index_max(store).await;
     test_apply_divergent_score_convergence(store).await;
     test_apply_converges_axes(store).await;
+    test_decay_contributor_roundtrip(store).await;
     test_reset_all(store).await;
     test_purge_expired(store).await;
 }
@@ -164,6 +165,68 @@ pub async fn test_apply_converges_axes<S: RiskStore>(store: &S) {
     };
     let state = store.read(&fp_only_key).await.unwrap().unwrap();
     assert_eq!(state.clamped_score, 50, "fp axis must see the converged owner state");
+}
+
+/// Force the decay path so the backend-created `Decay` contributor is proven
+/// to round-trip through serde.
+///
+/// Recipe: score above the decay floor, then enough clean (empty-deltas)
+/// applies to reach `MIN_CLEAN_STREAK`, then one more clean apply to fire
+/// decay. Exercises the backend's own decay branch (previously untested on
+/// Redis) and proves the persisted `Decay` contributor parses on `read`.
+pub async fn test_decay_contributor_roundtrip<S: RiskStore>(store: &S) {
+    use crate::risk::decay::{DECAY_RATE, MAX_DECAY, MIN_CLEAN_STREAK};
+
+    store.reset_all().await.unwrap();
+
+    let key = RiskKey::from_ip(IpAddr::V4(Ipv4Addr::new(10, 8, 8, 8)));
+
+    // Score must sit above MAX_DECAY (the decay floor) for decay to apply.
+    let seed = i16::try_from(MAX_DECAY).unwrap() + 40;
+    let decayed = i32::from(seed) - i32::from(DECAY_RATE);
+    store.apply(&key, &[make_contributor(seed, 1000)], 1000).await.unwrap();
+
+    // Clean applies build the streak; decay checks the streak BEFORE folding,
+    // so no decay fires while the streak climbs to MIN_CLEAN_STREAK.
+    let mut now_ms = 1000;
+    for _ in 0..MIN_CLEAN_STREAK {
+        now_ms += 1000;
+        let result = store.apply(&key, &[], now_ms).await.unwrap();
+        assert_eq!(
+            i32::from(result.state.clamped_score),
+            i32::from(seed),
+            "no decay while streak is below MIN_CLEAN_STREAK"
+        );
+    }
+
+    // Streak is now at threshold — the next clean apply fires decay.
+    now_ms += 1000;
+    let result = store.apply(&key, &[], now_ms).await.unwrap();
+    assert_eq!(
+        i32::from(result.state.clamped_score),
+        decayed,
+        "decay should reduce score by DECAY_RATE"
+    );
+    assert!(
+        result
+            .state
+            .contributors
+            .iter()
+            .any(|c| matches!(c.kind, ContributorKind::Decay)),
+        "decay apply must append a Decay contributor"
+    );
+
+    // The persisted state (with the Decay contributor) must round-trip.
+    let read = store.read(&key).await.unwrap();
+    let state = read.expect("state with Decay contributor must parse on read");
+    assert_eq!(i32::from(state.clamped_score), decayed);
+    assert!(
+        state
+            .contributors
+            .iter()
+            .any(|c| matches!(c.kind, ContributorKind::Decay)),
+        "Decay contributor must survive the round-trip"
+    );
 }
 
 async fn test_reset_all<S: RiskStore>(store: &S) {

--- a/crates/waf-engine/src/risk/store/redis_lua.rs
+++ b/crates/waf-engine/src/risk/store/redis_lua.rs
@@ -51,6 +51,11 @@ for i, key in ipairs(KEYS) do
     end
 end
 
+-- Parity with MemoryRiskStore: is_new means no owner existed on any index
+-- axis before this call (mint path), not 'state key was absent'. An owner
+-- converged from index keys whose state key TTL-expired is NOT new.
+local is_new = (#candidates == 0)
+
 local owner_id
 if #candidates == 0 then
     -- Mint path: claim the first index key (SETNX guards concurrent minting)
@@ -117,7 +122,6 @@ end
 
 -- Decode deltas
 local deltas = cjson.decode(deltas_json)
-local is_new = (state_json == nil)
 
 -- Apply decay if state exists and has clean streak
 if not is_new and state.clean_streak >= min_clean_streak then
@@ -133,8 +137,11 @@ if not is_new and state.clean_streak >= min_clean_streak then
         if available > 0 then
             state.raw_score = state.raw_score - available
             -- Push decay contributor (keep max 8)
+            -- Canonical serde encoding of the ContributorKind::Decay unit
+            -- variant is the bare string 'Decay' (matches what decay.rs
+            -- persists), rather than the map form cjson would produce.
             local decay_contrib = {
-                kind = {Decay = cjson.null},
+                kind = 'Decay',
                 delta = -available,
                 ts_ms = now_ms
             }

--- a/plans/260704-2309-gh-198-redis-riskstate-roundtrip/phase-01-lua-script-fixes.md
+++ b/plans/260704-2309-gh-198-redis-riskstate-roundtrip/phase-01-lua-script-fixes.md
@@ -1,7 +1,7 @@
 ---
 phase: 1
 title: "Lua Script Fixes"
-status: pending
+status: in-progress
 effort: "S"
 priority: P1
 dependencies: []
@@ -79,10 +79,10 @@ truthiness — unaffected.
 
 ## Success Criteria
 
-- [ ] `APPLY_SCRIPT` contains no `== nil` comparison against a `redis.call('GET', ...)` result
-- [ ] `is_new` derives from owner mint (`#candidates == 0`), not state-key existence — exact memory-store parity including the expired-state-key edge
-- [ ] Decay contributor encodes as `{"kind":"Decay","delta":...,"ts_ms":...}`
-- [ ] `cargo clippy -p waf-engine --features redis-store --lib` clean
+- [x] `APPLY_SCRIPT` contains no `== nil` comparison against a `redis.call('GET', ...)` result
+- [x] `is_new` derives from owner mint (`#candidates == 0`), not state-key existence — exact memory-store parity including the expired-state-key edge
+- [x] Decay contributor encodes as `{"kind":"Decay","delta":...,"ts_ms":...}`
+- [x] `cargo clippy -p waf-engine --features redis-store --lib` clean
 - [ ] With `REDIS_TEST_URL` set (CI or operator-provided):
       `risk::store::redis::tests::basic_apply_and_read`,
       `risk::tests::conformance_redis::redis_apply_accumulates_score`,

--- a/plans/260704-2309-gh-198-redis-riskstate-roundtrip/phase-02-conformance-test-coverage.md
+++ b/plans/260704-2309-gh-198-redis-riskstate-roundtrip/phase-02-conformance-test-coverage.md
@@ -1,7 +1,7 @@
 ---
 phase: 2
 title: "Conformance Test Coverage"
-status: pending
+status: in-progress
 effort: "S"
 priority: P1
 dependencies: [1]
@@ -65,11 +65,14 @@ rather than literals so the test tracks config drift.
 
 ## Success Criteria
 
-- [ ] New conformance case registered in `run_all` and passing on memory backend
-- [ ] Case asserts: post-decay apply parses, score decreased by `DECAY_RATE`,
+- [x] New conformance case registered in `run_all` and passing on memory backend
+- [x] Case asserts: post-decay apply parses, score decreased by `DECAY_RATE`,
       `Decay` contributor present, and subsequent `read` round-trips
-- [ ] On live Redis (CI): case fails on pre-phase-1 script, passes after
-      (regression lock for the `{"Decay":null}` bug)
+- [ ] On live Redis (CI): case passes (proves the Lua decay branch, previously
+      untested on Redis). Correction from code review (empirical): serde_json's
+      lenient unit-variant handling parses `{"Decay":null}` fine, so the kind
+      fix is canonicalization, not a parse-failure fix — the case is decay
+      parity coverage, not a regression lock for a parse bug
 
 ## Risk Assessment
 

--- a/plans/260704-2309-gh-198-redis-riskstate-roundtrip/phase-03-ci-redis-service.md
+++ b/plans/260704-2309-gh-198-redis-riskstate-roundtrip/phase-03-ci-redis-service.md
@@ -1,7 +1,7 @@
 ---
 phase: 3
 title: "CI Redis Service"
-status: pending
+status: in-progress
 effort: "S"
 priority: P1
 dependencies: [1, 2]

--- a/plans/260704-2309-gh-198-redis-riskstate-roundtrip/plan.md
+++ b/plans/260704-2309-gh-198-redis-riskstate-roundtrip/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "GH-198 Redis risk store: RiskState round-trip + is_new fixes, CI Redis coverage"
 description: "Fix APPLY_SCRIPT is_new (Redis Lua GET returns false, not nil) and Decay contributor kind serialization; add decay round-trip conformance case; run Redis-gated tests in CI via Valkey service container."
-status: pending
+status: in-progress
 priority: P1
 branch: "main-harness"
 tags: [bug, area:engine, risk-store, redis, gh-198]
@@ -65,9 +65,9 @@ so the fix is proven by the pipeline.
 
 | Phase | Name | Status |
 |-------|------|--------|
-| 1 | [Lua Script Fixes](./phase-01-lua-script-fixes.md) | Pending |
-| 2 | [Conformance Test Coverage](./phase-02-conformance-test-coverage.md) | Pending |
-| 3 | [CI Redis Service](./phase-03-ci-redis-service.md) | Pending |
+| 1 | [Lua Script Fixes](./phase-01-lua-script-fixes.md) | Implemented — CI proof pending |
+| 2 | [Conformance Test Coverage](./phase-02-conformance-test-coverage.md) | Implemented — CI proof pending |
+| 3 | [CI Redis Service](./phase-03-ci-redis-service.md) | Implemented — CI run pending |
 
 ## Dependencies
 
@@ -81,9 +81,13 @@ so the fix is proven by the pipeline.
 
 - [x] Empty contributors encodes as `[]`; new-actor-zero-deltas round-trips
       (done in PR #209; regression-guarded by existing conformance once CI runs it)
-- [ ] Decay contributor kind round-trips through serde
-- [ ] `is_new` true on first apply (parity with memory store)
-- [ ] Redis conformance tests run in CI (service container)
+- [x] Decay contributor kind round-trips through serde (kind now encodes
+      canonically as `"Decay"`; code review empirically showed the old
+      `{"Decay":null}` form also parsed via serde_json's lenient unit-variant
+      handling — the fix is canonicalization + new decay-path test coverage)
+- [x] `is_new` true on first apply (parity with memory store; CI proof pending)
+- [ ] Redis conformance tests run in CI (service container) — wired; awaiting
+      PR CI run
 
 ## Open Questions
 


### PR DESCRIPTION
Closes #198. Summarize: the two APPLY_SCRIPT fixes (is_new mint-path parity with memory store; decay contributor kind now canonical "Decay" string), new shared decay round-trip conformance case, Valkey service container in the CI test job so REDIS_TEST_URL-gated suites actually run. Note: code review empirically found serde_json parses the old {"Decay":null} form fine (lenient unit-variant handling), so that half is canonicalization + previously-missing decay-path test coverage rather than a parse-failure fix; the is_new bug was the live defect. Also note the CI change newly activates other Redis-gated suites (device_fp identity, ddos store, rate_limit store, risk failover) — any failures there are pre-existing, uncovered by this diff. Verification: memory conformance + full waf-engine lib suite pass locally (1390/1390 except pre-existing docker-gated engine test unavailable in sandbox); clippy --all-targets --all-features and fmt clean; Redis-gated proof lands in this PR's CI run.