### PR TITLE
fix(waf-engine): enforce risk scorer verdicts in inspect() (#195)

### DIFF
--- a/crates/waf-engine/CLAUDE.md
+++ b/crates/waf-engine/CLAUDE.md
@@ -10,6 +10,7 @@ Core detection engine. Evaluates inbound HTTP requests against rule sets and sec
 - **Device fingerprinting (FR-010)**: TLS ClientHello + HTTP/2 frame capture, JA3 / JA4 / Akamai H2 fingerprint hashers, identity store (in-memory or Redis), risk-signal providers (UA blocklist/entropy, fingerprint conflict, IP hopping, H2 anomaly), risk aggregator.
 - **Transaction velocity (FR-012)**: signal-only; dispatched from gateway `logging()` hook (not `response_filter`) so streaming, WAF-blocked, and origin-down paths are handled correctly. Events carry tristate `Outcome::{Pending, Ok, Failed}`; classifiers ignore Pending. Velocity signals carry both `count` (settled attempts in window) and `ok_count` (subset that succeeded). Cookie-less requests fall back to `RequestCtx.device_fp` scoped by `peer_ip` for session identity.
 - **CrowdSec integration**: AppSec component, decision sync, cache, pusher, models.
+- **Cumulative risk scoring (FR-025)**: per-actor score with decay, enforced in `inspect()` — threshold/canary/pinned outcomes surface as Block/Challenge decisions (`Phase::RiskScore`, `rule_name = "cumulative_risk"`), mode-gated by the `risk_assessment` feature. Escalation is a fallback gate: it only fires when the pipeline decision is a plain Allow, so detections downgraded to LogOnly by monitor mode keep their own decision and suppress risk escalation for that request (`risk_assessment` in monitor mode is the rollout valve). Canary honeypot hits (FR-028) pin the score to 100 and insert the IP into the DDoS dynamic ban table with config-driven TTL.
 - **Community blocklist**: enrollment, fetch, reporter, checker.
 - **Plugins**: WASM (`wasmtime`) and Rhai script execution for custom logic.
 - **GeoIP**: ip2region + MaxMind lookups with background updater.
@@ -48,8 +49,9 @@ src/
 │   ├── identity/            # memory + redis stores (redis gated by feature)
 │   ├── behavior/            # FR-011 behavioral anomaly detection (per-actor cadence/path classifiers)
 │   └── providers/           # ua_blocklist, ua_entropy, fp_conflict, ip_hopping, h2_anomaly
-├── risk/                    # FR-025 cumulative risk scoring (in-memory + config hot-reload)
+├── risk/                    # FR-025 cumulative risk scoring (enforced via Phase::RiskScore in engine.rs)
 │   ├── config.rs, scorer.rs, score.rs, decay.rs, threshold.rs
+│   ├── canary.rs            # FR-028 honeypot paths → score pin + DDoS ban-table insert
 │   ├── key.rs               # RiskKey (triple-index: IP/fingerprint/session)
 │   ├── state.rs             # RiskState, Contributor, ContributorKind
 │   ├── reload.rs            # notify-based hot-reload with ArcSwap

--- a/crates/waf-engine/src/engine.rs
+++ b/crates/waf-engine/src/engine.rs
@@ -42,8 +42,9 @@ use crate::logging::{AuditEvent, AuditEventType, AuditSender, DbBatchWriter, DbL
 use crate::rules::custom_file_loader::CustomRuleFileWatcher;
 use crate::rules::engine::{CustomRulesEngine, from_db_rule};
 
+use crate::risk::canary::{CanaryLayer, DEFAULT_CANARY_BAN_TTL_SECS};
 use crate::risk::config::RiskConfig;
-use crate::risk::scorer::Scorer;
+use crate::risk::scorer::{Scorer, ScorerResult};
 use crate::risk::store::MemoryRiskStore;
 
 /// WAF engine configuration
@@ -150,12 +151,19 @@ pub struct WafEngine {
     mode_registry: OnceLock<ModeRegistry>,
     /// Hot-swappable risk-scoring config. Default `RiskConfig` has
     /// `enabled = false`, so `Scorer.score()` returns score=0 / Allow until
-    /// operators wire a real config via [`Self::replace_risk_config`].
+    /// a real config is loaded via [`Self::replace_risk_config`].
     risk_cfg: Arc<ArcSwap<RiskConfig>>,
     /// Risk scorer threaded into `inspect()`. Backed by the in-memory store
     /// so engine construction stays infrastructure-free. Provides the
-    /// `decision.risk_score` value attached to every WAF decision.
+    /// `decision.risk_score` attached to every WAF decision and drives
+    /// FR-025 enforcement: a scorer Block/Challenge escalates a plain-Allow
+    /// pipeline decision (see [`Self::inspect`]).
     scorer: Arc<Scorer<MemoryRiskStore>>,
+    /// FR-028 canary honeypot layer installed on the scorer. Bound to the
+    /// `DDoS` [`DynamicBanTable`] so canary hits IP-ban at the `DDoS` phase on
+    /// subsequent requests. Paths and ban TTL follow `RiskConfig.canary`
+    /// via [`Self::replace_risk_config`].
+    risk_canary: Arc<CanaryLayer>,
     // ── FR-007/FR-042 relay-intel feed metadata (D3) ─────────────────────────
     /// Threat-intel feed metadata (Tor / ASN / datacenter), loaded from
     /// `configs/relay.yaml` at startup via [`Self::load_relay_feeds`]. Empty
@@ -250,7 +258,17 @@ impl WafEngine {
         // Operators that want real scoring call `replace_risk_config`.
         let risk_cfg = Arc::new(ArcSwap::from(Arc::new(RiskConfig::default())));
         let risk_store = Arc::new(MemoryRiskStore::new());
-        let scorer = Arc::new(Scorer::new(risk_store, Arc::clone(&risk_cfg)));
+        // FR-028 canary layer bound to the DDoS ban table: a canary hit bans
+        // the IP so follow-up requests block at the DDoS phase. Paths stay
+        // empty (inert) until `replace_risk_config` loads them.
+        let risk_canary = Arc::new(CanaryLayer::with_ban_table(
+            Vec::new(),
+            Arc::clone(ddos_check.ban_table()),
+            DEFAULT_CANARY_BAN_TTL_SECS,
+        ));
+        let mut scorer = Scorer::new(risk_store, Arc::clone(&risk_cfg));
+        scorer.set_canary(Arc::clone(&risk_canary));
+        let scorer = Arc::new(scorer);
 
         Self {
             store,
@@ -283,6 +301,7 @@ impl WafEngine {
             mode_registry: OnceLock::new(),
             risk_cfg,
             scorer,
+            risk_canary,
             relay_feeds: ArcSwap::from_pointee(Vec::new()),
         }
     }
@@ -294,6 +313,11 @@ impl WafEngine {
     /// scoring via this entry point; tests use it to enable scoring on a
     /// per-test basis.
     pub fn replace_risk_config(&self, cfg: RiskConfig) {
+        // Keep the canary layer in sync with the config: path set and ban TTL
+        // are both hot-reloadable. The TTL governs the DDoS-table ban and the
+        // force_max score pin (`CanaryLayer::ban_ttl_ms`).
+        self.risk_canary.reload(cfg.canary.paths.clone());
+        self.risk_canary.set_ban_ttl_secs(cfg.canary.ban_ttl_secs);
         self.risk_cfg.store(Arc::new(cfg));
     }
 
@@ -677,16 +701,59 @@ impl WafEngine {
         let (mut decision, fast_path) = self.inspect_pipeline(ctx).await;
         // Fast-path exits (guard off, IP/URL allow/block lists) skip risk
         // scoring entirely: no store write, risk_score stays 0.
-        if matches!(fast_path, FastPath::Miss) {
-            let scorer_score = self
-                .scorer
-                .score(ctx, None, &[], None, now_ms)
-                .await
-                .map_or(0, |r| r.score);
-            decision.risk_score = scorer_score.min(100);
+        if matches!(fast_path, FastPath::Miss)
+            && let Ok(scorer_result) = self.scorer.score(ctx, None, &[], None, now_ms).await
+        {
+            let risk_score = scorer_result.score.min(100);
+            decision.risk_score = risk_score;
+            // FR-025 enforcement: escalation-only gate. A scorer Block or
+            // Challenge replaces the pipeline decision only when that decision
+            // is a plain Allow. Any decision carrying a detection — enforced
+            // or downgraded to LogOnly by a monitored feature — is returned
+            // untouched; a scorer Allow never downgrades anything.
+            if matches!(decision.action, WafAction::Allow)
+                && matches!(scorer_result.action, WafAction::Block { .. } | WafAction::Challenge)
+            {
+                let mut risk_decision = Self::make_risk_decision(ctx, &scorer_result);
+                self.apply_mode(ctx, &mut risk_decision, "risk_assessment", Some("cumulative_risk"));
+                self.log_security_event(ctx, &risk_decision);
+                self.report_community_signal(ctx, &risk_decision);
+                risk_decision.risk_score = risk_score;
+                decision = risk_decision;
+            }
         }
         self.send_audit_event(ctx, &decision, inspect_time);
         decision
+    }
+
+    /// Build the Block/Challenge decision for a risk-scorer escalation.
+    ///
+    /// All risk enforcement events carry `Phase::RiskScore` and the single
+    /// rule name `cumulative_risk` (threshold, pinned-actor, and canary hits
+    /// alike — canary hits stay distinguishable via the scorer's info log).
+    /// Mode resolution is handled by `apply_mode()` at the call site.
+    fn make_risk_decision(ctx: &RequestCtx, scorer_result: &ScorerResult) -> WafDecision {
+        let result = DetectionResult {
+            rule_id: None,
+            rule_name: "cumulative_risk".to_string(),
+            phase: waf_common::Phase::RiskScore,
+            detail: format!("risk score {}", scorer_result.score),
+            rule_action: None,
+            action_status: None,
+        };
+        match scorer_result.action {
+            WafAction::Block { status, .. } => {
+                let body = render_block_page(ctx, "cumulative_risk");
+                WafDecision::block(status, Some(body), result)
+            }
+            _ => WafDecision {
+                action: WafAction::Challenge,
+                result: Some(result),
+                risk_score: 0,
+                mode: InteropMode::Enforce,
+                rule_id: None,
+            },
+        }
     }
 
     /// Original inspection pipeline. Split out of [`Self::inspect`] so the
@@ -1275,6 +1342,257 @@ mod tests {
         assert!(
             !engine.scorer.store().is_empty().await,
             "scored request must write the risk store"
+        );
+    }
+
+    /// Spin up an engine on a scratch Postgres. Enforcement tests need no DB
+    /// rules, so no host row is created — `make_ctx` carries the host config.
+    async fn spawn_engine() -> (WafEngine, Option<testcontainers::ContainerAsync<PostgresImage>>) {
+        let (url, container) = if let Ok(url) = std::env::var("PG_TEST_URL") {
+            (url, None)
+        } else {
+            let container = PostgresImage::default()
+                .with_tag("16-alpine")
+                .start()
+                .await
+                .expect("start postgres testcontainer");
+            let host = container.get_host().await.expect("container host");
+            let port = container.get_host_port_ipv4(5432).await.expect("container port");
+            (
+                format!("postgres://postgres:postgres@{host}:{port}/postgres"),
+                Some(container),
+            )
+        };
+        let db = Database::connect(&url, 5).await.expect("db connect");
+        db.migrate().await.expect("migrate");
+        let engine = WafEngine::new(Arc::new(db), WafEngineConfig::default());
+        (engine, container)
+    }
+
+    /// `make_ctx` with custom risk thresholds. `challenge` mirrors `allow` —
+    /// only the allow/block boundaries drive `threshold::decide`.
+    fn make_ctx_with_thresholds(path: &str, ip: &str, allow: u32, block: u32) -> RequestCtx {
+        use waf_common::tier::{CachePolicy, FailMode, RiskThresholds, TierPolicy};
+
+        let mut ctx = make_ctx("risk-test", path, ip);
+        ctx.tier_policy = Arc::new(TierPolicy {
+            fail_mode: FailMode::Open,
+            ddos_threshold_rps: 1000,
+            cache_policy: CachePolicy::NoCache,
+            risk_thresholds: RiskThresholds {
+                allow,
+                challenge: allow,
+                block,
+            },
+        });
+        ctx
+    }
+
+    fn enabled_risk_config() -> RiskConfig {
+        RiskConfig {
+            enabled: true,
+            ..RiskConfig::default()
+        }
+    }
+
+    /// Threshold gate drives the returned decision: score-at-block → 403 with
+    /// a `Phase::RiskScore` result, challenge band → Challenge, disabled
+    /// config → Allow even with block-at-0 thresholds.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn risk_threshold_matrix_enforced() {
+        let (engine, _container) = spawn_engine().await;
+        engine.replace_risk_config(enabled_risk_config());
+
+        // Block: score 0 >= block threshold 0.
+        let mut ctx = make_ctx_with_thresholds("/", "198.51.100.1", 0, 0);
+        let decision = engine.inspect(&mut ctx).await;
+        assert!(
+            matches!(decision.action, WafAction::Block { status: 403, .. }),
+            "block-at-0 thresholds must 403, got {:?}",
+            decision.action
+        );
+        let result = decision.result.as_ref().expect("risk block must carry a result");
+        assert_eq!(result.phase, waf_common::Phase::RiskScore);
+        assert_eq!(result.rule_name, "cumulative_risk");
+
+        // Challenge: score 0 in [allow=0, block=101).
+        let mut ctx = make_ctx_with_thresholds("/", "198.51.100.2", 0, 101);
+        let decision = engine.inspect(&mut ctx).await;
+        assert!(
+            matches!(decision.action, WafAction::Challenge),
+            "challenge-band thresholds must challenge, got {:?}",
+            decision.action
+        );
+        let result = decision.result.as_ref().expect("risk challenge must carry a result");
+        assert_eq!(result.phase, waf_common::Phase::RiskScore);
+        assert_eq!(result.rule_name, "cumulative_risk");
+
+        // Disabled config short-circuits before the threshold gate.
+        engine.replace_risk_config(RiskConfig::default());
+        let mut ctx = make_ctx_with_thresholds("/", "198.51.100.3", 0, 0);
+        let decision = engine.inspect(&mut ctx).await;
+        assert!(
+            matches!(decision.action, WafAction::Allow),
+            "disabled risk config must not enforce, got {:?}",
+            decision.action
+        );
+    }
+
+    /// FR-028 canary contract: a canary hit 403s at `Phase::RiskScore` with
+    /// score 100 (issue AC #2), IP-bans via the `DDoS` table so the follow-up
+    /// request blocks at `Phase::Ddos`, and a directly pinned actor blocks
+    /// through the threshold override (issue AC #3).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn canary_hit_bans_and_pin_blocks() {
+        use crate::checks::ddos::DdosTierCfg;
+        use crate::risk::config::CanaryConfig;
+        use waf_common::tier::Tier;
+
+        let (engine, _container) = spawn_engine().await;
+        // Default DdosConfig has no tiers → the ban-table check never runs.
+        // Configure the CatchAll tier with unreachable burst thresholds so
+        // only the ban lookup is active.
+        engine.ddos_cfg.store(Arc::new(DdosConfig {
+            tiers: HashMap::from([(
+                Tier::CatchAll,
+                DdosTierCfg {
+                    per_fp_threshold: 1_000_000,
+                    per_fp_window_s: 60,
+                    per_tier_threshold: 1_000_000,
+                    per_tier_window_s: 60,
+                },
+            )]),
+            ..DdosConfig::default()
+        }));
+        engine.replace_risk_config(RiskConfig {
+            canary: CanaryConfig {
+                enabled: true,
+                paths: vec!["/admin-test".to_string()],
+                ban_ttl_secs: 600,
+            },
+            ..enabled_risk_config()
+        });
+
+        // Canary hit → real 403 at the engine boundary (issue AC #2).
+        let mut ctx = make_ctx("risk-test", "/admin-test", "203.0.113.50");
+        let decision = engine.inspect(&mut ctx).await;
+        assert!(
+            matches!(decision.action, WafAction::Block { status: 403, .. }),
+            "canary hit must 403, got {:?}",
+            decision.action
+        );
+        let result = decision.result.as_ref().expect("canary block must carry a result");
+        assert_eq!(result.phase, waf_common::Phase::RiskScore);
+        assert_eq!(result.rule_name, "cumulative_risk");
+        assert_eq!(decision.risk_score, 100, "canary force-max must pin score to 100");
+
+        // Same IP, normal path → blocked by the DDoS ban planted by the
+        // canary hit (FR-028 ban-table contract; Phase 19 runs pre-scoring).
+        let mut ctx = make_ctx("risk-test", "/", "203.0.113.50");
+        let decision = engine.inspect(&mut ctx).await;
+        assert!(
+            matches!(decision.action, WafAction::Block { .. }),
+            "banned canary IP must stay blocked, got {:?}",
+            decision.action
+        );
+        let result = decision.result.as_ref().expect("ban block must carry a result");
+        assert_eq!(
+            result.phase,
+            waf_common::Phase::Ddos,
+            "post-canary block must come from the DDoS ban phase, not re-scoring"
+        );
+
+        // Different IP, pinned directly via force_max → threshold override
+        // blocks even with default (permissive) thresholds (issue AC #3).
+        let mut ctx = make_ctx("risk-test", "/", "203.0.113.51");
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        engine
+            .scorer
+            .force_max(&ctx, None, now_ms + 60_000, now_ms)
+            .await
+            .expect("force_max");
+        let decision = engine.inspect(&mut ctx).await;
+        assert!(
+            matches!(decision.action, WafAction::Block { status: 403, .. }),
+            "pinned actor must block via override, got {:?}",
+            decision.action
+        );
+        let result = decision.result.as_ref().expect("pinned block must carry a result");
+        assert_eq!(result.phase, waf_common::Phase::RiskScore);
+        assert_eq!(result.rule_name, "cumulative_risk");
+        assert_eq!(decision.risk_score, 100, "pinned actor must carry score 100");
+    }
+
+    /// Monitor mode on `risk_assessment` downgrades a risk block to `LogOnly`:
+    /// the Block intent and `Phase::RiskScore` result are preserved for
+    /// logging, but the request proceeds.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn risk_block_respects_monitor_mode() {
+        let (engine, _container) = spawn_engine().await;
+        engine.replace_risk_config(enabled_risk_config());
+        let mr = ModeRegistry::new();
+        mr.set_feature("risk_assessment", InteropMode::LogOnly);
+        engine.set_mode_registry(mr);
+
+        let mut ctx = make_ctx_with_thresholds("/", "198.51.100.10", 0, 0);
+        let decision = engine.inspect(&mut ctx).await;
+        assert!(
+            matches!(decision.action, WafAction::Block { .. }),
+            "block intent must be preserved for logging, got {:?}",
+            decision.action
+        );
+        assert_eq!(decision.mode, InteropMode::LogOnly);
+        assert!(
+            decision.is_enforcement_allowed(),
+            "monitored risk block must let the request proceed"
+        );
+        let result = decision.result.as_ref().expect("monitored block must carry a result");
+        assert_eq!(result.phase, waf_common::Phase::RiskScore);
+        assert_eq!(result.rule_name, "cumulative_risk");
+    }
+
+    /// The escalation gate applies to plain-Allow decisions only: a pipeline
+    /// detection — enforced or downgraded to `LogOnly` by a monitored feature —
+    /// is never replaced by a risk escalation.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn risk_never_overrides_pipeline_decisions() {
+        let (engine, _container) = spawn_engine().await;
+        engine.replace_risk_config(enabled_risk_config());
+
+        // Enforced detection: SQLi block wins even at block-at-0 thresholds.
+        let mut ctx = make_ctx_with_thresholds("/", "198.51.100.20", 0, 0);
+        ctx.query = "id=1' OR '1'='1".into();
+        let decision = engine.inspect(&mut ctx).await;
+        assert!(
+            matches!(decision.action, WafAction::Block { .. }),
+            "SQLi payload must block, got {:?}",
+            decision.action
+        );
+        let result = decision.result.as_ref().expect("SQLi block must carry a result");
+        assert_eq!(
+            result.phase,
+            waf_common::Phase::SqlInjection,
+            "enforced detection must keep its own phase, not Phase::RiskScore"
+        );
+
+        // LogOnly'd detection: with injection_control in monitor mode the
+        // SQLi decision (mode LogOnly) is still returned — no risk escalation.
+        let mr = ModeRegistry::new();
+        mr.set_feature("injection_control", InteropMode::LogOnly);
+        engine.set_mode_registry(mr);
+        let mut ctx = make_ctx_with_thresholds("/", "198.51.100.21", 0, 0);
+        ctx.query = "id=1' OR '1'='1".into();
+        let decision = engine.inspect(&mut ctx).await;
+        let result = decision.result.as_ref().expect("LogOnly'd SQLi must carry its result");
+        assert_eq!(
+            result.phase,
+            waf_common::Phase::SqlInjection,
+            "LogOnly'd detection must not be replaced by a risk escalation"
+        );
+        assert_eq!(decision.mode, InteropMode::LogOnly);
+        assert!(
+            decision.is_enforcement_allowed(),
+            "LogOnly'd SQLi decision must let the request proceed"
         );
     }
 }

--- a/crates/waf-engine/src/risk/canary.rs
+++ b/crates/waf-engine/src/risk/canary.rs
@@ -11,6 +11,7 @@
 use std::collections::HashSet;
 use std::net::IpAddr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use arc_swap::ArcSwap;
 use tracing::warn;
@@ -29,8 +30,9 @@ pub struct CanaryLayer {
     paths: ArcSwap<HashSet<String>>,
     /// Reference to `DDoS` ban table for IP blocking.
     ban_table: Option<Arc<DynamicBanTable>>,
-    /// Ban TTL in seconds for canary hits.
-    ban_ttl_secs: u32,
+    /// Ban TTL in seconds for canary hits. Atomic so config hot-reloads can
+    /// update it through a shared `Arc<CanaryLayer>`.
+    ban_ttl_secs: AtomicU32,
 }
 
 impl CanaryLayer {
@@ -40,7 +42,7 @@ impl CanaryLayer {
         Self {
             paths: ArcSwap::from(Arc::new(HashSet::new())),
             ban_table: None,
-            ban_ttl_secs: DEFAULT_CANARY_BAN_TTL_SECS,
+            ban_ttl_secs: AtomicU32::new(DEFAULT_CANARY_BAN_TTL_SECS),
         }
     }
 
@@ -51,7 +53,7 @@ impl CanaryLayer {
         Self {
             paths: ArcSwap::from(Arc::new(set)),
             ban_table: None,
-            ban_ttl_secs: DEFAULT_CANARY_BAN_TTL_SECS,
+            ban_ttl_secs: AtomicU32::new(DEFAULT_CANARY_BAN_TTL_SECS),
         }
     }
 
@@ -62,7 +64,7 @@ impl CanaryLayer {
         Self {
             paths: ArcSwap::from(Arc::new(set)),
             ban_table: Some(ban_table),
-            ban_ttl_secs,
+            ban_ttl_secs: AtomicU32::new(ban_ttl_secs),
         }
     }
 
@@ -71,9 +73,10 @@ impl CanaryLayer {
         self.ban_table = Some(ban_table);
     }
 
-    /// Set the ban TTL in seconds.
-    pub const fn set_ban_ttl_secs(&mut self, ttl: u32) {
-        self.ban_ttl_secs = ttl;
+    /// Set the ban TTL in seconds. Takes `&self` so config hot-reloads can
+    /// update a layer shared behind `Arc`.
+    pub fn set_ban_ttl_secs(&self, ttl: u32) {
+        self.ban_ttl_secs.store(ttl, Ordering::Relaxed);
     }
 
     /// Check if the given path is a canary path (exact match).
@@ -98,17 +101,19 @@ impl CanaryLayer {
             return false;
         }
 
+        let ban_ttl_secs = self.ban_ttl_secs();
+
         // Log the honeypot hit
         warn!(
             canary_path = path,
             client_ip = %ip,
-            ban_ttl_secs = self.ban_ttl_secs,
+            ban_ttl_secs,
             "canary honeypot triggered — scanner detected"
         );
 
         // Add to dynamic ban table
         if let Some(ref ban_table) = self.ban_table {
-            let expires_ms = now_ms.saturating_add(i64::from(self.ban_ttl_secs) * 1000);
+            let expires_ms = now_ms.saturating_add(i64::from(ban_ttl_secs) * 1000);
             ban_table.insert(ip, expires_ms);
         }
 
@@ -135,14 +140,14 @@ impl CanaryLayer {
 
     /// Get the ban TTL in seconds.
     #[must_use]
-    pub const fn ban_ttl_secs(&self) -> u32 {
-        self.ban_ttl_secs
+    pub fn ban_ttl_secs(&self) -> u32 {
+        self.ban_ttl_secs.load(Ordering::Relaxed)
     }
 
     /// Get the ban TTL in milliseconds.
     #[must_use]
     pub fn ban_ttl_ms(&self) -> i64 {
-        i64::from(self.ban_ttl_secs) * 1000
+        i64::from(self.ban_ttl_secs()) * 1000
     }
 }
 
@@ -247,7 +252,7 @@ mod tests {
 
     #[test]
     fn ban_ttl_configuration() {
-        let mut layer = CanaryLayer::new();
+        let layer = CanaryLayer::new();
         assert_eq!(layer.ban_ttl_secs(), DEFAULT_CANARY_BAN_TTL_SECS);
         assert_eq!(layer.ban_ttl_ms(), i64::from(DEFAULT_CANARY_BAN_TTL_SECS) * 1000);
 

--- a/docs/journals/2026-07-05-gh-195-risk-action-enforcement-implementation.md
+++ b/docs/journals/2026-07-05-gh-195-risk-action-enforcement-implementation.md
@@ -1,0 +1,63 @@
+# GH-195: Risk Action Enforcement Implementation
+
+**Date**: 2026-07-05 00:56
+**Severity**: Critical
+**Component**: waf-engine (risk scorer, canary layer, decision wrapper)
+**Status**: Resolved (PR pending; issue #195 commented with AC→test mapping)
+
+## What Happened
+
+Implemented P1 security fix #195: `WafEngine::inspect()` was discarding `ScorerResult.action` (Block/Challenge decisions computed by the risk layer but never enforced). Wired enforcement as an escalation-only gate: plain-Allow pipeline decisions escalate to Block/Challenge via `Phase::RiskScore` (single rule_name "cumulative_risk", feature "risk_assessment" in mode registry); enforced or LogOnly'd detections preserve their original decision (never overridden). Completed full FR-028 canary wiring: `CanaryLayer` now bound to DDoS `DynamicBanTable` pre-Arc-wrap, `ban_ttl_secs` converted to `AtomicU32` for hot-reload through shared Arc, `replace_risk_config` syncs both paths and TTL. Production behavior remains inert pending #196 (RiskConfig enforcement disabled by default). Added ~340 lines to engine.rs (5 inline tests), updated canary.rs, documented decisions in CLAUDE.md. Wrote 5 enforcement tests (risk_threshold_matrix_enforced, canary_hit_bans_and_pin_blocks for ACs #2/#3, risk_block_respects_monitor_mode, risk_never_overrides_pipeline_decisions, fast_path_exits_skip_risk_scoring). Full waf-engine lib suite 1400 tests green (default + --all-features); clippy --all-features -D warnings clean. Code reviewer ship-ready, 0 blocking; tester DONE.
+
+## The Brutal Truth
+
+This implementation hurt. Docker group permission denial (user not in docker group—known friction from GH-206) forced respecting auto-mode's DROP/CREATE DATABASE rejection on the shared postgres container. Built a throwaway `gh195-pg` container on port 15433 instead (15432 taken by dev stack), cleaned up after—minor friction but real. Worse: mid-test-run, cargo test hit SIGBUS + ENOSPC with linker dying at 100% disk. Took `cargo clean` to recover 314.7 GiB of accumulated target/ artifacts. Full rebuild then passed (3205 tests green; all 315 failures are environmental testcontainer docker-socket PermissionDenied, CI covers those). Most frustrating: test 2b required explicitly storing a `DdosConfig` with a `CatchAll` tier—the default `DdosConfig` has empty tiers, so ban-table lookups never ran until the test stored a config with a CatchAll tier explicitly. These aren't code bugs, but they hurt productivity.
+
+## Technical Details
+
+**Enforcement wiring:**
+- `inspect()` now checks `matches!(decision.action, WafAction::Allow)` and escalates to `Phase::RiskScore` when `ScorerResult.action` is Block or Challenge.
+- Single `rule_name = "cumulative_risk"` logged for all risk enforcement events (user decision from validation session, no `ScorerReason` enum).
+- LogOnly'd detections and enforced detections preserve their decision; risk escalation is strictly Allow → {Block, Challenge}.
+- Gateway renders Block/Challenge risk decisions to client (existing contract honored).
+
+**Canary wiring (full FR-028):**
+- `CanaryLayer` constructed with `DynamicBanTable` reference pre-Arc-wrap in `WafEngine::new` (fixes ordering bug from planning session).
+- `ban_ttl_secs` changed from u32 to `AtomicU32` to enable hot-reload via `Arc<Scorer>`.
+- `replace_risk_config` syncs both canary paths and ban TTL atomically.
+- Post-canary requests block at `Phase::Ddos` (ban-table lookup), not re-scored at risk layer.
+
+**Test suite (5 tests, 4 ACs covered):**
+- `risk_threshold_matrix_enforced`: block-at-0 thresholds → Block 403; challenge band {0, 101} → Challenge; disabled config → Allow (AC #1). Outcomes forced via custom `Arc<TierPolicy>` thresholds, not manufactured anomalies.
+- `canary_hit_bans_and_pin_blocks`: `/admin-test` hit → 403 with score 100 (AC #2); same-IP follow-up blocks at `Phase::Ddos` via ban table; different IP driven through `scorer.force_max` blocks via pin override (AC #3).
+- `risk_block_respects_monitor_mode`: `risk_assessment` in monitor mode → Block intent kept, `mode: LogOnly`, request proceeds.
+- `risk_never_overrides_pipeline_decisions`: SQLi detection (enforced or LogOnly'd) is returned as-is, never replaced by risk escalation.
+- `fast_path_exits_skip_risk_scoring` (pre-existing, unmodified): fast-path exits never invoke the scorer.
+- All tests use the PG testcontainer / `PG_TEST_URL` pattern; the canary test stores a `DdosConfig` with a CatchAll tier explicitly.
+
+**Gotchas:**
+1. DdosConfig default has empty tiers array—ban-table lookups silently miss. Tests require explicit tier construction.
+2. Docker group denial respected; throwaway container spun up and cleaned (no leftover state).
+3. Disk exhaustion at 100%—aggressive `cargo clean` needed. Lesson: monitor workspace disk in future test runs.
+
+## Lessons Learned
+
+1. **Arc-wrap ordering is a silent contract.** The canary layer must be constructed and installed *before* Arc-wrapping the Scorer, not after. Compiler doesn't catch this (set_canary exists but becomes unreachable). Testing forced discovery.
+
+2. **Default configs can silently block features.** DdosConfig's empty-tiers default meant the ban-table was always empty, causing test phantom failures. Tests that depend on downstream effects (ban-table blocks) must validate their setup explicitly.
+
+3. **Enforcement gates are simpler than monitoring-aware escalation.** Plain `Allow → {Block, Challenge}` is easier to reason about than "escalate only if enforcement is enabled for this feature." LogOnly'd features shield their actors as a side effect, documented in risk scoring docs—no special code needed.
+
+4. **Single rule_name avoids churn.** Using "cumulative_risk" for all risk events (no ScorerReason enum) keeps the decision contract stable. Canary hits remain distinguishable via existing canary log line, so audit trail is complete.
+
+## Next Steps
+
+- PR pending submission for #195; AC→test mapping already posted on the issue.
+- #196 (startup config wiring) is complementary, not blocking; production behavior remains inert until it lands.
+- Disk cleanup lesson: future test runs should monitor workspace usage or use explicit cleanup hooks.
+- No blocking concerns; code review and tester sign-off complete.
+
+---
+
+**Status**: DONE
+**Summary**: GH-195 P1 enforcement wired as escalation-only gate (plain Allow → Block/Challenge); full FR-028 canary wiring (DDoS ban table + hot-reload TTL); 5 tests green, reviewer ship-ready.

--- a/docs/journals/2026-07-05-gh-195-risk-action-enforcement-planning.md
+++ b/docs/journals/2026-07-05-gh-195-risk-action-enforcement-planning.md
@@ -1,0 +1,85 @@
+# GH-195 Risk Action Enforcement: 3-Phase Plan + Validation Complete
+
+**Date:** 2026-07-05 00:04 +07:00
+**Severity:** High
+**Component:** waf-engine (risk scorer, canary layer, decision wrapper)
+**Status:** Plan validated; ready for Phase 1 implementation
+
+## What Happened
+
+Created a 3-phase plan for GitHub issue #195 (P1, security): the risk layer computes Block/Challenge decisions via `ScorerResult.action` but `WafEngine::inspect()` discards them (`map_or(0, |r| r.score)` keeps only the score). Consequence: the FR-025 risk enforcement feature is wired but unreachable in production. Secondary discovery: the engine builds `Scorer` with `canary: None` then immediately Arc-wraps it, making the FR-028 canary force-max path unreachable. Generated the plan via `/ck:plan --github`; posted plan comment to issue #195. Conducted validation interview (4 questions); verified 14 plan claims against source (0 failed). Interview reversed two design recommendations and expanded the canary scope: escalation gate narrowed to plain-Allow-only (LogOnly'd detections stay untouched), dropped a proposed `ScorerReason` enum (all risk events use single `rule_name = "cumulative_risk"`), and wired full FR-028 canary (DDoS ban table + config-driven TTL, not just paths). Consolidated test shape (7 → 4 testcontainers). Posted corrective comment to issue #195 capturing decisions.
+
+Plan structure: Phase 1 (engine wiring), Phase 2 (enforcement tests), Phase 3 (verification and docs). Phase 2 depends on Phase 1; Phase 3 runs last.
+
+## The Brutal Truth
+
+This planning session was clean. Grep verification succeeded (14 claims checked, 0 failed). The validation interview landed decisive choices that deviate from the recommended design but make engineering sense — escalate-only gate (plain Allow) is simpler than monitoring-aware escalation, single rule name avoids churn in `ScorerResult`, and full canary wiring (with DDoS ban table + config TTL) is the feature-complete version, not the minimal one. The test consolidation (7 → 4) trades scenario granularity for clarity.
+
+The one friction point: couldn't apply the `ready to review` label to #195 because the GitHub token is read-only on the repo. The decision comment went into the issue anyway, so the artifact is complete; the label is cosmetic.
+
+## Technical Details
+
+**The bugs:**
+- `inspect()` line 685 (engine.rs): `map_or(0, |r| r.score)` reads the score but discards `ScorerResult.action` (Block/Challenge/Allow).
+- Canary construction (line 253, engine.rs): `Scorer::new()` called with `canary: None` *before* the layer exists; then `Arc::new(scorer)` wraps it immutably. `Scorer::set_canary` is defined (scorer.rs:109) but unreachable after Arc-wrap.
+
+**Verification successes:** Ordering placement already fixed by GH-206 Phase 3 (commit c37a8fe) — scoring runs after `inspect_pipeline()` on `FastPath::Miss` only, not before. `Phase::RiskScore` and mode registry entry exist and are wired (interop/checker_feature_map.rs:28). Gateway renders Block/Challenge. Community reporter already assigns confidence 0.65 to RiskScore events. `RequestCtx.tier_policy` is public Arc (types.rs:116) for test forcing. `DdosCheck::ban_table()` accessor exists (checks/ddos/check.rs:76). `CanaryLayer::with_ban_table` constructor exists (canary.rs:60).
+
+**Scope fold to consider:** Issue #195 AC #4 is already met by GH-206 (scoring placement is post-pipeline, not pre); this plan defines the deliberate placement as "escalation-only gate at wrapper, applies only when pipeline action is plain Allow."
+
+## What We Tried
+
+**Decision point Q1: Escalation gate behavior vs LogOnly'd detections**
+- Recommended: `is_enforcement_allowed()` check (monitoring-aware escalation).
+- User chose: plain `matches!(decision.action, WafAction::Allow)` (escalate Allow only; detections downgraded to LogOnly keep their decision).
+- Rationale: simpler; monitored features shield their actors from risk escalation (accepted trade-off, called out in risk docs).
+
+**Decision point Q2: `ScorerReason` enum on `ScorerResult`**
+- Recommended: add enum to distinguish canary hits from threshold hits in decision output.
+- User chose: no enum; all risk events log `rule_name = "cumulative_risk"` (single static name; canary hits remain distinguishable only via existing canary log line).
+- Rationale: avoids churn in `ScorerResult` type; reduces `Phase 1` code.
+
+**Decision point Q3: Canary wiring scope**
+- Recommended: wire paths only (minimal scope).
+- User chose: full FR-028 wiring (DDoS ban table + config-driven `ban_ttl_secs`).
+- Rationale: feature-complete; ban table reuse means post-canary requests block at the DDoS phase, which is the intended behavior. Test consequence: pinned-actor test now drives `force_max` on a separate IP (pinned actor itself will be in the ban table after first canary hit).
+
+**Decision point Q4: Test shape**
+- Consolidate 7 single-scenario tests into ~4 testcontainer groups (related cases per container).
+
+## Root Cause Analysis
+
+**Why enforcement was unreachable:**
+- `inspect()` was written to extract `.score` only, leaving the decision field unused. No explicit rejection of enforcement; just incomplete integration.
+- Scorer was constructed with `canary: None` (the layer didn't exist yet in the constructor call graph) and immediately Arc-wrapped, preventing `set_canary` from being called later. This was an ordering bug in `WafEngine::new`, not a design flaw.
+
+**Why this wasn't caught earlier:**
+- No integration tests exercise `inspect()` with `ScorerResult.action != Allow` (weak proof on the feature).
+- The FR-028 canary layer was built on the assumption that it would be installed post-construction; the Arc-wrap assumption broke that contract silently.
+
+## Lessons Learned
+
+1. **Validation interviews should force explicit choice between alternatives.** The three reversed/expanded decisions are all sound; the recommended versions would have worked but cost code or completeness. Framing as trade-offs (simpler code vs feature-complete) drives better choices.
+
+2. **Completeness matters when features are interdependent.** Full canary wiring (DDoS table + config TTL) is better than paths-only because the ban-table block is the natural enforcement point; partial wiring would leave the feature fragmented.
+
+3. **LogOnly'd detections as a shield is an accepted trade-off, not a bug.** Operators who leave features in monitor mode with risk enforcement active will see risk escalation suppressed for those requests. Document this clearly so it's not surprising.
+
+4. **Claim verification at plan time catches constructor bugs.** Checking `Arc::new(scorer)` line 253 and `set_canary` definition location (unreachable after Arc-wrap) surfaced the ordering issue that would otherwise have required runtime testing to find.
+
+## Next Steps
+
+- [x] Plan generated via `/ck:plan --github` (complete).
+- [x] 14 claims verified against source (complete, 0 failed).
+- [x] Validation interview (4 decisions captured; complete).
+- [x] Corrective comment posted to issue #195 (complete; cannot apply label due to token perms).
+- [ ] Phase 1 implementation: add `risk_canary` field, construct with DDoS ban table, install on scorer pre-Arc-wrap, wire decisions in `inspect()`, extend canary TTL reload.
+- [ ] Phase 2: 4 testcontainers covering Allow-to-Block, Allow-to-Challenge, pinned-actor force-max on separate IP, monitor-mode LogOnly downgrade.
+- [ ] Phase 3: rollout docs (enable risk scoring via #196 first, then enable enforcement thresholds via config).
+- [ ] Note for next session: GitHub token is read-only; `ready to review` label cannot be applied via bot.
+
+---
+
+**Status:** DONE
+**Summary:** 3-phase plan created and validated; 14 claims verified, 0 failed. Validation interview reversed two design choices (escalation gate, enum scope) and expanded canary wiring to full FR-028. Ready to implement Phase 1.
+**Concerns/Blockers:** None blocking. Label automation unavailable (read-only token).

--- a/plans/260704-2344-gh-195-risk-action-enforcement/phase-01-engine-enforcement-wiring.md
+++ b/plans/260704-2344-gh-195-risk-action-enforcement/phase-01-engine-enforcement-wiring.md
@@ -1,0 +1,83 @@
+---
+phase: 1
+title: "Engine enforcement wiring"
+status: completed
+priority: P1
+dependencies: []
+---
+
+# Phase 1: Engine enforcement wiring
+
+<!-- Updated: Validation Session 1 - escalate plain Allow only; dropped ScorerReason enum; full FR-028 canary wiring (ban table + config TTL) -->
+
+## Overview
+
+Make `WafEngine::inspect()` consume the full `ScorerResult` and escalate a plain-Allow pipeline decision to Block/Challenge when the scorer says so, respecting the mode registry. Wire the FR-028 canary layer fully into the engine scorer: config-driven paths, DDoS ban table, and config-driven ban TTL.
+
+## Requirements
+
+- Functional: scorer Block/Challenge becomes the returned `WafDecision` only when the pipeline decision's action is plain `WafAction::Allow`; any decision carrying a detection (enforced or LogOnly'd) is returned untouched; scorer Allow changes nothing; monitor mode on `risk_assessment` downgrades risk enforcement to LogOnly; canary hits IP-ban via the DDoS `DynamicBanTable` with `CanaryConfig.ban_ttl_secs`.
+- Non-functional: zero extra work on the fast paths (GH-206 invariant preserved); no new allocations on the Allow path.
+
+## Architecture
+
+Data flow in the wrapper (`engine.rs:673-690`), after `inspect_pipeline` returns `(decision, fast_path)`:
+
+```text
+if fast_path == Miss:
+    scorer_result = scorer.score(ctx, None, &[], None, now_ms)   # unchanged call
+    decision.risk_score = scorer_result.score.min(100)
+    if matches!(decision.action, WafAction::Allow)                # plain Allow only (Validation S1)
+       and scorer_result.action is Block|Challenge:
+        risk_decision = make_risk_decision(ctx, &scorer_result)
+            - DetectionResult { phase: Phase::RiskScore,
+                                rule_name: "cumulative_risk",     # single name (Validation S1)
+                                detail: "risk score {score}",
+                                rule_id: None, rule_action: None, action_status: None }
+            - Block{status, ..}  -> WafDecision::block(status, render_block_page(ctx, "cumulative_risk"), result)
+            - Challenge          -> WafDecision { action: Challenge, result: Some(result), .. }
+        apply_mode(ctx, &mut risk_decision, "risk_assessment", Some("cumulative_risk"))
+        log_security_event(ctx, &risk_decision)
+        report_community_signal(ctx, &risk_decision)              # reporter.rs:92 already maps RiskScore -> 0.65
+        risk_decision.risk_score = scorer_result.score.min(100)
+        decision = risk_decision
+send_audit_event(ctx, &decision, inspect_time)                    # unchanged — audits risk blocks for free
+```
+
+Key decisions (post-validation):
+
+1. **Escalate plain Allow only** (Validation S1, Q1): gate on `matches!(decision.action, WafAction::Allow)`. A detection downgraded to LogOnly keeps its decision in the return value even if the scorer says Block — the monitored feature's outcome is preserved. `ScorerResult` remains untouched (no reason enum); all risk events use `rule_name = "cumulative_risk"` (Q2).
+2. **Block body**: use `render_block_page(ctx, "cumulative_risk")` for consistency with every other block path; `threshold::decide`'s plain `"Access denied."` body is not the rendered surface and stays as-is.
+3. **Full FR-028 canary wiring** (Q3): in `WafEngine::new` (engine.rs:253), construct the layer with the DDoS ban table already available in `new()`:
+   `let canary = Arc::new(CanaryLayer::with_ban_table(Vec::new(), Arc::clone(ddos_check.ban_table()), DEFAULT_CANARY_BAN_TTL_SECS));`
+   (constructor at `risk/canary.rs:60`; accessor at `checks/ddos/check.rs:76` — if `ddos_check` is constructed after the scorer in `new()`, reorder locally). Call `scorer.set_canary(Arc::clone(&canary))` **before** `Arc::new(scorer)` (`set_canary` takes `&mut self`, scorer.rs:109). Store `risk_canary: Arc<CanaryLayer>` as a new engine field.
+4. **Config consumption in `replace_risk_config`** (engine.rs:296): apply `cfg.canary.paths` and `cfg.canary.ban_ttl_secs` to the layer. `CanaryLayer::reload` (canary.rs:119) currently swaps paths only; extend it to also accept the TTL (or convert `ban_ttl_secs` to `AtomicU32` with a setter — implementer's choice; update the few `reload` callers the compiler flags). `ban_ttl_ms()` (canary.rs:144) feeds the force-max pin duration, so the config TTL now governs both the IP ban and the score pin.
+
+## Related Code Files
+
+- Modify: `crates/waf-engine/src/engine.rs` — wrapper (`inspect`) + `make_risk_decision` helper, `new` (canary construction with ban table + field), `replace_risk_config` (paths + TTL reload), struct field docs at lines 151-157 (score is no longer observability-only).
+- Modify: `crates/waf-engine/src/risk/canary.rs` — TTL reload support (signature extension or atomic field).
+- Read-only reference: `crates/waf-engine/src/risk/scorer.rs`, `crates/waf-engine/src/risk/threshold.rs`, `crates/waf-engine/src/checks/ddos/check.rs`, `crates/waf-engine/src/interop/checker_feature_map.rs`.
+
+## Implementation Steps
+
+1. Add `risk_canary: Arc<CanaryLayer>` engine field; construct via `with_ban_table` using `ddos_check.ban_table()` in `new()`; install on scorer pre-Arc-wrap.
+2. Extend `CanaryLayer` TTL hot-reload (canary.rs); consume `cfg.canary.{paths, ban_ttl_secs}` in `replace_risk_config`.
+3. Rewrite the scoring block in `inspect()` per the architecture flow above; keep `inspect()` readable with a `fn make_risk_decision(&self, ctx: &RequestCtx, result: &ScorerResult) -> WafDecision` helper.
+4. Update the stale `risk_cfg`/`scorer` field doc comments (engine.rs:151-157) — score now drives enforcement, not just headers.
+
+## Success Criteria
+
+- [x] `cargo build -p waf-engine` clean; no remaining `map_or(0, |r| r.score)` in `inspect()`.
+- [x] Scorer `Block` → returned decision is `WafAction::Block` with `Phase::RiskScore` result and `rule_name == "cumulative_risk"`; `Challenge` → `WafAction::Challenge`; `Allow` → pipeline decision untouched.
+- [x] Non-Allow pipeline decisions (enforced or LogOnly'd) are returned unmodified apart from `risk_score`.
+- [x] Canary hit inserts the IP into the DDoS `DynamicBanTable` with the configured TTL and pins the score.
+- [x] Monitor mode on `risk_assessment` yields `mode: LogOnly` decision (request proceeds, event logged).
+- [x] Fast-path requests still never touch the scorer (existing test `fast_path_exits_skip_risk_scoring` green).
+- [x] Default (disabled) config: zero behavior change — full existing suite green.
+
+## Risk Assessment
+
+- **False-positive blocking once #196 lands**: thresholds come from `ctx.tier_policy.risk_thresholds` (tier defaults at `waf-common/src/tier.rs:88`); monitor mode via mode registry is the operator rollout valve. Document rollout order in Phase 3.
+- **LogOnly'd detections shield actors from risk enforcement** (accepted trade-off, Validation S1 Q1): while a feature is in monitor mode, its detections suppress risk escalation for that request. Operators should not leave broad features in monitor mode with risk enforcement active. Call out in Phase 3 docs.
+- **Ban-table coupling**: canary hits now surface as DDoS-phase blocks on subsequent requests (Phase 19 runs before scoring). Intended FR-028 behavior; Phase 2 tests assert it explicitly so it is a contract, not an accident.

--- a/plans/260704-2344-gh-195-risk-action-enforcement/phase-02-enforcement-tests.md
+++ b/plans/260704-2344-gh-195-risk-action-enforcement/phase-02-enforcement-tests.md
@@ -1,0 +1,68 @@
+---
+phase: 2
+title: "Enforcement tests"
+status: completed
+priority: P1
+dependencies: [1]
+---
+
+# Phase 2: Enforcement tests
+
+<!-- Updated: Validation Session 1 - consolidated to 4 tests; rule_name is always "cumulative_risk"; canary now IP-bans via DDoS table; pinned test drives force_max directly -->
+
+## Overview
+
+Prove enforcement end-to-end at the engine boundary: threshold block/challenge/disabled, canary 403 + IP ban, pinned-actor block, monitor-mode LogOnly, and no-override invariants. Covers issue ACs #2 and #3 plus the "weak proof" intake flag. Consolidated to ~4 testcontainer spin-ups (Validation S1).
+
+## Requirements
+
+- Functional: every scorer action variant observable through `engine.inspect()` return value.
+- Non-functional: tests follow the existing inline-`#[cfg(test)]` pattern in `engine.rs` (PG testcontainer / `PG_TEST_URL`, `make_ctx`, `replace_risk_config`) — see `fast_path_exits_skip_risk_scoring` at `engine.rs:1204` as the template. Inline placement is required anyway: tests touch the private `scorer` field.
+
+## Architecture
+
+Score-forcing technique: `inspect()` calls `scorer.score(ctx, None, &[], None, now_ms)` with no deltas, so a clean request scores ~0. Rather than manufacturing L2 anomalies, drive `decide()` via `ctx.tier_policy.risk_thresholds` (swap in a custom `Arc<TierPolicy>`; `RequestCtx.tier_policy` is pub, types.rs:116):
+
+- Block case: thresholds `{allow: 0, challenge: 0, block: 0}` → score 0 ≥ block → Block.
+- Challenge case: `{allow: 0, challenge: 0, block: 101}` → score 0 in [allow, block) → Challenge.
+- Allow case: defaults (`tier.rs:88`) with score 0 → Allow.
+
+Canary and pinned cases don't need threshold games: the canary path force-maxes regardless; the pinned case drives `scorer.force_max` (pub, scorer.rs:348) directly — it must NOT reuse the canary-hit IP, because with the ban table wired (Phase 1) that IP gets blocked at the DDoS phase before scoring runs.
+
+All risk enforcement events assert `rule_name == "cumulative_risk"` (single name, Validation S1).
+
+## Related Code Files
+
+- Modify: `crates/waf-engine/src/engine.rs` (inline `#[cfg(test)]` module — new tests alongside `fast_path_exits_skip_risk_scoring`).
+- Modify (only if compile fallout from Phase 1): `crates/waf-engine/tests/risk_scorer_decision_matrix.rs`, `crates/waf-engine/tests/risk_scorer_extended.rs`.
+
+## Implementation Steps
+
+Four consolidated tests, one testcontainer each (Validation S1):
+
+1. `risk_threshold_matrix_enforced` — one engine, three requests:
+   a. block-at-0 thresholds → `WafAction::Block { status: 403, .. }`, `result.phase == Phase::RiskScore`, `rule_name == "cumulative_risk"`, `risk_score` attached (use distinct IPs per request to avoid state bleed);
+   b. challenge-band thresholds → `WafAction::Challenge` with `Phase::RiskScore` result (gateway FR-006 rendering is existing covered behavior; the engine boundary is the contract here);
+   c. swap in default (disabled) `RiskConfig` + block-at-0 thresholds → Allow (scorer short-circuits before `decide`).
+2. `canary_hit_bans_and_pin_blocks` — canary config (`canary.enabled = true`, `paths = ["/admin-test"]`, explicit `ban_ttl_secs`) via `replace_risk_config`:
+   a. request to `/admin-test` → Block 403, `Phase::RiskScore`, `rule_name == "cumulative_risk"`, score 100 (**issue AC #2**);
+   b. follow-up request from the same IP to a normal path → blocked at the DDoS ban phase (result phase is the DDoS phase, not RiskScore) — asserts the FR-028 ban-table contract from Phase 1;
+   c. from a **different** IP: call `scorer.force_max(ip, ttl_ms)` directly, then request a normal path with default thresholds → Block via pin override (`decide(_, _, true)`), `Phase::RiskScore` (**issue AC #3**).
+3. `risk_block_respects_monitor_mode` — block-at-0 thresholds + mode registry putting `risk_assessment` in monitor (`set_mode_registry`, engine.rs:555) → decision carries Block intent downgraded to `mode: LogOnly`, `is_enforcement_allowed()` true (request proceeds, event logged).
+4. `risk_never_overrides_pipeline_decisions` — block-at-0 thresholds, two requests:
+   a. enforced case: SQLi payload (blacklist is a fast path; SQLi is not) → returned decision keeps the SQLi phase/rule, not `Phase::RiskScore`; `risk_score` still attached;
+   b. LogOnly'd case: same SQLi payload with the SQLi feature in monitor mode → returned decision still carries the SQLi detection (mode LogOnly), NOT a risk escalation — asserts the plain-Allow-only gate (Validation S1 Q1).
+5. Re-run `fast_path_exits_skip_risk_scoring` unmodified — fast-path invariant holds with enforcement wired.
+
+## Success Criteria
+
+- [x] All 4 new tests green under `cargo test -p waf-engine` (with Docker or `PG_TEST_URL`).
+- [x] Issue AC #2 (canary → real 403) and AC #3 (pinned actor blocks) each map to a named assertion (test 2a / 2c).
+- [x] LogOnly'd-detection non-escalation (Validation S1 Q1) covered by test 4b.
+- [x] No existing test weakened or deleted.
+
+## Risk Assessment
+
+- **Cross-request state bleed**: consolidated tests share the risk store; use distinct client IPs per sub-case unless the test is deliberately exercising accumulated state (test 2 is).
+- **Tier-policy mutability in `make_ctx`**: if `make_ctx` hardcodes tier policy, extend it with a thresholds override parameter locally in the test module — do not change production types.
+- **DDoS-phase assertion (2b)**: exact phase/rule name for a dynamic ban block should be read from `checks/ddos/check.rs` at implementation time; assert on action Block + non-RiskScore phase if the ban surface is not a stable contract.

--- a/plans/260704-2344-gh-195-risk-action-enforcement/phase-03-verification-and-docs.md
+++ b/plans/260704-2344-gh-195-risk-action-enforcement/phase-03-verification-and-docs.md
@@ -1,0 +1,43 @@
+---
+phase: 3
+title: "Verification and docs"
+status: completed
+priority: P2
+dependencies: [1, 2]
+---
+
+# Phase 3: Verification and docs
+
+<!-- Updated: Validation Session 1 - canary ban-table + TTL binding moved into Phase 1 scope (no longer a follow-up); added monitor-mode rollout caveat; issue comment must note validation design changes -->
+
+## Overview
+
+Cross-cutting gate: full workspace checks, doc sync for the behavior change (risk score is now an enforcement input, not observability-only), and issue close-out notes.
+
+## Requirements
+
+- Functional: none (no code beyond fixes surfaced by the gate).
+- Non-functional: CI-equivalent checks clean; docs match shipped behavior.
+
+## Related Code Files
+
+- Modify: `crates/waf-engine/CLAUDE.md` — `risk/` section: note enforcement wiring (threshold/canary/pinned → Block/Challenge via `Phase::RiskScore`, mode-gated by `risk_assessment`).
+- Modify: `docs/system-architecture.md` — only if it describes the risk layer as observability-only (verify before editing).
+- Verify (no edit expected): `docs/stories/` FR-025 story proof status — `scripts/bin/harness-cli` absent, so record in plan status instead.
+
+## Implementation Steps
+
+1. `cargo fmt --all --check`, `cargo clippy -p waf-engine --all-targets -- -D warnings`, `cargo test -p waf-engine`; broaden to `cargo test --workspace` (gateway consumes `WafDecision` — contract unchanged in shape, but verify).
+2. Update `crates/waf-engine/CLAUDE.md` risk bullet (risk layer now enforces Block/Challenge via `Phase::RiskScore`, `rule_name = "cumulative_risk"`, canary wired to the DDoS ban table); fix any remaining "observability-only" phrasing (engine.rs doc comments handled in Phase 1 — grep `observability` / `until operators wire` to catch stragglers). Document the operator rollout caveat: features left in monitor mode suppress risk escalation for requests they detect (Validation S1 Q1 trade-off), and `risk_assessment` monitor mode is the rollout valve.
+3. Comment on issue #195: what landed, test names per AC, note the validation-session design deltas from the original plan comment (single `cumulative_risk` rule name instead of the `ScorerReason` enum; plain-Allow-only escalation; full FR-028 canary wiring including ban table + config TTL, no longer deferred), and the explicit non-goals → production config wiring stays #196; the HTTP/3 Challenge pass-through gap (`gateway/src/http3.rs:304`) gets a follow-up note (new issue only if maintainer agrees).
+4. Update this plan's status via `ck plan check`.
+
+## Success Criteria
+
+- [x] fmt/clippy/tests green workspace-wide.
+- [x] No doc claims risk score is observability-only.
+- [x] Issue #195 updated with AC→test mapping and follow-up notes.
+
+## Risk Assessment
+
+- Workspace test run may surface gateway assumptions that `inspect()` never returns Challenge (grep `WafAction::Challenge` handling paths — already confirmed handled in `proxy_waf_response.rs:187`, `http3.rs:304` pass-through is pre-existing). Low risk; rollback is reverting the wrapper block (single-commit scope).

--- a/plans/260704-2344-gh-195-risk-action-enforcement/plan.md
+++ b/plans/260704-2344-gh-195-risk-action-enforcement/plan.md
@@ -1,0 +1,87 @@
+---
+title: "GH-195 risk enforcement: wire ScorerResult.action into inspect() decision"
+description: "Consume ScorerResult.action (Block/Challenge) in WafEngine::inspect() so the FR-025 risk layer can actually enforce; wire the canary layer into the engine scorer"
+status: completed
+priority: P1
+branch: "fix/gh-195-risk-action-enforcement"
+tags: [security, risk, engine, bug]
+blockedBy: []
+blocks: []
+created: "2026-07-04T16:49:55.653Z"
+createdBy: "ck:plan"
+source: skill
+---
+
+# GH-195 risk enforcement: wire ScorerResult.action into inspect() decision
+
+## Overview
+
+GitHub issue: https://github.com/future-and-go/mini-waf/issues/195 (P1, risk:security, CONFIRMED by multi-agent review 2026-07-03).
+
+`WafEngine::inspect()` (`crates/waf-engine/src/engine.rs:681-686`) calls `self.scorer.score(...)` and keeps only `.score` via `map_or(0, |r| r.score)`. `ScorerResult.action` — computed by `threshold::decide` (threshold gate + pinned-actor override, `risk/scorer.rs:258-260`) and by the canary force-max path (`risk/scorer.rs:198-205`) — is discarded. Result: an actor at score 100 gets proxied with only an `X-WAF-Risk-Score: 100` header; the risk layer can never block or challenge.
+
+All downstream plumbing already exists and is verified unused-but-ready:
+
+- `Phase::RiskScore` (= 20) in `waf-common`.
+- Mode registry maps `Phase::RiskScore → ("risk_assessment", Some("cumulative_risk"))` (`interop/checker_feature_map.rs:28`).
+- Gateway renders `WafAction::Challenge` via FR-006 (`gateway/src/proxy_waf_response.rs:187-207`) and `WafAction::Block` via the block path.
+- Community reporter already assigns confidence 0.65 to `Phase::RiskScore` events (`community/reporter.rs:92`).
+- `send_audit_event` runs on every decision in the `inspect()` wrapper — risk blocks get audited for free.
+
+What's genuinely missing: (a) the wrapper never maps the action into the returned `WafDecision`; (b) the engine's `Scorer` is built with `canary: None` and immediately `Arc`-wrapped (`engine.rs:253`), so the canary path is unreachable in production — but the issue's AC #2 requires a canary-driven 403.
+
+## Ordering decision (issue AC #4)
+
+The issue flagged "scoring runs before host-guard/whitelist/blacklist fast paths" — that was fixed by GH-206 Phase 3 (commit c37a8fe): scoring now runs after `inspect_pipeline()` and only when `FastPath::Miss`. The remaining deliberate placement decision, made here:
+
+**Risk enforcement is an escalation-only gate at the wrapper.** It applies only when `fast_path == FastPath::Miss` **and** the pipeline decision's action is plain `WafAction::Allow`. It never overrides any decision carrying a detection — enforced blocks (SQLi, DDoS, rate limit, ...) *and* mode-downgraded LogOnly detections both keep their original decision (Validation Session 1: LogOnly'd detections are not escalated; the monitored feature's decision stays intact in the return value). A scorer `Allow` never downgrades anything. Fast-path exits (guard off, IP/URL allow/block lists) keep skipping scoring entirely per GH-206.
+
+## Behavior gate
+
+`RiskConfig::default()` has `enabled = false` → scorer returns score 0 / `Allow`. Production behavior is unchanged by this fix until operators wire a real config — that startup wiring is **#196** (separate issue, same root-cause family). Tests enable scoring per-test via `engine.replace_risk_config(...)` (existing pattern at `engine.rs:1225`).
+
+## Intake
+
+- Input type: change request (bug fix on accepted FR-025 behavior). Lane: **normal with stronger validation** (flags: existing behavior, client-visible contract — requests can now be 403'd/challenged when risk is enabled, weak proof — zero tests exercise enforcement).
+- `scripts/bin/harness-cli` absent in working tree → story registration is a clean skip (GH-206 precedent); issue #195 is the tracked work item.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Engine enforcement wiring](./phase-01-engine-enforcement-wiring.md) | Completed |
+| 2 | [Enforcement tests](./phase-02-enforcement-tests.md) | Completed |
+| 3 | [Verification and docs](./phase-03-verification-and-docs.md) | Completed |
+
+Phase 2 depends on Phase 1; Phase 3 runs last.
+
+## Dependencies
+
+- **#196** (risk admin API façade / startup config wiring): complementary, not blocking. This plan makes enforcement real once a config is loaded; #196 makes configs load in production. Neither blocks the other; both must land for end-to-end production enforcement.
+- **Plan 260704-2309-gh-198-redis-riskstate-roundtrip** (branch `fix/gh-198-redis-riskstate-roundtrip`): touches `risk/store/redis*.rs` only — no file overlap with this plan (engine.rs, scorer.rs, canary.rs). No blocking relationship.
+- **Plan 260703-2158-gh-206** (completed): this plan builds on its `FastPath` wrapper structure; no conflict.
+- HTTP/3 listener (`gateway/src/http3.rs:304`) treats `Challenge` as pass-through — pre-existing gap for *all* challenge decisions (FR-006), not introduced here. Out of scope; noted for a follow-up issue.
+
+## Validation Log
+
+### Session 1 — 2026-07-05 (validate interview, 4 questions)
+
+Verification pass (Standard tier): claims checked 14, Verified 14, Failed 0, Unverified 0. Key confirmations: `RequestCtx.tier_policy` is a pub `Arc<TierPolicy>` (types.rs:116) so the threshold-forcing test technique works; `Scorer::force_max` is pub (scorer.rs:348); disabled config early-returns Allow; `set_mode_registry` exists (engine.rs:555); `DdosCheck::ban_table()` accessor exists (checks/ddos/check.rs:76).
+
+| # | Decision point | Answer | Effect |
+|---|---------------|--------|--------|
+| 1 | Escalation gate vs LogOnly'd detections | **Escalate plain Allow only** (rejects plan recommendation) | Gate condition is `matches!(decision.action, WafAction::Allow)`, not `is_enforcement_allowed()`. Monitored-feature detections keep their decision. |
+| 2 | `ScorerReason` enum on `ScorerResult` | **No — single rule_name** (rejects plan recommendation) | All risk enforcement events log `rule_name = "cumulative_risk"`; no `ScorerResult` changes, no literal churn. Canary hits remain distinguishable only via the existing canary info log line. |
+| 3 | Canary wiring scope | **Full FR-028 wiring** (expands scope) | Bind DDoS `DynamicBanTable` + config-driven `ban_ttl_secs` to the engine's `CanaryLayer`, not just paths. Consequence: post-canary requests block at the DDoS ban phase, so the pinned-actor test drives `force_max` directly. |
+| 4 | Test shape | **Consolidate related cases** | ~4 testcontainers instead of 7 single-scenario tests. |
+
+## Acceptance Criteria (from issue #195)
+
+- [x] `inspect()` consumes `ScorerResult.action` and maps Block/Challenge into the pipeline decision (escalation-only, per ordering decision above) — `risk_threshold_matrix_enforced`.
+- [x] Canary force-max produces an actual 403 in an integration test — `canary_hit_bans_and_pin_blocks` sub-case a (plus ban-table contract in sub-case b).
+- [x] Pinned-actor override blocks in a test — `canary_hit_bans_and_pin_blocks` sub-case c.
+- [x] Ordering placement decided deliberately and documented (done: escalation-only gate at wrapper, post-GH-206; `fast_path_exits_skip_risk_scoring` holds).
+
+## Completion Log
+
+- 2026-07-05: All phases done. waf-engine lib 1400 tests green (incl. 5 enforcement tests, verified under default and `--all-features`); fmt + clippy (`--all-targets --all-features -D warnings`) clean. Workspace `--no-fail-fast`: 3205 passed; all 315 failures are environmental testcontainer docker-socket `PermissionDenied` (local user not in docker group — CI runners cover these). Code review: ship-ready, no blocking findings (`plans/reports/code-reviewer-260705-0044-gh-195-risk-action-enforcement-report.md`). FR-025 story proof recorded here in lieu of `harness-cli` (absent in working tree, GH-206 precedent).

--- a/plans/reports/code-reviewer-260705-0044-gh-195-risk-action-enforcement-report.md
+++ b/plans/reports/code-reviewer-260705-0044-gh-195-risk-action-enforcement-report.md
@@ -1,0 +1,102 @@
+# Code Review — GH-195 Risk Action Enforcement
+
+Branch: `fix/gh-195-risk-action-enforcement` (working-tree, uncommitted)
+Scope: `crates/waf-engine/src/engine.rs`, `crates/waf-engine/src/risk/canary.rs`, `crates/waf-engine/CLAUDE.md`
+Verified: `cargo check -p waf-engine --tests` compiles clean.
+
+## Overall Assessment
+
+Ship-ready. The fix wires `ScorerResult.action` into the returned `WafDecision`
+as an escalation-only gate and completes FR-028 canary → DDoS-ban wiring. All
+five acceptance criteria trace to code + a passing test. No blocking issues. No
+public-contract breakage. Side-effect ordering (log/community/audit) matches the
+existing detection pipeline. The specific race, double-count, clamp, and
+error-path concerns raised in the task were checked and are non-issues.
+
+## Acceptance Criteria — verified
+
+- **AC#1** (scorer Block/Challenge surface in decision): engine.rs:714-723 gate +
+  `make_risk_decision` (735-757) build `Phase::RiskScore` / `rule_name =
+  "cumulative_risk"`, Block carries a rendered block-page body via
+  `WafDecision::block` (equivalent to `make_block_decision`), `risk_score`
+  reattached at 721. Test `risk_threshold_matrix_enforced`.
+- **AC#2** (canary hit → 403 score 100 + DDoS ban): scorer.rs:182-206 force_max +
+  ban-table insert; engine.rs canary layer bound to `ddos_check.ban_table()` at
+  264-270. Test `canary_hit_bans_and_pin_blocks` sub-cases a/b, incl. follow-up
+  block at `Phase::Ddos`.
+- **AC#3** (pinned actor blocks via override): `state.is_pinned` → `decide(...,
+  override_block=true)` (scorer.rs:258-260, threshold.rs:18-23). Sub-case c.
+- **Monitor mode**: `apply_mode(... "risk_assessment" ...)` downgrades to LogOnly;
+  `is_enforcement_allowed()` true (types.rs). Test `risk_block_respects_monitor_mode`.
+- **Risk never overrides pipeline**: `matches!(decision.action, WafAction::Allow)`
+  gate. Enforced and LogOnly'd SQLi both keep `Phase::SqlInjection`. Test
+  `risk_never_overrides_pipeline_decisions`.
+
+## Targeted concerns from the task — all cleared
+
+- **Double-counting `risk_score`**: none. In the escalation branch the pre-set
+  `decision.risk_score` (708) is discarded when `decision = risk_decision` (722);
+  final score set exactly once at 721. Non-escalation branch keeps the 708 value.
+- **`.min(100)` clamp**: redundant (`ScorerResult.score` is `u8` already clamped
+  0..=100) but harmless; matches prior code. Not worth changing.
+- **Scorer error path**: `let Ok(scorer_result) = ...` skips the whole block on
+  `Err`; `decision.risk_score` stays at the pipeline default (0 for plain Allow).
+  Behaviorally equivalent to the old `map_or(0, ...)`. No panic, no escalation on
+  error (fail-open for risk only — safe, pipeline decision preserved).
+- **`replace_risk_config` ordering / race**: canary `reload(paths)` +
+  `set_ban_ttl_secs` run *before* `risk_cfg.store` (engine.rs:319-321). Analyzed
+  against concurrent `inspect()`: the only transient window is old
+  `cfg.canary.enabled` with new paths/ttl. Enabling (false→true): gate still off
+  → new paths simply not yet active (safe delay). Disabling (true→false, paths
+  cleared): `check_and_ban` on the empty set returns false (safe). Path-only
+  change: transiently uses new paths, which is the desired end state. Effectively
+  race-free; ordering is correct. Not a defect.
+
+## Side-effect ordering — verified against pipeline
+
+`send_audit_event` is called once at the end (engine.rs:725) with the FINAL
+decision, so escalated risk blocks are audited correctly. In the escalation
+branch `log_security_event` + `report_community_signal` fire after `apply_mode`
+(718-720), which is exactly the detection-pipeline pattern (e.g. 879-880,
+892-893) — including firing in monitor/LogOnly mode. Pipeline blocks
+(`FastPath::Miss`, non-Allow action) skip the escalation gate, so there is no
+double `log_security_event` and no double audit. Confirmed parity.
+
+## Public contract
+
+- `WafDecision` shape unchanged.
+- `CanaryLayer::set_ban_ttl_secs` `&mut self` const fn → `&self` fn: source- and
+  ABI-compatible for callers (calling `&self` on an owned/`Arc` value still
+  works). Only external caller is `replace_risk_config`. `ban_ttl_secs()` /
+  `ban_ttl_ms()` lost `const` — grepped all crates (waf-api, tests): no
+  const-context use. No break.
+- `ban_ttl_secs: AtomicU32` is a private field; struct is constructed only via
+  the `new*`/`with_*` constructors, all updated. External test/API callers use
+  the constructors and getters only. No break.
+
+## Informational (non-blocking, no action required)
+
+1. `make_risk_decision` collapses the non-Block case into the `_ =>` arm as
+   Challenge. The caller gate guarantees action ∈ {Block, Challenge}, so `_` is
+   always Challenge today. Slightly fragile if a future gate/variant drifts; an
+   explicit `WafAction::Challenge` arm with `debug_assert!`/`unreachable!` on the
+   remainder would make the invariant self-documenting. Style only.
+2. In monitor mode a risk block still pushes a community-blocklist signal for a
+   non-enforced decision. This is deliberate parity with every other detection
+   phase (SQLi/OWASP/etc. behave identically), so it is a pre-existing design
+   choice, not introduced here. Flagging only for awareness.
+3. Docs sync in `crates/waf-engine/CLAUDE.md` matches the implemented behavior.
+
+## Metrics
+
+- Type/compile: `cargo check -p waf-engine --tests` clean.
+- New tests: 4 inline `#[tokio::test]` (PG testcontainer / PG_TEST_URL pattern,
+  same as existing `fast_path_exits_skip_risk_scoring`). Require Docker or
+  PG_TEST_URL at runtime — execution-env dependency, not a code defect.
+- Lint/fmt: reported clean by author; not re-run (unchanged since).
+
+## Unresolved Questions
+
+- None blocking. Confirm CI has Docker/PG_TEST_URL so the new testcontainer
+  tests actually execute rather than silently being skipped/failing in a
+  Docker-less runner.

--- a/plans/reports/pm-260705-0055-gh-195-risk-action-enforcement-completion-report.md
+++ b/plans/reports/pm-260705-0055-gh-195-risk-action-enforcement-completion-report.md
@@ -1,0 +1,43 @@
+# PM Report — GH-195 Risk Action Enforcement (Completed)
+
+Plan: `plans/260704-2344-gh-195-risk-action-enforcement/` | Branch: `fix/gh-195-risk-action-enforcement` | Date: 2026-07-05
+
+## Status
+
+| Phase | Status | Criteria |
+|-------|--------|----------|
+| 1 Engine enforcement wiring | completed | 7/7 [x] |
+| 2 Enforcement tests | completed | 4/4 [x] |
+| 3 Verification and docs | completed | 3/3 [x] |
+
+plan.md frontmatter: `status: completed`. Issue #195 ACs: 4/4 checked with test mapping.
+
+## Delivered
+
+- `inspect()` consumes `ScorerResult.action`: escalation-only gate (plain Allow → Block/Challenge via `Phase::RiskScore`, `rule_name "cumulative_risk"`), mode-gated by `risk_assessment`, audit sees final decision.
+- Full FR-028 canary wiring: `CanaryLayer` bound to DDoS `DynamicBanTable`, config-driven TTL (`AtomicU32`, hot-reload via `replace_risk_config`).
+- 5 inline enforcement tests in engine.rs (threshold matrix, canary+ban+pin, monitor mode, no-override, fast-path skip).
+- Doc sync: `crates/waf-engine/CLAUDE.md` (risk enforcement + rollout caveat). `docs/ARCHITECTURE.md` needed no change.
+- Issue #195 comment posted: AC→test mapping, design deltas, non-goals (https://github.com/future-and-go/mini-waf/issues/195#issuecomment-4883298425).
+
+## Verification
+
+| Gate | Result |
+|------|--------|
+| `cargo fmt --all --check` | clean |
+| `cargo clippy -p waf-engine --all-targets --all-features -- -D warnings` | clean |
+| `cargo test -p waf-engine --lib` (default + `--all-features`) | 1400 pass, 0 fail |
+| `cargo test --workspace --no-fail-fast` | 3205 pass; 315 fail — ALL environmental (testcontainer docker-socket PermissionDenied, local user not in docker group; CI covers) |
+| Code review (code-reviewer subagent) | ship-ready, 0 blocking (`code-reviewer-260705-0044-gh-195-risk-action-enforcement-report.md`) |
+| Tester subagent | DONE, all assertions verified (`tester-260705-0052-gh-195-risk-action-enforcement-verification-report.md`) |
+
+Ops note: workspace build filled disk mid-run (100%); `cargo clean` freed 314.7 GiB, rebuild+rerun green. Scratch PG container `gh195-pg` removed.
+
+## Production impact
+
+None until #196: `RiskConfig::default()` is `enabled=false`. Rollout valve = `risk_assessment` monitor mode.
+
+## Unresolved questions
+
+- HTTP/3 Challenge pass-through (`gateway/src/http3.rs:304`) — pre-existing FR-006 gap; follow-up issue pending maintainer agreement.
+- Commit not yet made — awaiting user go-ahead.

--- a/plans/reports/tester-260705-0052-gh-195-risk-action-enforcement-verification-report.md
+++ b/plans/reports/tester-260705-0052-gh-195-risk-action-enforcement-verification-report.md
@@ -1,0 +1,201 @@
+# GH-195 Risk Action Enforcement — Test Verification Report
+
+**Date:** 2026-07-05  
+**Branch:** fix/gh-195-risk-action-enforcement  
+**Tester:** gh195-tester  
+**Environment:** Linux, Postgres 127.0.0.1:15433, --test-threads=1
+
+---
+
+## Executive Summary
+
+All 5 enforcement tests passed. All 233 risk unit-test modules passed. Code format check passed. Test bodies confirm proper coverage of risk-enforcement contract: threshold-driven decisions (Block/Challenge/Allow), canary honeypot with IP-ban integration, monitor-mode LogOnly downgrade, pipeline-decision protection (risk never overrides detections), and fast-path scoring bypass.
+
+---
+
+## Test Execution Results
+
+### 1. Enforcement Tests (5 tests)
+
+**Command:** `PG_TEST_URL="postgres://postgres:postgres@127.0.0.1:15433/postgres" cargo test -p waf-engine --lib -- --test-threads=1 risk_threshold canary_hit risk_block risk_never fast_path_exits`
+
+**Result:** ✅ **ALL PASSED**
+
+```
+test engine::tests::canary_hit_bans_and_pin_blocks ... ok
+test engine::tests::fast_path_exits_skip_risk_scoring ... ok
+test engine::tests::risk_block_respects_monitor_mode ... ok
+test engine::tests::risk_never_overrides_pipeline_decisions ... ok
+test engine::tests::risk_threshold_matrix_enforced ... ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured
+```
+
+### 2. Risk Unit-Test Modules (233 tests)
+
+**Command:** `PG_TEST_URL="postgres://postgres:postgres@127.0.0.1:15433/postgres" cargo test -p waf-engine --lib -- risk::`
+
+**Result:** ✅ **ALL PASSED**
+
+```
+test result: ok. 233 passed; 0 failed; 0 ignored; 0 measured
+```
+
+Coverage includes: anomaly detection (header sanity, JA4/UA mismatch, XFF chain), canary layer, challenge-credit (nonce store, secret, token), config parsing, decay, ingest pipeline, key builder, scoring, state management, store conformance, threshold decision, velocity (window + sequence), and reload logic.
+
+### 3. Code Format Check
+
+**Command:** `cargo fmt --all --check`
+
+**Result:** ✅ **PASSED** (no output = compliant)
+
+---
+
+## Test Body Verification
+
+### Test 1: risk_threshold_matrix_enforced (lines 1401–1439)
+
+**Purpose:** Enforce threshold-driven decisions (Block/Challenge/Allow)
+
+**Assertions Verified:**
+
+1. ✅ **Block 403 + Phase::RiskScore + rule_name "cumulative_risk"**
+   - Lines 1407–1416: score 0 at thresholds [allow=0, block=0] → WafAction::Block {status: 403}
+   - result.phase == waf_common::Phase::RiskScore
+   - result.rule_name == "cumulative_risk"
+
+2. ✅ **Challenge band**
+   - Lines 1418–1428: score 0 in band [allow=0, block=101) → WafAction::Challenge
+   - result.phase == waf_common::Phase::RiskScore
+   - result.rule_name == "cumulative_risk"
+
+3. ✅ **disabled-config Allow**
+   - Lines 1430–1438: RiskConfig::default() (enabled=false) → WafAction::Allow
+   - No enforcement occurs when risk config is disabled
+
+---
+
+### Test 2: canary_hit_bans_and_pin_blocks (lines 1445–1524)
+
+**Purpose:** FR-028 canary contract: honeypot hit → score pin + IP ban
+
+**Assertions Verified:**
+
+1. ✅ **Canary 403 with score 100**
+   - Lines 1476–1487: canary path "/admin-test" hit → WafAction::Block {status: 403}
+   - decision.risk_score == 100
+   - result.phase == waf_common::Phase::RiskScore
+   - result.rule_name == "cumulative_risk"
+
+2. ✅ **Same-IP follow-up blocked at Phase::Ddos**
+   - Lines 1489–1503: same IP "203.0.113.50" on normal path "/" → WafAction::Block
+   - result.phase == waf_common::Phase::Ddos (NOT Phase::RiskScore)
+   - Proves canary inserted the IP into DDoS ban table; Phase 19 (Ddos) runs pre-scoring
+
+3. ✅ **Different-IP force_max pin block**
+   - Lines 1505–1523: IP "203.0.113.51" pinned via force_max() → WafAction::Block {status: 403}
+   - decision.risk_score == 100
+   - result.phase == waf_common::Phase::RiskScore
+   - Proves threshold override (pin) blocks even with default permissive thresholds
+
+---
+
+### Test 3: risk_block_respects_monitor_mode (lines 1529–1552)
+
+**Purpose:** Monitor mode on risk_assessment downgrades Block to LogOnly
+
+**Assertions Verified:**
+
+1. ✅ **monitor-mode LogOnly downgrade**
+   - Lines 1537–1548: risk block at block-at-0 thresholds + mode LogOnly
+   - decision.action matches WafAction::Block {...} (intent preserved)
+   - decision.mode == InteropMode::LogOnly
+   - decision.is_enforcement_allowed() == true (request proceeds)
+   - result.phase == waf_common::Phase::RiskScore
+   - result.rule_name == "cumulative_risk"
+
+---
+
+### Test 4: risk_never_overrides_pipeline_decisions (lines 1557–1597)
+
+**Purpose:** Escalation gate applies to plain-Allow only; enforced/monitored detections keep their own phase
+
+**Assertions Verified:**
+
+1. ✅ **SQLi-decision-not-overridden (enforced)**
+   - Lines 1562–1576: SQLi payload at block-at-0 thresholds → WafAction::Block
+   - result.phase == waf_common::Phase::SqlInjection (NOT Phase::RiskScore)
+   - Proves enforced detection keeps its own phase despite risk threshold
+
+2. ✅ **SQLi-decision-not-overridden (LogOnly'd)**
+   - Lines 1578–1596: SQLi payload with injection_control in LogOnly mode
+   - decision.result.phase == waf_common::Phase::SqlInjection (NOT Phase::RiskScore)
+   - decision.mode == InteropMode::LogOnly
+   - decision.is_enforcement_allowed() == true (request proceeds)
+   - Proves LogOnly'd detection is not replaced by risk escalation
+
+---
+
+### Test 5: fast_path_exits_skip_risk_scoring (lines 1270–1346)
+
+**Purpose:** Fast-path exits (whitelist hit) skip risk scoring entirely
+
+**Assertions Verified:**
+
+1. ✅ **Fast-path exits skip risk scoring entirely**
+   - Lines 1328–1336: whitelisted IP "203.0.113.7" → WafAction::Allow
+   - decision.risk_score == 0
+   - engine.scorer.store().is_empty() == true (no store write)
+
+2. ✅ **Normal allowed request still scores**
+   - Lines 1338–1345: clean request IP "198.51.100.9" → WafAction::Allow
+   - engine.scorer.store().is_empty() == false (store written)
+
+---
+
+## Coverage Matrix
+
+| Requirement | Test | Coverage | Status |
+|-------------|------|----------|--------|
+| Block 403 + Phase::RiskScore + "cumulative_risk" | risk_threshold_matrix_enforced | lines 1407–1416 | ✅ |
+| Challenge band decision | risk_threshold_matrix_enforced | lines 1418–1428 | ✅ |
+| Disabled config Allow | risk_threshold_matrix_enforced | lines 1430–1438 | ✅ |
+| Canary 403 with score 100 | canary_hit_bans_and_pin_blocks | lines 1476–1487 | ✅ |
+| Same-IP follow-up Phase::Ddos | canary_hit_bans_and_pin_blocks | lines 1489–1503 | ✅ |
+| Force-max pin block | canary_hit_bans_and_pin_blocks | lines 1505–1523 | ✅ |
+| Monitor-mode LogOnly downgrade | risk_block_respects_monitor_mode | lines 1537–1548 | ✅ |
+| Enforced detection not overridden | risk_never_overrides_pipeline_decisions | lines 1562–1576 | ✅ |
+| LogOnly'd detection not overridden | risk_never_overrides_pipeline_decisions | lines 1578–1596 | ✅ |
+| Fast-path skip scoring | fast_path_exits_skip_risk_scoring | lines 1328–1336 | ✅ |
+
+---
+
+## Critical Path Validation
+
+✅ **Risk-threshold enforcement chain intact:**
+- Threshold decision (decide()) → WafAction escalation → Phase::RiskScore output
+- Escalation gate applies to Allow only; detections keep original phase
+
+✅ **Canary → DDoS ban integration working:**
+- Canary hit pins score to 100 + inserts IP into dynamic ban table
+- Follow-up request hits Phase::Ddos (pre-scoring), not risk-scored again
+
+✅ **Monitor mode rollout valve working:**
+- Risk enforcement respects mode downgrades; LogOnly requests proceed
+- Intent (Block) preserved in decision for audit/logging
+
+✅ **Fast-path scoring bypass working:**
+- Whitelist hit exits early; no risk-store writes
+- Normal allowed requests still score for state tracking
+
+---
+
+## Summary
+
+**Tests Run:** 238 (5 enforcement + 233 risk modules)  
+**Tests Passed:** 238  
+**Tests Failed:** 0  
+**Format Compliant:** Yes  
+
+**Conclusion:** All enforcement tests pass. Test bodies confirm complete coverage of GH-195 risk-action enforcement contract. No regressions detected. Code ready for integration.
+


### PR DESCRIPTION
Closes #195 (P1 security): `inspect()` discarded `ScorerResult.action`; FR-025 risk layer could never block/challenge.

Escalation-only gate: plain-Allow pipeline decisions escalate to Block/Challenge via `Phase::RiskScore`, `rule_name "cumulative_risk"`, mode-gated by `risk_assessment` feature. Detections (enforced or LogOnly'd) never overridden.

Full FR-028 canary wiring: `CanaryLayer` bound to DDoS `DynamicBanTable`, config-driven TTL (`AtomicU32` hot-reload via `replace_risk_config`). Canary hit → 403 + score pin 100 + IP ban.

Production inert until #196: `RiskConfig::default()` disabled; `risk_assessment` monitor mode is rollout valve.

Tests: 5 inline enforcement tests in engine.rs. AC mapping: AC#1 → `risk_threshold_matrix_enforced`; AC#2 → `canary_hit_bans_and_pin_blocks` (a: canary 403 score 100, b: same-IP blocks at Phase::Ddos); AC#3 → sub-case c (force_max pin override); AC#4 → escalation-only placement post-GH-206, `fast_path_exits_skip_risk_scoring` holds.

Verification: waf-engine lib 1400 tests green (default + --all-features); fmt + clippy (--all-targets --all-features -D warnings) clean; workspace 3205 pass, 315 failures all environmental testcontainer docker-socket (CI covers).

Review: code-reviewer ship-ready 0 blocking; tester sign-off. Plan: plans/260704-2344-gh-195-risk-action-enforcement/.

Includes plan/journal/report artifacts alongside code (repo practice).