### PR TITLE
fix(risk): run canary honeypot check before seed-score early return

### DIFF
--- a/crates/waf-engine/benches/risk_anomaly.rs
+++ b/crates/waf-engine/benches/risk_anomaly.rs
@@ -147,7 +147,13 @@ fn bench_decay(c: &mut Criterion) {
                 state.clean_streak = 15;
                 state
             },
-            |mut state| black_box(apply_decay(&mut state, 2000)),
+            |mut state| {
+                black_box(apply_decay(
+                    &mut state,
+                    2000,
+                    &waf_engine::risk::config::DecayConfig::default(),
+                ))
+            },
             criterion::BatchSize::SmallInput,
         )
     });

--- a/crates/waf-engine/src/engine.rs
+++ b/crates/waf-engine/src/engine.rs
@@ -340,7 +340,7 @@ impl WafEngine {
         if cfg.store.backend == "redis" {
             #[cfg(feature = "redis-store")]
             {
-                let runtime_cfg = cfg.store.redis.to_runtime_config(cfg.ttl_secs);
+                let runtime_cfg = cfg.store.redis.to_runtime_config(cfg.ttl_secs, cfg.decay.clone());
                 // Bound the initial connect: ConnectionManager retries with
                 // backoff internally, which can stall startup for minutes
                 // when the host silently drops packets. Fail-soft needs a
@@ -365,7 +365,7 @@ impl WafEngine {
             #[cfg(not(feature = "redis-store"))]
             warn!("risk: store.backend=redis requires the redis-store build feature; using memory store");
         }
-        let store = Arc::new(MemoryRiskStore::new());
+        let store = Arc::new(MemoryRiskStore::with_decay(cfg.decay.clone()));
         // The purge loop needs the concrete `Arc<MemoryRiskStore>`; start it
         // before the Arc is unsized to `Arc<dyn RiskStore>`.
         let ttl_ms = i64::try_from(cfg.ttl_secs.saturating_mul(1000)).unwrap_or(i64::MAX);

--- a/crates/waf-engine/src/risk/config.rs
+++ b/crates/waf-engine/src/risk/config.rs
@@ -72,7 +72,7 @@ pub struct RiskConfig {
 }
 
 /// Store backend selection.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StoreConfig {
     /// Backend type: "memory" or "redis" (redis requires feature flag).
     #[serde(default = "default_backend")]
@@ -81,6 +81,15 @@ pub struct StoreConfig {
     /// Redis configuration (only used when backend = "redis").
     #[serde(default)]
     pub redis: RedisStoreConfig,
+}
+
+impl Default for StoreConfig {
+    fn default() -> Self {
+        Self {
+            backend: default_backend(),
+            redis: RedisStoreConfig::default(),
+        }
+    }
 }
 
 /// Redis store configuration (Phase 7).
@@ -119,7 +128,7 @@ impl RedisStoreConfig {
     /// Convert to runtime `RedisRiskConfig` (requires `redis-store` feature).
     #[cfg(feature = "redis-store")]
     #[must_use]
-    pub fn to_runtime_config(&self, ttl_secs: u64) -> crate::risk::store::redis::RedisRiskConfig {
+    pub fn to_runtime_config(&self, ttl_secs: u64, decay: DecayConfig) -> crate::risk::store::redis::RedisRiskConfig {
         crate::risk::store::redis::RedisRiskConfig {
             url: self.url.clone(),
             key_prefix: self.key_prefix.clone(),
@@ -128,6 +137,7 @@ impl RedisStoreConfig {
             op_timeout: std::time::Duration::from_millis(self.op_timeout_ms),
             breaker_threshold: self.breaker_threshold,
             cache_capacity: self.cache_capacity,
+            decay,
         }
     }
 }
@@ -379,7 +389,45 @@ impl RiskConfig {
         let doc: RiskDocument = serde_yaml::from_str(&content)
             .with_context(|| format!("failed to parse risk config: {}", path.display()))?;
 
+        doc.risk
+            .validate()
+            .with_context(|| format!("invalid risk config: {}", path.display()))?;
+
         Ok(Arc::new(doc.risk))
+    }
+
+    /// Reject values that are verified-harmful at runtime.
+    ///
+    /// Checks: zero TTL (every actor expires instantly), zero GC interval
+    /// (panics `tokio::time::interval`), zero ingest channel capacity (panics
+    /// the bounded mpsc), unknown store backend, and a decay floor above the
+    /// score range. `decay_rate: 0` (decay disabled) and `min_clean_streak: 0`
+    /// (decay eligible immediately) are valid. Risk thresholds
+    /// (allow/challenge/block) live in `TierPolicy.risk_thresholds` and are
+    /// not validated here.
+    pub fn validate(&self) -> Result<()> {
+        if self.ttl_secs == 0 {
+            anyhow::bail!("risk config: ttl_secs must be > 0");
+        }
+        if self.gc_interval_secs == 0 {
+            anyhow::bail!("risk config: gc_interval_secs must be > 0");
+        }
+        if self.ingest.channel_capacity == 0 {
+            anyhow::bail!("risk config: ingest.channel_capacity must be > 0");
+        }
+        if !matches!(self.store.backend.as_str(), "memory" | "redis") {
+            anyhow::bail!(
+                "risk config: store.backend must be \"memory\" or \"redis\", got \"{}\"",
+                self.store.backend
+            );
+        }
+        if self.decay.max_decay > 100 {
+            anyhow::bail!(
+                "risk config: decay.max_decay must be <= 100, got {}",
+                self.decay.max_decay
+            );
+        }
+        Ok(())
     }
 
     /// TTL in milliseconds.
@@ -505,5 +553,67 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(cfg.ttl_ms(), 60_000);
+    }
+
+    #[test]
+    fn validate_accepts_default_config() {
+        assert!(RiskConfig::default().validate().is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_disabled_decay_and_zero_streak() {
+        let mut cfg = RiskConfig::default();
+        cfg.decay.decay_rate = 0;
+        cfg.decay.min_clean_streak = 0;
+        assert!(cfg.validate().is_ok(), "rate 0 and streak 0 are valid decay settings");
+    }
+
+    #[test]
+    fn validate_rejects_zero_ttl() {
+        let cfg = RiskConfig {
+            ttl_secs: 0,
+            ..Default::default()
+        };
+        assert!(cfg.validate().unwrap_err().to_string().contains("ttl_secs"));
+    }
+
+    #[test]
+    fn validate_rejects_zero_gc_interval() {
+        let cfg = RiskConfig {
+            gc_interval_secs: 0,
+            ..Default::default()
+        };
+        assert!(cfg.validate().unwrap_err().to_string().contains("gc_interval_secs"));
+    }
+
+    #[test]
+    fn validate_rejects_zero_channel_capacity() {
+        let mut cfg = RiskConfig::default();
+        cfg.ingest.channel_capacity = 0;
+        assert!(cfg.validate().unwrap_err().to_string().contains("channel_capacity"));
+    }
+
+    #[test]
+    fn validate_rejects_unknown_backend() {
+        let mut cfg = RiskConfig::default();
+        cfg.store.backend = "postgres".to_string();
+        assert!(cfg.validate().unwrap_err().to_string().contains("backend"));
+    }
+
+    #[test]
+    fn validate_rejects_decay_floor_above_score_range() {
+        let mut cfg = RiskConfig::default();
+        cfg.decay.max_decay = 101;
+        assert!(cfg.validate().unwrap_err().to_string().contains("max_decay"));
+    }
+
+    #[test]
+    fn from_path_rejects_zero_gc_interval_without_panic() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("risk.yaml");
+        std::fs::write(&path, "risk:\n  enabled: true\n  gc_interval_secs: 0\n").unwrap();
+
+        let err = RiskConfig::from_path(&path).unwrap_err();
+        assert!(format!("{err:#}").contains("gc_interval_secs"));
     }
 }

--- a/crates/waf-engine/src/risk/decay.rs
+++ b/crates/waf-engine/src/risk/decay.rs
@@ -5,69 +5,62 @@
 //! Decay has a floor of `MAX_DECAY` (50) — scores never drop below this via
 //! automatic decay (only explicit credits can go lower).
 
+use crate::risk::config::DecayConfig;
 use crate::risk::state::{Contributor, ContributorKind, RiskState};
 
-/// Maximum points that can be decayed away automatically.
+/// Default maximum points that can be decayed away automatically.
+///
 /// Scores above this floor require explicit credits to reduce further.
+/// Runtime decay reads `DecayConfig`; this const is a test/bench reference.
 pub const MAX_DECAY: i32 = 50;
 
-/// Minimum clean streak before decay kicks in.
+/// Default minimum clean streak before decay kicks in.
+/// Runtime decay reads `DecayConfig`; this const is a test/bench reference.
 pub const MIN_CLEAN_STREAK: u32 = 10;
 
-/// Points decayed per clean request after `MIN_CLEAN_STREAK`.
+/// Default points decayed per clean request after the clean streak.
+/// Runtime decay reads `DecayConfig`; this const is a test/bench reference.
 pub const DECAY_RATE: i16 = 1;
 
 /// Apply decay to the state if conditions are met.
 ///
 /// Returns the decay delta applied (0 if no decay). Mutates state in place.
-pub fn apply_decay(state: &mut RiskState, now_ms: i64) -> i16 {
-    if state.clean_streak < MIN_CLEAN_STREAK {
+/// `decay.decay_rate == 0` disables decay through the `available` arithmetic.
+pub fn apply_decay(state: &mut RiskState, now_ms: i64, decay: &DecayConfig) -> i16 {
+    let delta = preview_decay(state, now_ms, decay);
+    if delta == 0 {
         return 0;
     }
 
-    if state.is_pinned(now_ms) {
-        return 0;
-    }
-
-    let floor = MAX_DECAY;
-    if state.raw_score <= floor {
-        return 0;
-    }
-
-    let available = (state.raw_score - floor).min(i32::from(DECAY_RATE));
-    if available <= 0 {
-        return 0;
-    }
-
-    #[allow(clippy::cast_possible_truncation)]
-    let decay_delta = -(available as i16); // safe: available is clamped to DECAY_RATE (1)
-    state.raw_score = state.raw_score.saturating_add(i32::from(decay_delta));
-    state.push_contributor(Contributor::new(ContributorKind::Decay, decay_delta, now_ms));
+    state.raw_score = state.raw_score.saturating_add(i32::from(delta));
+    state.push_contributor(Contributor::new(ContributorKind::Decay, delta, now_ms));
     state.reclamp();
 
-    decay_delta
+    delta
 }
 
 /// Calculate how much decay would apply without mutating state.
 #[must_use]
-pub fn preview_decay(state: &RiskState, now_ms: i64) -> i16 {
-    if state.clean_streak < MIN_CLEAN_STREAK {
+pub fn preview_decay(state: &RiskState, now_ms: i64, decay: &DecayConfig) -> i16 {
+    if state.clean_streak < decay.min_clean_streak {
         return 0;
     }
     if state.is_pinned(now_ms) {
         return 0;
     }
-    let floor = MAX_DECAY;
+    // validate() enforces max_decay <= 100; the fallback keeps an
+    // unvalidated construction from panicking.
+    let floor = i32::try_from(decay.max_decay).unwrap_or(100);
     if state.raw_score <= floor {
         return 0;
     }
-    let available = (state.raw_score - floor).min(i32::from(DECAY_RATE));
+    let available = (state.raw_score - floor).min(i32::from(decay.decay_rate));
     if available <= 0 {
         return 0;
     }
     #[allow(clippy::cast_possible_truncation)]
     {
-        -(available as i16) // safe: available is clamped to DECAY_RATE (1)
+        -(available as i16) // safe: available is clamped to decay_rate (u16)
     }
 }
 
@@ -82,7 +75,7 @@ mod tests {
         state.clamped_score = 80;
         state.clean_streak = 5;
 
-        let decay = apply_decay(&mut state, 2000);
+        let decay = apply_decay(&mut state, 2000, &DecayConfig::default());
         assert_eq!(decay, 0);
         assert_eq!(state.raw_score, 80);
     }
@@ -94,7 +87,7 @@ mod tests {
         state.clamped_score = 80;
         state.clean_streak = 15;
 
-        let decay = apply_decay(&mut state, 2000);
+        let decay = apply_decay(&mut state, 2000, &DecayConfig::default());
         assert_eq!(decay, -1);
         assert_eq!(state.raw_score, 79);
         assert_eq!(state.clamped_score, 79);
@@ -107,11 +100,11 @@ mod tests {
         state.clamped_score = 51;
         state.clean_streak = 15;
 
-        let decay = apply_decay(&mut state, 2000);
+        let decay = apply_decay(&mut state, 2000, &DecayConfig::default());
         assert_eq!(decay, -1);
         assert_eq!(state.raw_score, 50);
 
-        let decay2 = apply_decay(&mut state, 3000);
+        let decay2 = apply_decay(&mut state, 3000, &DecayConfig::default());
         assert_eq!(decay2, 0);
         assert_eq!(state.raw_score, 50);
     }
@@ -124,7 +117,7 @@ mod tests {
         state.clean_streak = 15;
         state.pinned_until_ms = Some(5000);
 
-        let decay = apply_decay(&mut state, 2000);
+        let decay = apply_decay(&mut state, 2000, &DecayConfig::default());
         assert_eq!(decay, 0);
         assert_eq!(state.raw_score, 80);
     }
@@ -136,8 +129,8 @@ mod tests {
         state.clamped_score = 75;
         state.clean_streak = 20;
 
-        let preview = preview_decay(&state, 2000);
-        let actual = apply_decay(&mut state, 2000);
+        let preview = preview_decay(&state, 2000, &DecayConfig::default());
+        let actual = apply_decay(&mut state, 2000, &DecayConfig::default());
         assert_eq!(preview, actual);
     }
 }

--- a/crates/waf-engine/src/risk/ingest/worker.rs
+++ b/crates/waf-engine/src/risk/ingest/worker.rs
@@ -13,6 +13,7 @@ use crate::device_fp::types::FpKey;
 use crate::risk::ingest::metrics::IngestMetrics;
 use crate::risk::ingest::signal_to_contributor::{SignalWeights, signals_to_contributors};
 use crate::risk::key::RiskKey;
+use crate::risk::score::clamp_per_request_deltas;
 use crate::risk::store::RiskStore;
 
 /// Job submitted to the worker queue.
@@ -101,6 +102,10 @@ async fn process_job(
         metrics.record_processed(lag_ms as u64);
         return Ok(());
     }
+
+    // One job carries one request's signals — cap its positive delta sum
+    // like the sync path does.
+    let (contributors, _raw_sum) = clamp_per_request_deltas(&contributors);
 
     // Apply to store
     store.apply(&risk_key, &contributors, now_ms).await?;

--- a/crates/waf-engine/src/risk/scorer.rs
+++ b/crates/waf-engine/src/risk/scorer.rs
@@ -20,6 +20,7 @@ use crate::risk::canary::CanaryLayer;
 use crate::risk::challenge_credit::{ChallengeVerifier, VerifyOutcome};
 use crate::risk::config::RiskConfig;
 use crate::risk::key::{RiskKey, SessionId};
+use crate::risk::score::clamp_per_request_deltas;
 use crate::risk::seed::{SeedLayer, SeedVerdict};
 use crate::risk::state::{Contributor, ContributorKind, CreditOutcome};
 use crate::risk::store::RiskStore;
@@ -253,6 +254,10 @@ impl<S: RiskStore + ?Sized> Scorer<S> {
         if let Some(credit_delta) = self.evaluate_challenge_credit(ctx, &key, now_ms, cfg).await {
             all_deltas.push(credit_delta);
         }
+
+        // Cap this request's positive delta sum to MAX_PER_REQUEST_DELTA
+        // before the store fold (which only clamps the total score).
+        let (all_deltas, _raw_sum) = clamp_per_request_deltas(&all_deltas);
 
         // Apply to store (decay happens inside store.apply before fold)
         let result = self.store.apply(&key, &all_deltas, now_ms).await?;
@@ -650,6 +655,30 @@ mod tests {
 
         assert_eq!(result.score, 95);
         assert!(matches!(result.action, WafAction::Block { .. }));
+    }
+
+    #[tokio::test]
+    async fn oversized_positive_batch_capped_and_credit_preserved() {
+        use crate::risk::state::{ContributorKind, SeedKind};
+
+        let scorer = make_scorer();
+        let ctx = make_ctx();
+
+        // Positive deltas sum to 160 (> the per-request cap). The oldest
+        // positive is truncated so the newest 100 points land, and the
+        // negative credit survives the cap.
+        let deltas = vec![
+            Contributor::new(ContributorKind::Seed(SeedKind::Generic), 60, 1000),
+            Contributor::new(ContributorKind::AdminCredit, -20, 1000),
+            Contributor::new(ContributorKind::Seed(SeedKind::Generic), 60, 1000),
+            Contributor::new(ContributorKind::Seed(SeedKind::Generic), 40, 1000),
+        ];
+        let result = scorer.score(&ctx, None, &deltas, None, 1000).await.unwrap();
+
+        assert_eq!(
+            result.score, 80,
+            "cap keeps the newest 100 positive points; the credit still applies"
+        );
     }
 
     #[tokio::test]

--- a/crates/waf-engine/src/risk/scorer.rs
+++ b/crates/waf-engine/src/risk/scorer.rs
@@ -152,32 +152,24 @@ impl<S: RiskStore + ?Sized> Scorer<S> {
             });
         }
 
-        // L0 seed layer evaluation FIRST — whitelist short-circuits everything
-        if let Some(ref seed) = self.seed
-            && cfg.seed.enabled
-        {
-            match seed.evaluate(ctx.client_ip) {
-                SeedVerdict::Whitelisted => {
-                    return Ok(ScorerResult {
-                        action: WafAction::Allow,
-                        score: 0,
-                        is_new: false,
-                    });
-                }
-                SeedVerdict::Score { delta, kind } => {
-                    let seed_contrib = Contributor::new(ContributorKind::Seed(kind), i16::from(delta), now_ms);
-                    let mut all_deltas = vec![seed_contrib];
-                    all_deltas.extend_from_slice(sync_deltas);
-                    return self
-                        .score_with_l2(ctx, fp_key, &all_deltas, tx_endpoint, now_ms, &cfg)
-                        .await;
-                }
-                SeedVerdict::None => {}
-            }
+        // L0 seed layer — evaluate once; whitelist short-circuits everything,
+        // including the canary check below.
+        let seed_verdict = match (&self.seed, cfg.seed.enabled) {
+            (Some(seed), true) => seed.evaluate(ctx.client_ip),
+            _ => SeedVerdict::None,
+        };
+
+        if matches!(seed_verdict, SeedVerdict::Whitelisted) {
+            return Ok(ScorerResult {
+                action: WafAction::Allow,
+                score: 0,
+                is_new: false,
+            });
         }
 
-        // FR-028 Canary honeypot check — AFTER whitelist, BEFORE other layers
-        // On canary hit: force_max + return Block immediately
+        // Canary honeypot check — after whitelist, before seed scoring and all
+        // other layers, so a seed-scored scanner (Tor exit, datacenter ASN)
+        // still trips the trap. On canary hit: force_max + return Block.
         if let Some(ref canary) = self.canary
             && cfg.canary.enabled
             && canary.check_and_ban(&ctx.path, ctx.client_ip, now_ms)
@@ -204,8 +196,20 @@ impl<S: RiskStore + ?Sized> Scorer<S> {
             });
         }
 
-        self.score_with_l2(ctx, fp_key, sync_deltas, tx_endpoint, now_ms, &cfg)
-            .await
+        match seed_verdict {
+            SeedVerdict::Score { delta, kind } => {
+                let seed_contrib = Contributor::new(ContributorKind::Seed(kind), i16::from(delta), now_ms);
+                let mut all_deltas = vec![seed_contrib];
+                all_deltas.extend_from_slice(sync_deltas);
+                self.score_with_l2(ctx, fp_key, &all_deltas, tx_endpoint, now_ms, &cfg)
+                    .await
+            }
+            // Whitelisted returned above; None carries only the caller deltas.
+            _ => {
+                self.score_with_l2(ctx, fp_key, sync_deltas, tx_endpoint, now_ms, &cfg)
+                    .await
+            }
+        }
     }
 
     /// Internal scoring with L2 layer evaluation.

--- a/crates/waf-engine/src/risk/scorer.rs
+++ b/crates/waf-engine/src/risk/scorer.rs
@@ -23,7 +23,7 @@ use crate::risk::key::{RiskKey, SessionId};
 use crate::risk::seed::{SeedLayer, SeedVerdict};
 use crate::risk::state::{Contributor, ContributorKind, CreditOutcome};
 use crate::risk::store::RiskStore;
-use crate::risk::threshold::decide;
+use crate::risk::threshold::{decide, degraded_action};
 use crate::risk::velocity::{TxEndpoint, VelocityLayer};
 
 /// Result of scoring a request.
@@ -260,7 +260,25 @@ impl<S: RiskStore + ?Sized> Scorer<S> {
 
         let override_block = state.is_pinned(now_ms);
         let thresholds = &ctx.tier_policy.risk_thresholds;
-        let action = decide(state.clamped_score, thresholds, override_block);
+        let action = if result.degraded {
+            // Store lost its authority (backend outage); the tier's declared
+            // fail mode decides instead of the unauthoritative score alone.
+            tracing::warn!(
+                target: "risk::degrade",
+                client_ip = %ctx.client_ip,
+                fail_mode = ?ctx.tier_policy.fail_mode,
+                score = state.clamped_score,
+                "risk store degraded; applying tier fail_mode"
+            );
+            degraded_action(
+                ctx.tier_policy.fail_mode,
+                state.clamped_score,
+                thresholds,
+                override_block,
+            )
+        } else {
+            decide(state.clamped_score, thresholds, override_block)
+        };
 
         Ok(ScorerResult {
             action,
@@ -456,6 +474,131 @@ mod tests {
         };
         let swap = Arc::new(ArcSwap::from(Arc::new(cfg)));
         Scorer::new(store, swap)
+    }
+
+    /// Store stub whose `apply` always reports a degraded backend with a
+    /// preset best-known score — deterministic outage without a Redis server.
+    struct DegradedStore {
+        score: u8,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::risk::store::RiskStore for DegradedStore {
+        async fn read(&self, _key: &RiskKey) -> anyhow::Result<Option<crate::risk::state::RiskState>> {
+            anyhow::bail!("backend unreachable")
+        }
+
+        async fn apply(
+            &self,
+            _key: &RiskKey,
+            _deltas: &[Contributor],
+            now_ms: i64,
+        ) -> anyhow::Result<crate::risk::store::store_trait::ApplyResult> {
+            let mut state = crate::risk::state::RiskState::new(now_ms);
+            state.clamped_score = self.score;
+            Ok(crate::risk::store::store_trait::ApplyResult {
+                state,
+                is_new: self.score == 0,
+                degraded: true,
+            })
+        }
+
+        async fn force_max(&self, _key: &RiskKey, _until_ms: i64, _now_ms: i64) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn clear(&self, _key: &RiskKey) -> anyhow::Result<bool> {
+            Ok(false)
+        }
+
+        async fn purge_expired(&self, _ttl_ms: i64, _now_ms: i64) -> anyhow::Result<usize> {
+            Ok(0)
+        }
+
+        async fn reset_all(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn len(&self) -> usize {
+            0
+        }
+    }
+
+    fn make_degraded_scorer(score: u8) -> Scorer<DegradedStore> {
+        let cfg = RiskConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let swap = Arc::new(ArcSwap::from(Arc::new(cfg)));
+        Scorer::new(Arc::new(DegradedStore { score }), swap)
+    }
+
+    fn ctx_with_fail_mode(fail_mode: FailMode) -> RequestCtx {
+        let mut ctx = make_ctx();
+        ctx.tier_policy = Arc::new(TierPolicy {
+            fail_mode,
+            ddos_threshold_rps: 1000,
+            cache_policy: CachePolicy::NoCache,
+            risk_thresholds: RiskThresholds {
+                allow: 30,
+                challenge: 70,
+                block: 90,
+            },
+        });
+        ctx
+    }
+
+    #[tokio::test]
+    async fn degraded_fail_open_unknown_actor_allowed() {
+        let scorer = make_degraded_scorer(0);
+        let ctx = ctx_with_fail_mode(FailMode::Open);
+
+        let result = scorer.score(&ctx, None, &[], None, 1000).await.unwrap();
+        assert_eq!(result.score, 0);
+        assert!(matches!(result.action, WafAction::Allow));
+    }
+
+    #[tokio::test]
+    async fn degraded_fail_open_cached_high_score_still_blocks() {
+        let scorer = make_degraded_scorer(95);
+        let ctx = ctx_with_fail_mode(FailMode::Open);
+
+        let result = scorer.score(&ctx, None, &[], None, 1000).await.unwrap();
+        assert_eq!(result.score, 95, "cached score must not be reset by the outage");
+        assert!(matches!(result.action, WafAction::Block { status: 403, .. }));
+    }
+
+    #[tokio::test]
+    async fn degraded_fail_close_blocks_503_even_at_score_zero() {
+        let scorer = make_degraded_scorer(0);
+        let ctx = ctx_with_fail_mode(FailMode::Close);
+
+        let result = scorer.score(&ctx, None, &[], None, 1000).await.unwrap();
+        assert!(matches!(
+            result.action,
+            WafAction::Block {
+                status: 503,
+                body: None
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn healthy_store_ignores_fail_close() {
+        let store = Arc::new(MemoryRiskStore::new());
+        let cfg = RiskConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let swap = Arc::new(ArcSwap::from(Arc::new(cfg)));
+        let scorer = Scorer::new(store, swap);
+        let ctx = ctx_with_fail_mode(FailMode::Close);
+
+        let result = scorer.score(&ctx, None, &[], None, 1000).await.unwrap();
+        assert!(
+            matches!(result.action, WafAction::Allow),
+            "fail_mode must only apply during store degradation"
+        );
     }
 
     #[tokio::test]

--- a/crates/waf-engine/src/risk/store/conformance.rs
+++ b/crates/waf-engine/src/risk/store/conformance.rs
@@ -22,6 +22,7 @@ pub async fn run_all<S: RiskStore>(store: &S) {
     test_apply_divergent_score_convergence(store).await;
     test_apply_converges_axes(store).await;
     test_decay_contributor_roundtrip(store).await;
+    test_oversized_batch_clamps_to_cap(store).await;
     test_clear_removes_all_axes(store).await;
     test_admin_credit_reduces_score(store).await;
     test_reset_all(store).await;
@@ -231,6 +232,90 @@ pub async fn test_decay_contributor_roundtrip<S: RiskStore>(store: &S) {
     );
 }
 
+/// A single apply whose deltas sum past the score cap must clamp the visible
+/// score to 100 while the negative credit contributor still round-trips.
+async fn test_oversized_batch_clamps_to_cap<S: RiskStore>(store: &S) {
+    store.reset_all().await.unwrap();
+
+    let key = RiskKey::from_ip(IpAddr::V4(Ipv4Addr::new(10, 11, 11, 11)));
+    let deltas = vec![
+        make_contributor(60, 1000),
+        make_contributor(60, 1000),
+        Contributor::new(ContributorKind::AdminCredit, -20, 1000),
+        make_contributor(30, 1000),
+    ];
+    let result = store.apply(&key, &deltas, 1000).await.unwrap();
+    assert_eq!(result.state.clamped_score, 100, "visible score must clamp at 100");
+
+    let state = store.read(&key).await.unwrap().expect("state must persist");
+    assert_eq!(state.clamped_score, 100);
+    assert!(
+        state
+            .contributors
+            .iter()
+            .any(|c| matches!(c.kind, ContributorKind::AdminCredit)),
+        "credit contributor must survive the round-trip"
+    );
+}
+
+/// Decay must honor a non-default configured rate.
+///
+/// Call with a store built with `decay_rate = 3` and otherwise-default decay
+/// settings (memory: `MemoryRiskStore::with_decay`, redis: `RedisRiskConfig.decay`).
+pub async fn test_decay_honors_configured_rate<S: RiskStore>(store: &S) {
+    use crate::risk::decay::{MAX_DECAY, MIN_CLEAN_STREAK};
+
+    store.reset_all().await.unwrap();
+
+    let key = RiskKey::from_ip(IpAddr::V4(Ipv4Addr::new(10, 12, 12, 12)));
+    let seed = i16::try_from(MAX_DECAY).unwrap() + 40;
+    store.apply(&key, &[make_contributor(seed, 1000)], 1000).await.unwrap();
+
+    // Build the clean streak; decay checks the streak BEFORE folding, so no
+    // decay fires while the streak climbs to the threshold.
+    let mut now_ms = 1000;
+    for _ in 0..MIN_CLEAN_STREAK {
+        now_ms += 1000;
+        store.apply(&key, &[], now_ms).await.unwrap();
+    }
+
+    now_ms += 1000;
+    let result = store.apply(&key, &[], now_ms).await.unwrap();
+    assert_eq!(
+        i32::from(result.state.clamped_score),
+        i32::from(seed) - 3,
+        "decay must subtract the configured rate, not the default"
+    );
+}
+
+/// A store built with `decay_rate = 0` must never decay, no matter how long
+/// the clean streak grows.
+pub async fn test_decay_disabled_when_rate_zero<S: RiskStore>(store: &S) {
+    store.reset_all().await.unwrap();
+
+    let key = RiskKey::from_ip(IpAddr::V4(Ipv4Addr::new(10, 13, 13, 13)));
+    store.apply(&key, &[make_contributor(90, 1000)], 1000).await.unwrap();
+
+    let mut now_ms = 1000;
+    for _ in 0..30 {
+        now_ms += 1000;
+        let result = store.apply(&key, &[], now_ms).await.unwrap();
+        assert_eq!(
+            result.state.clamped_score, 90,
+            "decay_rate 0 must leave the score untouched"
+        );
+    }
+
+    let state = store.read(&key).await.unwrap().expect("state must persist");
+    assert!(
+        !state
+            .contributors
+            .iter()
+            .any(|c| matches!(c.kind, ContributorKind::Decay)),
+        "decay_rate 0 must not append Decay contributors"
+    );
+}
+
 /// Admin clear must remove the state so no axis resurrects the old score.
 pub async fn test_clear_removes_all_axes<S: RiskStore>(store: &S) {
     store.reset_all().await.unwrap();
@@ -334,11 +419,30 @@ async fn test_purge_expired<S: RiskStore>(store: &S) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::risk::config::DecayConfig;
     use crate::risk::store::MemoryRiskStore;
 
     #[tokio::test]
     async fn memory_store_passes_conformance() {
         let store = MemoryRiskStore::new();
         run_all(&store).await;
+    }
+
+    #[tokio::test]
+    async fn memory_store_decay_honors_configured_rate() {
+        let store = MemoryRiskStore::with_decay(DecayConfig {
+            decay_rate: 3,
+            ..Default::default()
+        });
+        test_decay_honors_configured_rate(&store).await;
+    }
+
+    #[tokio::test]
+    async fn memory_store_decay_disabled_when_rate_zero() {
+        let store = MemoryRiskStore::with_decay(DecayConfig {
+            decay_rate: 0,
+            ..Default::default()
+        });
+        test_decay_disabled_when_rate_zero(&store).await;
     }
 }

--- a/crates/waf-engine/src/risk/store/memory.rs
+++ b/crates/waf-engine/src/risk/store/memory.rs
@@ -14,6 +14,7 @@ use parking_lot::RwLock;
 use tokio::time::interval;
 use tracing::{debug, info};
 
+use crate::risk::config::DecayConfig;
 use crate::risk::decay::apply_decay;
 use crate::risk::key::RiskKey;
 use crate::risk::score::fold;
@@ -28,15 +29,23 @@ pub struct MemoryRiskStore {
     by_ip: DashMap<IpAddr, StateRef>,
     by_fp: DashMap<u64, StateRef>,
     by_session: DashMap<Vec<u8>, StateRef>,
+    decay: DecayConfig,
 }
 
 impl MemoryRiskStore {
     #[must_use]
     pub fn new() -> Self {
+        Self::with_decay(DecayConfig::default())
+    }
+
+    /// Build a store whose decay follows the given config instead of defaults.
+    #[must_use]
+    pub fn with_decay(decay: DecayConfig) -> Self {
         Self {
             by_ip: DashMap::new(),
             by_fp: DashMap::new(),
             by_session: DashMap::new(),
+            decay,
         }
     }
 
@@ -151,7 +160,7 @@ impl RiskStore for MemoryRiskStore {
             let mut state = state_ref.write();
             // Decay BEFORE fold (FR-025 §4): read state → decay → fold new deltas
             if !is_new {
-                apply_decay(&mut state, now_ms);
+                apply_decay(&mut state, now_ms, &self.decay);
             }
             fold(&mut state, deltas, now_ms);
         }

--- a/crates/waf-engine/src/risk/store/memory.rs
+++ b/crates/waf-engine/src/risk/store/memory.rs
@@ -133,6 +133,7 @@ impl RiskStore for MemoryRiskStore {
             return Ok(ApplyResult {
                 state: RiskState::new(now_ms),
                 is_new: true,
+                degraded: false,
             });
         }
 
@@ -161,7 +162,11 @@ impl RiskStore for MemoryRiskStore {
         }
 
         let state = state_ref.read().clone();
-        Ok(ApplyResult { state, is_new })
+        Ok(ApplyResult {
+            state,
+            is_new,
+            degraded: false,
+        })
     }
 
     #[allow(clippy::option_if_let_else)]

--- a/crates/waf-engine/src/risk/store/redis.rs
+++ b/crates/waf-engine/src/risk/store/redis.rs
@@ -29,7 +29,7 @@ use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use super::redis_lua::{APPLY_SCRIPT, CLEAR_SCRIPT, FORCE_MAX_SCRIPT};
-use crate::risk::decay::{DECAY_RATE, MAX_DECAY, MIN_CLEAN_STREAK};
+use crate::risk::config::DecayConfig;
 use crate::risk::key::RiskKey;
 use crate::risk::state::{Contributor, RiskState};
 use crate::risk::store::store_trait::{ApplyResult, RiskStore};
@@ -49,6 +49,8 @@ pub struct RedisRiskConfig {
     pub breaker_threshold: u32,
     /// LRU cache capacity for fail-open fallback (default: 10000).
     pub cache_capacity: usize,
+    /// Decay parameters fed into the Lua apply script.
+    pub decay: DecayConfig,
 }
 
 impl Default for RedisRiskConfig {
@@ -60,6 +62,7 @@ impl Default for RedisRiskConfig {
             op_timeout: Duration::from_millis(100),
             breaker_threshold: 5,
             cache_capacity: 10_000,
+            decay: DecayConfig::default(),
         }
     }
 }
@@ -367,9 +370,9 @@ impl RiskStore for RedisRiskStore {
             .arg(now_ms)
             .arg(&deltas_json)
             .arg(self.cfg.ttl_secs)
-            .arg(MIN_CLEAN_STREAK)
-            .arg(DECAY_RATE)
-            .arg(MAX_DECAY);
+            .arg(self.cfg.decay.min_clean_streak)
+            .arg(self.cfg.decay.decay_rate)
+            .arg(self.cfg.decay.max_decay);
 
         let res = timeout(self.cfg.op_timeout, invocation.invoke_async::<String>(&mut conn)).await;
 
@@ -663,6 +666,7 @@ mod tests {
             op_timeout: Duration::from_nanos(1),
             breaker_threshold: 5,
             cache_capacity: 100,
+            decay: DecayConfig::default(),
         })
         .await
         .expect("connect to REDIS_TEST_URL");
@@ -705,6 +709,7 @@ mod tests {
             op_timeout: Duration::from_millis(500),
             breaker_threshold: 5,
             cache_capacity: 100,
+            decay: DecayConfig::default(),
         })
         .await
         .expect("connect to REDIS_TEST_URL");
@@ -741,6 +746,7 @@ mod tests {
             op_timeout: Duration::from_millis(500),
             breaker_threshold: 5,
             cache_capacity: 100,
+            decay: DecayConfig::default(),
         })
         .await
         .expect("connect to REDIS_TEST_URL");

--- a/crates/waf-engine/src/risk/store/redis.rs
+++ b/crates/waf-engine/src/risk/store/redis.rs
@@ -196,6 +196,13 @@ impl RedisRiskStore {
         self.cache.lock().get(&cache_key).map(|e| e.state.clone())
     }
 
+    /// Best-known substitute when Redis is unreachable: the last cached state
+    /// for this actor, else a fresh zero state. Always flagged `degraded` so
+    /// the caller applies its fail-mode policy instead of trusting the score.
+    fn degraded_apply_result(&self, key: &RiskKey, now_ms: i64) -> ApplyResult {
+        degraded_substitute(self.cache_lookup(key), now_ms)
+    }
+
     /// Update LRU cache with new state.
     fn cache_update(&self, key: &RiskKey, owner_id: &str, state: &RiskState) {
         let cache_key = Self::cache_key(key);
@@ -275,6 +282,24 @@ impl RedisRiskStore {
     }
 }
 
+/// Build the degraded `ApplyResult` from an optional cached state: the last
+/// known state when present (`is_new: false`), else a fresh zero state.
+/// `degraded` is always `true` — the score is a substitute, not authority.
+fn degraded_substitute(cached: Option<RiskState>, now_ms: i64) -> ApplyResult {
+    cached.map_or_else(
+        || ApplyResult {
+            state: RiskState::new(now_ms),
+            is_new: true,
+            degraded: true,
+        },
+        |state| ApplyResult {
+            state,
+            is_new: false,
+            degraded: true,
+        },
+    )
+}
+
 /// Response from apply Lua script.
 #[derive(serde::Deserialize)]
 struct ApplyResponse {
@@ -312,10 +337,9 @@ impl RiskStore for RedisRiskStore {
                 }
                 Ok(max_state.map(|(_, state)| state))
             }
-            Err(e) => {
-                warn!(error = %e, "risk redis: read failed, checking cache");
-                Ok(self.cache_lookup(key))
-            }
+            // Faithful error: read is advisory (not on the enforcement gate),
+            // so callers must see the outage instead of a stale cache value.
+            Err(e) => Err(e.context("risk redis: read")),
         }
     }
 
@@ -324,6 +348,7 @@ impl RiskStore for RedisRiskStore {
             return Ok(ApplyResult {
                 state: RiskState::new(now_ms),
                 is_new: true,
+                degraded: false,
             });
         }
 
@@ -357,29 +382,18 @@ impl RiskStore for RedisRiskStore {
                 Ok(ApplyResult {
                     state: response.state,
                     is_new: response.is_new,
+                    degraded: false,
                 })
             }
             Ok(Err(e)) => {
                 self.record_fail();
-                warn!(error = %e, "risk redis: apply failed, using cache fallback");
-                if let Some(state) = self.cache_lookup(key) {
-                    return Ok(ApplyResult { state, is_new: false });
-                }
-                Ok(ApplyResult {
-                    state: RiskState::new(now_ms),
-                    is_new: true,
-                })
+                warn!(error = %e, "risk redis: apply failed, degraded fallback");
+                Ok(self.degraded_apply_result(key, now_ms))
             }
             Err(_) => {
                 self.record_fail();
-                warn!("risk redis: apply timeout, using cache fallback");
-                if let Some(state) = self.cache_lookup(key) {
-                    return Ok(ApplyResult { state, is_new: false });
-                }
-                Ok(ApplyResult {
-                    state: RiskState::new(now_ms),
-                    is_new: true,
-                })
+                warn!("risk redis: apply timeout, degraded fallback");
+                Ok(self.degraded_apply_result(key, now_ms))
             }
         }
     }
@@ -602,6 +616,67 @@ mod tests {
         cache.push("a".to_string(), cache_entry("owner-a2"));
         assert_eq!(cache.len(), 2);
         assert_eq!(cache.get(&"a".to_string()).unwrap().owner_id, "owner-a2");
+    }
+
+    #[test]
+    fn degraded_substitute_keeps_cached_score() {
+        let mut cached = RiskState::new(0);
+        cached.clamped_score = 87;
+
+        let result = degraded_substitute(Some(cached), 5000);
+        assert!(result.degraded, "cache hit during outage is still degraded");
+        assert!(!result.is_new);
+        assert_eq!(
+            result.state.clamped_score, 87,
+            "last known score must survive the outage"
+        );
+    }
+
+    #[test]
+    fn degraded_substitute_without_cache_is_flagged_not_authoritative() {
+        let result = degraded_substitute(None, 5000);
+        assert!(
+            result.degraded,
+            "fresh zero state during outage must carry the degraded flag"
+        );
+        assert!(result.is_new);
+        assert_eq!(result.state.clamped_score, 0);
+    }
+
+    /// Timeout arm of `apply` + faithful `read` error — runs only when
+    /// `REDIS_TEST_URL` is set. A 1ns op timeout forces every round-trip
+    /// through the failure arms against a real server.
+    #[tokio::test]
+    async fn outage_apply_degrades_and_read_errors() {
+        use crate::risk::key::RiskKey;
+        use std::net::Ipv4Addr;
+
+        let Ok(url) = std::env::var("REDIS_TEST_URL") else {
+            tracing::info!("skipping: REDIS_TEST_URL unset");
+            return;
+        };
+
+        let store = RedisRiskStore::new(RedisRiskConfig {
+            url,
+            key_prefix: unique_prefix(),
+            ttl_secs: 3600,
+            op_timeout: Duration::from_nanos(1),
+            breaker_threshold: 5,
+            cache_capacity: 100,
+        })
+        .await
+        .expect("connect to REDIS_TEST_URL");
+
+        let key = RiskKey::from_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 101)));
+
+        let result = store.apply(&key, &[], 1000).await.unwrap();
+        assert!(result.degraded, "timed-out apply must be flagged degraded");
+        assert_eq!(result.state.clamped_score, 0);
+
+        assert!(
+            store.read(&key).await.is_err(),
+            "read must surface the outage, not the cache"
+        );
     }
 
     fn unique_prefix() -> String {

--- a/crates/waf-engine/src/risk/store/store_trait.rs
+++ b/crates/waf-engine/src/risk/store/store_trait.rs
@@ -16,6 +16,11 @@ pub struct ApplyResult {
     pub state: RiskState,
     /// True if this was a new entry (not an update to existing).
     pub is_new: bool,
+    /// True when the backend could not reach its authority and `state` is a
+    /// best-known substitute (last cached value or a fresh zero state). Set
+    /// only by backends that can transiently fail; callers must apply their
+    /// fail-mode policy instead of trusting the score as authoritative.
+    pub degraded: bool,
 }
 
 /// Async trait for risk state storage.
@@ -157,6 +162,7 @@ mod tests {
             Ok(ApplyResult {
                 state: RiskState::new(now_ms),
                 is_new: true,
+                degraded: false,
             })
         }
 
@@ -231,6 +237,7 @@ mod tests {
         let r = ApplyResult {
             state: RiskState::new(42),
             is_new: true,
+            degraded: false,
         };
         let r2 = r.clone();
         assert_eq!(r2.state.created_ms, 42);

--- a/crates/waf-engine/src/risk/tests/canary.rs
+++ b/crates/waf-engine/src/risk/tests/canary.rs
@@ -267,6 +267,110 @@ async fn partial_path_match_does_not_trigger() {
 }
 
 #[tokio::test]
+async fn seed_scored_ip_still_hits_canary() {
+    // A seed-scored IP (Tor exit) hitting a canary path must be blocked —
+    // the seed Score classification must not short-circuit past the canary
+    // check the way the whitelist does.
+
+    let store = Arc::new(MemoryRiskStore::new());
+    let ban_table = Arc::new(DynamicBanTable::new());
+
+    let cfg = RiskConfig {
+        enabled: true,
+        canary: CanaryConfig {
+            enabled: true,
+            paths: vec!["/admin-test".to_string()],
+            ban_ttl_secs: 3600,
+        },
+        ..Default::default()
+    };
+    let swap = Arc::new(ArcSwap::from(Arc::new(cfg)));
+
+    // Seed table classifies the client IP as a Tor exit → SeedVerdict::Score.
+    let ctx = make_ctx("/admin-test");
+    let mut builder = SeedTablesBuilder::new();
+    builder.add_tor_exit(ctx.client_ip);
+    let tables = Arc::new(ArcSwapSeed::from(Arc::new(builder.build())));
+    let seed = Arc::new(SeedLayer::new(tables, SeedDeltas::default()));
+
+    let canary = Arc::new(CanaryLayer::with_ban_table(
+        vec!["/admin-test".to_string()],
+        Arc::clone(&ban_table),
+        3600,
+    ));
+
+    let mut scorer = Scorer::new(store, swap);
+    scorer.set_seed(seed);
+    scorer.set_canary(canary);
+
+    let now_ms = 1_000_000;
+    let result = scorer.score(&ctx, None, &[], None, now_ms).await.unwrap();
+
+    // Canary must fire despite the seed Score classification.
+    assert!(
+        matches!(result.action, WafAction::Block { .. }),
+        "Tor-exit IP on a canary path must be blocked"
+    );
+    assert_eq!(result.score, 100);
+    assert!(ban_table.contains(ctx.client_ip, now_ms));
+
+    // force_max pinned the actor: a later normal request still reads 100.
+    let normal_ctx = make_ctx("/normal-path");
+    let result2 = scorer.score(&normal_ctx, None, &[], None, now_ms + 1000).await.unwrap();
+    assert_eq!(result2.score, 100, "canary pin must persist in the store");
+}
+
+#[tokio::test]
+async fn seed_scored_ip_on_normal_path_accrues_seed_delta() {
+    // The seed contributor must still reach scoring on the non-canary path —
+    // guards against the canary reorder dropping the seed delta.
+
+    let store = Arc::new(MemoryRiskStore::new());
+    let ban_table = Arc::new(DynamicBanTable::new());
+
+    let cfg = RiskConfig {
+        enabled: true,
+        canary: CanaryConfig {
+            enabled: true,
+            paths: vec!["/admin-test".to_string()],
+            ban_ttl_secs: 3600,
+        },
+        ..Default::default()
+    };
+    let swap = Arc::new(ArcSwap::from(Arc::new(cfg)));
+
+    let ctx = make_ctx("/normal-path");
+    let mut builder = SeedTablesBuilder::new();
+    builder.add_tor_exit(ctx.client_ip);
+    let tables = Arc::new(ArcSwapSeed::from(Arc::new(builder.build())));
+    let seed = Arc::new(SeedLayer::new(tables, SeedDeltas::default()));
+
+    let canary = Arc::new(CanaryLayer::with_ban_table(
+        vec!["/admin-test".to_string()],
+        Arc::clone(&ban_table),
+        3600,
+    ));
+
+    let mut scorer = Scorer::new(store, swap);
+    scorer.set_seed(seed);
+    scorer.set_canary(canary);
+
+    let now_ms = 1_000_000;
+    let result = scorer.score(&ctx, None, &[], None, now_ms).await.unwrap();
+
+    assert!(
+        !matches!(result.action, WafAction::Block { .. }),
+        "non-canary path must not block on the seed delta alone"
+    );
+    assert_eq!(
+        result.score,
+        SeedDeltas::default().tor_exit,
+        "seed delta must accrue on the non-canary path"
+    );
+    assert!(!ban_table.contains(ctx.client_ip, now_ms));
+}
+
+#[tokio::test]
 async fn whitelist_bypasses_canary() {
     // Test that seed whitelist short-circuits BEFORE canary check
     // A whitelisted IP hitting a canary path should be allowed, not blocked

--- a/crates/waf-engine/src/risk/tests/conformance_redis.rs
+++ b/crates/waf-engine/src/risk/tests/conformance_redis.rs
@@ -7,7 +7,8 @@
 
 use std::time::Duration;
 
-use crate::risk::store::conformance::run_all;
+use crate::risk::config::DecayConfig;
+use crate::risk::store::conformance::{run_all, test_decay_disabled_when_rate_zero, test_decay_honors_configured_rate};
 use crate::risk::store::redis::{RedisRiskConfig, RedisRiskStore};
 
 fn unique_prefix() -> String {
@@ -32,11 +33,64 @@ async fn redis_store_passes_conformance() {
         op_timeout: Duration::from_millis(500),
         breaker_threshold: 5,
         cache_capacity: 1000,
+        decay: DecayConfig::default(),
     })
     .await
     .expect("connect to REDIS_TEST_URL");
 
     run_all(&store).await;
+}
+
+/// The Lua apply script must decay by the configured rate, not the default.
+#[tokio::test]
+async fn redis_decay_honors_configured_rate() {
+    let Ok(url) = std::env::var("REDIS_TEST_URL") else {
+        tracing::info!("skipping: REDIS_TEST_URL unset");
+        return;
+    };
+
+    let store = RedisRiskStore::new(RedisRiskConfig {
+        url,
+        key_prefix: unique_prefix(),
+        ttl_secs: 3600,
+        op_timeout: Duration::from_millis(500),
+        breaker_threshold: 5,
+        cache_capacity: 1000,
+        decay: DecayConfig {
+            decay_rate: 3,
+            ..Default::default()
+        },
+    })
+    .await
+    .expect("connect to REDIS_TEST_URL");
+
+    test_decay_honors_configured_rate(&store).await;
+}
+
+/// The Lua apply script must not decay at all when `decay_rate` is 0.
+#[tokio::test]
+async fn redis_decay_disabled_when_rate_zero() {
+    let Ok(url) = std::env::var("REDIS_TEST_URL") else {
+        tracing::info!("skipping: REDIS_TEST_URL unset");
+        return;
+    };
+
+    let store = RedisRiskStore::new(RedisRiskConfig {
+        url,
+        key_prefix: unique_prefix(),
+        ttl_secs: 3600,
+        op_timeout: Duration::from_millis(500),
+        breaker_threshold: 5,
+        cache_capacity: 1000,
+        decay: DecayConfig {
+            decay_rate: 0,
+            ..Default::default()
+        },
+    })
+    .await
+    .expect("connect to REDIS_TEST_URL");
+
+    test_decay_disabled_when_rate_zero(&store).await;
 }
 
 /// Test that multiple applies accumulate correctly.
@@ -58,6 +112,7 @@ async fn redis_apply_accumulates_score() {
         op_timeout: Duration::from_millis(500),
         breaker_threshold: 5,
         cache_capacity: 1000,
+        decay: DecayConfig::default(),
     })
     .await
     .expect("connect");
@@ -101,6 +156,7 @@ async fn redis_triple_key_converges() {
         op_timeout: Duration::from_millis(500),
         breaker_threshold: 5,
         cache_capacity: 1000,
+        decay: DecayConfig::default(),
     })
     .await
     .expect("connect");
@@ -163,6 +219,7 @@ async fn redis_force_max_pins_score() {
         op_timeout: Duration::from_millis(500),
         breaker_threshold: 5,
         cache_capacity: 1000,
+        decay: DecayConfig::default(),
     })
     .await
     .expect("connect");
@@ -203,6 +260,7 @@ async fn redis_reset_all_clears_store() {
         op_timeout: Duration::from_millis(500),
         breaker_threshold: 5,
         cache_capacity: 1000,
+        decay: DecayConfig::default(),
     })
     .await
     .expect("connect");

--- a/crates/waf-engine/src/risk/tests/lifecycle.rs
+++ b/crates/waf-engine/src/risk/tests/lifecycle.rs
@@ -200,7 +200,7 @@ fn decay_respects_max_decay_floor() {
     // Decay should bring score down but not below MAX_DECAY
     for i in 0..20 {
         let ts = 2000 + i64::from(i) * 100;
-        apply_decay(&mut state, ts);
+        apply_decay(&mut state, ts, &crate::risk::config::DecayConfig::default());
     }
 
     assert!(

--- a/crates/waf-engine/src/risk/tests/redis_failover.rs
+++ b/crates/waf-engine/src/risk/tests/redis_failover.rs
@@ -7,6 +7,7 @@
 
 use std::time::Duration;
 
+use crate::risk::config::DecayConfig;
 use crate::risk::key::RiskKey;
 use crate::risk::state::{Contributor, ContributorKind, SeedKind};
 use crate::risk::store::RiskStore;
@@ -40,6 +41,7 @@ async fn cache_fallback_on_redis_failure() {
         op_timeout: Duration::from_millis(500),
         breaker_threshold: 5,
         cache_capacity: 1000,
+        decay: DecayConfig::default(),
     })
     .await
     .expect("connect");
@@ -154,6 +156,7 @@ async fn len_counts_state_keys() {
         op_timeout: Duration::from_millis(500),
         breaker_threshold: 5,
         cache_capacity: 1000,
+        decay: DecayConfig::default(),
     })
     .await
     .expect("connect");
@@ -191,6 +194,7 @@ async fn concurrent_applies_are_safe() {
             op_timeout: Duration::from_millis(500),
             breaker_threshold: 5,
             cache_capacity: 1000,
+            decay: DecayConfig::default(),
         })
         .await
         .expect("connect"),

--- a/crates/waf-engine/src/risk/threshold.rs
+++ b/crates/waf-engine/src/risk/threshold.rs
@@ -4,7 +4,7 @@
 //! thresholds. Uses the tier's `RiskThresholds` (allow, challenge, block).
 
 use waf_common::WafAction;
-use waf_common::tier::RiskThresholds;
+use waf_common::tier::{FailMode, RiskThresholds};
 
 /// Decide the action based on the score and thresholds.
 ///
@@ -38,6 +38,26 @@ pub fn decide(score: u8, thresholds: &RiskThresholds, override_block: bool) -> W
     WafAction::Challenge
 }
 
+/// Decide the action when the risk store is degraded (backend unreachable).
+///
+/// The score is a best-known substitute, not authority, so the tier's
+/// declared fail mode picks the policy:
+///
+/// - `FailMode::Open`  → [`decide`] on the best-known score: a cached high
+///   score still defends; an unknown actor (score 0) is allowed.
+/// - `FailMode::Close` → `Block { 503 }` regardless of score — never trust
+///   a stale or absent score on a fail-closed tier.
+#[must_use]
+pub fn degraded_action(fail_mode: FailMode, score: u8, thresholds: &RiskThresholds, override_block: bool) -> WafAction {
+    match fail_mode {
+        FailMode::Open => decide(score, thresholds, override_block),
+        FailMode::Close => WafAction::Block {
+            status: 503,
+            body: None,
+        },
+    }
+}
+
 /// Check if a score would result in Allow.
 #[must_use]
 pub const fn is_allowed(score: u8, thresholds: &RiskThresholds) -> bool {
@@ -67,6 +87,63 @@ mod tests {
             challenge: 70,
             block: 90,
         }
+    }
+
+    #[test]
+    fn degraded_open_trusts_best_known_score_across_bands() {
+        let t = default_thresholds();
+        // Same mapping as `decide` in every band: unknown actor allowed,
+        // cached mid score challenged, cached high score blocked.
+        assert!(matches!(
+            degraded_action(FailMode::Open, 0, &t, false),
+            WafAction::Allow
+        ));
+        assert!(matches!(
+            degraded_action(FailMode::Open, 29, &t, false),
+            WafAction::Allow
+        ));
+        assert!(matches!(
+            degraded_action(FailMode::Open, 30, &t, false),
+            WafAction::Challenge
+        ));
+        assert!(matches!(
+            degraded_action(FailMode::Open, 89, &t, false),
+            WafAction::Challenge
+        ));
+        assert!(matches!(
+            degraded_action(FailMode::Open, 90, &t, false),
+            WafAction::Block { status: 403, .. }
+        ));
+        assert!(matches!(
+            degraded_action(FailMode::Open, 100, &t, false),
+            WafAction::Block { status: 403, .. }
+        ));
+        // Pinned actor blocks even at a low cached score.
+        assert!(matches!(
+            degraded_action(FailMode::Open, 0, &t, true),
+            WafAction::Block { status: 403, .. }
+        ));
+    }
+
+    #[test]
+    fn degraded_close_blocks_503_regardless_of_score() {
+        let t = default_thresholds();
+        for score in [0u8, 29, 30, 89, 90, 100] {
+            assert!(
+                matches!(
+                    degraded_action(FailMode::Close, score, &t, false),
+                    WafAction::Block {
+                        status: 503,
+                        body: None
+                    }
+                ),
+                "fail-closed tier must block at score {score}"
+            );
+        }
+        assert!(matches!(
+            degraded_action(FailMode::Close, 0, &t, true),
+            WafAction::Block { status: 503, .. }
+        ));
     }
 
     #[test]

--- a/docs/journals/2026-07-05-gh-200-canary-before-seed-early-return-implementation.md
+++ b/docs/journals/2026-07-05-gh-200-canary-before-seed-early-return-implementation.md
@@ -1,0 +1,44 @@
+# 2026-07-05 — GH-200: canary before seed early-return (implementation)
+
+## What
+
+`Scorer::score` evaluated the L0 seed layer first, and the `SeedVerdict::Score`
+arm returned early into `score_with_l2` — skipping the canary honeypot block
+entirely for exactly the IPs most likely to probe honeypot paths (Tor exits,
+datacenter/bad ASNs). A Tor-exit scanner hitting `/admin-test` accrued a +30
+seed delta instead of the documented force_max + ban + 403.
+
+Fix is a pure intra-function reorder in `crates/waf-engine/src/risk/scorer.rs`:
+
+- Seed verdict is evaluated once into a local (`SeedVerdict::None` when the
+  layer is absent or disabled).
+- `Whitelisted` still returns Allow immediately — before canary, unchanged.
+- The canary block now runs unconditionally for every non-whitelisted request.
+- A tail `match` folds the seed contributor into `score_with_l2` on the
+  `Score` path; `None` passes the caller deltas through as before.
+
+No signature or public API change; ordering comment updated to match.
+
+## How it was verified
+
+- New `seed_scored_ip_still_hits_canary` (risk/tests/canary.rs): Tor-exit IP
+  on a canary path → `Block`, score 100, ban-table entry, and pin persists on
+  a later normal request. **Verified to fail on the unpatched scorer** (git
+  stash of scorer.rs → test fails; pop → passes), so it genuinely guards the
+  ordering.
+- New `seed_scored_ip_on_normal_path_accrues_seed_delta`: non-canary path
+  still accrues the tor_exit delta (30) — guards against the reorder dropping
+  the seed contributor.
+- `cargo test -p waf-engine --lib risk`: 239 passed (5 failures are the
+  pre-established docker-gated `engine::tests` testcontainer set).
+- `cargo clippy -p waf-engine --all-targets` clean; `cargo fmt --all --check`
+  clean. `whitelist_bypasses_canary` and
+  `canary_path_triggers_block_and_score_100` unchanged and green.
+
+## Gotchas
+
+- `ScorerResult.score` is `u8` — compare against `SeedDeltas::default().tor_exit`
+  directly, no widening.
+- The whitelist return must stay above the canary block; the mirror test pair
+  (`whitelist_bypasses_canary` / `seed_scored_ip_still_hits_canary`) now locks
+  the ordering in both directions.

--- a/docs/journals/2026-07-05-gh-201-redis-failmode-policy-implementation.md
+++ b/docs/journals/2026-07-05-gh-201-redis-failmode-policy-implementation.md
@@ -1,0 +1,58 @@
+# 2026-07-05 — GH-201: redis fail-mode policy (implementation)
+
+## What
+
+A Redis outage silently faked health: `RedisRiskStore::apply` swallowed
+errors/timeouts and returned a cache-hit or fresh zero state with no signal,
+and `read` fabricated `Ok(cached)` on failure. `TierPolicy.fail_mode` was
+never consulted — a fail-closed tier stayed wide open during an outage.
+
+Three-part fix:
+
+- **Store signaling** (`store_trait.rs`, `redis.rs`, `memory.rs`):
+  `ApplyResult` gains `degraded: bool`. The redis error/timeout arms return
+  the best-known substitute (last cached state, else fresh zero state) via
+  `degraded_substitute`, always flagged `degraded: true`. `read` now returns
+  the error faithfully (it is advisory — no production callers; verified by
+  grep). Memory store always sets `degraded: false`.
+- **Policy** (`threshold.rs`): pure `degraded_action(fail_mode, score,
+  thresholds, override_block)` — `Open` → normal `decide` on the best-known
+  score (a cached high score still defends), `Close` → `Block { 503, None }`
+  (parity with the DDoS degrade path).
+- **Scorer wiring** (`scorer.rs`): `score_with_l2` branches on
+  `result.degraded`, logs `warn!(target: "risk::degrade", ...)` with client
+  IP, fail mode, and score, then routes through `degraded_action`.
+
+The plan's optional breaker fast-fail short-circuit was deliberately dropped:
+short-circuiting at the top of `apply` would prevent `record_ok` from ever
+firing after Redis recovers, latching the breaker open permanently.
+
+## How it was verified
+
+- Pure unit tests for `degraded_substitute` (cached score survives, fresh
+  state flagged) and exhaustive `degraded_action` band tests (Open across
+  allow/challenge/block/pinned; Close always 503).
+- Deterministic mock-store acceptance tests in scorer tests (`DegradedStore`
+  whose `apply` always returns `degraded: true`): Open + score 0 → Allow;
+  Open + cached 95 → Block 403 (no score reset); Close + score 0 → Block 503;
+  healthy `MemoryRiskStore` + Close tier → Allow (fail_mode only applies
+  during degradation). The 503 assertion can only come from the new path —
+  `decide` never emits 503.
+- `REDIS_TEST_URL`-gated test drives the real timeout arm (1ns `op_timeout`
+  against a live server) → `degraded: true` + `read` → `Err`.
+- `cargo test -p waf-engine --lib --features redis-store "risk::"`: 260
+  passed, 0 failed (docker-gated `engine::tests` set excluded as
+  pre-established). Existing `redis_failover` suite unchanged and green.
+- `cargo clippy --all-targets --features redis-store` clean;
+  `cargo fmt --all --check` clean.
+
+## Gotchas
+
+- `RedisRiskStore::new` PINGs on construction, so an unreachable-URL store
+  cannot be built in the default test suite — that is why the degraded logic
+  is factored into the pure `degraded_substitute` free function and the
+  outage test is REDIS_TEST_URL-gated instead.
+- The redis store module is behind the `redis-store` cargo feature; a bare
+  `cargo test risk::store` silently skips it (13 vs 21 tests).
+- clippy pedantic `similar_names` fires on `store`/`score` bindings in the
+  same fn.

--- a/docs/journals/2026-07-05-gh-204-risk-delta-cap-decay-config-implementation.md
+++ b/docs/journals/2026-07-05-gh-204-risk-delta-cap-decay-config-implementation.md
@@ -1,0 +1,58 @@
+# 2026-07-05 — GH-204: risk per-request delta cap + configurable decay + config validation
+
+## What
+
+Three fixes on branch `fix/gh-204-risk-delta-cap-decay-config` (stacked on
+`fix/gh-201-redis-failmode-policy`):
+
+1. **Per-request delta cap enforced.** `clamp_per_request_deltas` existed but was
+   never called. Now wired into both entry points: `Scorer::score_with_l2` (sync
+   path, after seed/anomaly/velocity/credit deltas are gathered) and the ingest
+   worker's `process_job` (async path). Cap bounds one request's positive delta
+   sum to 100 while preserving negative credits; the store fold's total-score
+   clamp is a distinct, complementary op. Canary `force_max` stays uncapped by
+   design (pin, not delta).
+2. **`DecayConfig` honored by both backends.** `apply_decay`/`preview_decay` now
+   take `&DecayConfig` instead of reading the `MAX_DECAY`/`MIN_CLEAN_STREAK`/
+   `DECAY_RATE` consts. `MemoryRiskStore` gains `with_decay(DecayConfig)`
+   (constructor injection — no `RiskStore` trait change); `RedisRiskConfig` gains
+   a `decay` field fed into the Lua apply script ARGVs.
+   `RedisStoreConfig::to_runtime_config(ttl, decay)` and the engine's
+   `build_risk_store` thread the config through both backends. Decay settings are
+   store-lifetime (no hot-reload; YAGNI). `decay_rate: 0` disables decay through
+   the existing arithmetic — no special branch.
+3. **`RiskConfig::validate()` wired into `from_path`.** Rejects `ttl_secs == 0`,
+   `gc_interval_secs == 0` (would panic `tokio::time::interval`),
+   `ingest.channel_capacity == 0` (would panic the bounded mpsc), unknown
+   `store.backend`, and `decay.max_decay > 100`. `decay_rate: 0` and
+   `min_clean_streak: 0` are valid. `reload.rs` is already fail-soft, so a bad
+   YAML edit keeps the previous snapshot. Risk thresholds live in
+   `TierPolicy.risk_thresholds` — out of scope here.
+
+## Verified
+
+- `cargo test -p waf-engine --lib --features redis-store "risk::"` → 273 passed.
+- New tests: scorer end-to-end cap test (160 positive + −20 credit → score 80);
+  conformance `test_oversized_batch_clamps_to_cap` added to `run_all` (both
+  backends); `test_decay_honors_configured_rate` (rate 3) and
+  `test_decay_disabled_when_rate_zero` as pub conformance fns — memory via
+  `with_decay`, redis via `REDIS_TEST_URL`-gated tests; 8 validate() unit tests
+  plus a `from_path` reject-without-panic test.
+- `cargo clippy --workspace --all-targets` and `-p waf-engine --features
+  redis-store` clean; `cargo build -p prx-waf` green.
+- Full lib suite: 1449 passed; 6 `engine::tests::*` failures are the known
+  docker-gated testcontainer set (no docker socket locally; CI covers).
+
+## Gotchas
+
+- **`StoreConfig` derived `Default` yielded `backend: ""`** — inconsistent with
+  the serde default `"memory"`. Harmless before (engine only checks `== "redis"`)
+  but `validate()` exposed it: `RiskConfig::default().validate()` failed. Fixed
+  with a manual `Default` impl using `default_backend()`.
+- The decay consts (`MAX_DECAY` etc.) remain as test/bench references and as the
+  `DecayConfig` default values; runtime reads only the config.
+- sed-inserting the `decay` field after `cache_capacity:` lines also matched the
+  `Default for RedisRiskConfig` impl → duplicate field (E0062). Prefer targeted
+  edits over blanket seds on struct-literal patterns.
+- clippy `too_long_first_doc_paragraph` fires on 3-line first paragraphs — split
+  doc comments with a blank `///` line.

--- a/plans/260705-0958-gh-200-canary-before-seed-early-return/phase-01-reorder-canary-check-before-seed-score-early-return.md
+++ b/plans/260705-0958-gh-200-canary-before-seed-early-return/phase-01-reorder-canary-check-before-seed-score-early-return.md
@@ -1,7 +1,7 @@
 ---
 phase: 1
 title: "Reorder canary check before seed-Score early return"
-status: pending
+status: completed
 priority: P2
 dependencies: []
 effort: 30m
@@ -102,11 +102,11 @@ IPs skip the honeypot trap entirely.
 
 ## Success Criteria
 
-- [ ] `score()` evaluates the canary block for a non-whitelisted seed-Score IP
+- [x] `score()` evaluates the canary block for a non-whitelisted seed-Score IP
       (control-flow verified by reading the reordered function).
-- [ ] Whitelist still returns Allow before canary; `None` path unchanged.
-- [ ] Ordering comment matches the code.
-- [ ] `cargo test -p waf-engine risk` green; no signature changes.
+- [x] Whitelist still returns Allow before canary; `None` path unchanged.
+- [x] Ordering comment matches the code.
+- [x] `cargo test -p waf-engine risk` green; no signature changes.
 
 ## Risk Assessment
 

--- a/plans/260705-0958-gh-200-canary-before-seed-early-return/phase-02-acceptance-test-quality-gates.md
+++ b/plans/260705-0958-gh-200-canary-before-seed-early-return/phase-02-acceptance-test-quality-gates.md
@@ -1,7 +1,7 @@
 ---
 phase: 2
 title: "Acceptance test + quality gates"
-status: pending
+status: completed
 priority: P2
 dependencies: [1]
 effort: 30m
@@ -112,12 +112,12 @@ Notes for the implementer:
 
 ## Success Criteria
 
-- [ ] New test fails on unpatched `scorer.rs` (early return) and passes after
+- [x] New test fails on unpatched `scorer.rs` (early return) and passes after
       Phase 1 — confirms it actually guards the bug.
-- [ ] `Block` + `score == 100` + ban-table entry asserted for the Tor-exit +
+- [x] `Block` + `score == 100` + ban-table entry asserted for the Tor-exit +
       canary-path case.
-- [ ] Non-canary seed-Score path asserted to still accrue the seed delta.
-- [ ] `cargo test -p waf-engine risk` and `cargo clippy -p waf-engine --all-targets` green.
+- [x] Non-canary seed-Score path asserted to still accrue the seed delta.
+- [x] `cargo test -p waf-engine risk` and `cargo clippy -p waf-engine --all-targets` green.
 
 ## Risk Assessment
 

--- a/plans/260705-0958-gh-200-canary-before-seed-early-return/plan.md
+++ b/plans/260705-0958-gh-200-canary-before-seed-early-return/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "GH-200 risk: run canary check before seed-layer early return"
 description: "Fix the seed-Score early return in the scorer that skips the canary honeypot check for Tor/datacenter IPs — restore the documented whitelist → canary → other-layers ordering"
-status: pending
+status: completed
 priority: P2
 issue: https://github.com/future-and-go/mini-waf/issues/200
 branch: "main-harness"
@@ -49,8 +49,8 @@ covered by `whitelist_bypasses_canary`, `risk/tests/canary.rs:269-322`).
 
 | Phase | Name | Status |
 |-------|------|--------|
-| 1 | [Reorder canary check before seed-Score early return](./phase-01-reorder-canary-check-before-seed-score-early-return.md) | Pending |
-| 2 | [Acceptance test + quality gates](./phase-02-acceptance-test-quality-gates.md) | Pending |
+| 1 | [Reorder canary check before seed-Score early return](./phase-01-reorder-canary-check-before-seed-score-early-return.md) | Completed |
+| 2 | [Acceptance test + quality gates](./phase-02-acceptance-test-quality-gates.md) | Completed |
 
 ## Key Decisions
 
@@ -83,8 +83,8 @@ covered by `whitelist_bypasses_canary`, `risk/tests/canary.rs:269-322`).
 
 ## Acceptance Criteria (from issue)
 
-- [ ] Canary check evaluated before (or independently of) the seed early-return. → Phase 1
-- [ ] Test: a seed-classified IP (Tor exit) hitting a canary path gets `force_max`
+- [x] Canary check evaluated before (or independently of) the seed early-return. → Phase 1
+- [x] Test: a seed-classified IP (Tor exit) hitting a canary path gets `force_max`
       + `DynamicBanTable` entry + `Block`. → Phase 2
 
 ## Validation

--- a/plans/260705-0958-gh-201-redis-failmode-policy/plan.md
+++ b/plans/260705-0958-gh-201-redis-failmode-policy/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "GH-201 redis risk store: propagate errors, honor TierPolicy fail_mode on outage"
 description: "Redis store stops silently faking score-0 on outage; apply signals an explicit degraded flag, the Scorer maps store failure to the tier's FailMode (Open → allow with degraded telemetry, Close → block/challenge)."
-status: pending
+status: completed
 priority: P2
 branch: "main-harness"
 tags: [bug, area:engine, risk, redis, security, gh-201]
@@ -57,9 +57,9 @@ Established repo pattern to follow: a small pure `resolve`-style mapping
 
 | Phase | Name | Status |
 |-------|------|--------|
-| 1 | [Store faithful failure signaling (degraded ApplyResult + faithful Err)](./phase-01-store-faithful-failure-signaling-degraded-applyresult-faithf.md) | Pending |
-| 2 | [Scorer honors TierPolicy fail_mode on store failure](./phase-02-scorer-honors-tierpolicy-fail-mode-on-store-failure.md) | Pending |
-| 3 | [Acceptance tests + quality gates](./phase-03-acceptance-tests-quality-gates.md) | Pending |
+| 1 | [Store faithful failure signaling (degraded ApplyResult + faithful Err)](./phase-01-store-faithful-failure-signaling-degraded-applyresult-faithf.md) | Completed |
+| 2 | [Scorer honors TierPolicy fail_mode on store failure](./phase-02-scorer-honors-tierpolicy-fail-mode-on-store-failure.md) | Completed |
+| 3 | [Acceptance tests + quality gates](./phase-03-acceptance-tests-quality-gates.md) | Completed |
 
 ## Key Decisions
 
@@ -124,11 +124,11 @@ Established repo pattern to follow: a small pure `resolve`-style mapping
 
 ## Acceptance Criteria (from issue)
 
-- [ ] Store errors surface as an explicit degraded indicator (`apply`) or faithful
+- [x] Store errors surface as an explicit degraded indicator (`apply`) or faithful
       `Err` (`read`) — no silent score-0 substitution [Phase 1].
-- [ ] Scorer applies `TierPolicy.fail_mode` on store failure; `FailMode::Close`
+- [x] Scorer applies `TierPolicy.fail_mode` on store failure; `FailMode::Close`
       blocks/challenges, `FailMode::Open` allows on best-known score [Phase 2].
-- [ ] Test: simulated Redis outage → fail-open tier allows (degraded telemetry),
+- [x] Test: simulated Redis outage → fail-open tier allows (degraded telemetry),
       fail-closed tier does not [Phase 3].
 
 ## Validation

--- a/plans/260705-0958-gh-204-risk-delta-cap-decay-config/phase-01-enforce-per-request-delta-cap-in-the-scoring-pipeline.md
+++ b/plans/260705-0958-gh-204-risk-delta-cap-decay-config/phase-01-enforce-per-request-delta-cap-in-the-scoring-pipeline.md
@@ -1,7 +1,7 @@
 ---
 phase: 1
 title: "Enforce per-request delta cap in the scoring pipeline"
-status: pending
+status: completed
 effort: 1h
 ---
 

--- a/plans/260705-0958-gh-204-risk-delta-cap-decay-config/phase-02-honor-decayconfig-across-memory-and-redis-backends.md
+++ b/plans/260705-0958-gh-204-risk-delta-cap-decay-config/phase-02-honor-decayconfig-across-memory-and-redis-backends.md
@@ -1,7 +1,7 @@
 ---
 phase: 2
 title: "Honor DecayConfig across memory and redis backends"
-status: pending
+status: completed
 effort: 2h
 ---
 

--- a/plans/260705-0958-gh-204-risk-delta-cap-decay-config/phase-03-add-riskconfig-validate-wired-into-config-load.md
+++ b/plans/260705-0958-gh-204-risk-delta-cap-decay-config/phase-03-add-riskconfig-validate-wired-into-config-load.md
@@ -1,7 +1,7 @@
 ---
 phase: 3
 title: "Add RiskConfig::validate wired into config load"
-status: pending
+status: completed
 effort: 1h
 ---
 

--- a/plans/260705-0958-gh-204-risk-delta-cap-decay-config/phase-04-acceptance-tests-and-quality-gates.md
+++ b/plans/260705-0958-gh-204-risk-delta-cap-decay-config/phase-04-acceptance-tests-and-quality-gates.md
@@ -1,7 +1,7 @@
 ---
 phase: 4
 title: "Acceptance tests and quality gates"
-status: pending
+status: completed
 effort: 1h
 ---
 

--- a/plans/260705-0958-gh-204-risk-delta-cap-decay-config/plan.md
+++ b/plans/260705-0958-gh-204-risk-delta-cap-decay-config/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "GH-204 risk: enforce per-request delta cap, honor DecayConfig, add RiskConfig::validate"
 description: "Wire the defined-but-unused per-request delta cap into the scorer, thread DecayConfig into both store backends so it stops being dead config, and add RiskConfig::validate at the parse boundary"
-status: pending
+status: completed
 priority: P2
 effort: 5h
 branch: "main-harness"


### PR DESCRIPTION
Closes #200.

Stacked on #213 (GH-197) → #212 (GH-196) — based on `fix/gh-197-geo-rules-enforcement-wiring` so only this fix shows in the diff; GitHub retargets as the chain merges.

## Problem

`Scorer::score` evaluated the seed layer first and the `SeedVerdict::Score` arm returned early into `score_with_l2` — **before** the canary honeypot block. Tor exits and datacenter/bad-ASN IPs (exactly the clients that probe honeypot paths) never triggered `check_and_ban` → no `force_max`, no `DynamicBanTable` insert, no 403. They accrued a +30/+15/+25 seed delta and kept scanning. The comment claimed canary runs "AFTER whitelist, BEFORE other layers"; the control flow contradicted it.

## Fix

Pure intra-function reorder in `crates/waf-engine/src/risk/scorer.rs` (no signature changes):

1. Seed verdict evaluated once into a local (`None` when the layer is absent/disabled).
2. `Whitelisted` → Allow, still **before** canary (unchanged).
3. Canary block runs unconditionally for every non-whitelisted request.
4. Tail `match` folds the seed contributor into `score_with_l2` on the `Score` path; `None` passes caller deltas through as before.

## Tests

- `seed_scored_ip_still_hits_canary` — Tor-exit IP on a canary path → `Block`, score 100, ban-table entry, pin persists on a later request. **Verified to fail on the unpatched scorer** (stash/pop check), so it genuinely guards the ordering.
- `seed_scored_ip_on_normal_path_accrues_seed_delta` — non-canary path still accrues the tor_exit delta; guards against the reorder dropping the contributor.
- `whitelist_bypasses_canary` + `canary_path_triggers_block_and_score_100` unchanged and green — ordering locked in both directions.
- `cargo test -p waf-engine --lib risk`: 239 passed (5 failures = known docker-gated testcontainer set). Clippy all-targets + fmt clean.

Known pre-existing CI failures on main-harness (Coverage prx-waf floor, Security Audit, License advisories) are unrelated.
