### PR TITLE
fix(risk): honor tier fail_mode when redis risk store degrades

### DIFF
--- a/crates/waf-engine/src/risk/scorer.rs
+++ b/crates/waf-engine/src/risk/scorer.rs
@@ -23,7 +23,7 @@ use crate::risk::key::{RiskKey, SessionId};
 use crate::risk::seed::{SeedLayer, SeedVerdict};
 use crate::risk::state::{Contributor, ContributorKind, CreditOutcome};
 use crate::risk::store::RiskStore;
-use crate::risk::threshold::decide;
+use crate::risk::threshold::{decide, degraded_action};
 use crate::risk::velocity::{TxEndpoint, VelocityLayer};
 
 /// Result of scoring a request.
@@ -260,7 +260,25 @@ impl<S: RiskStore + ?Sized> Scorer<S> {
 
         let override_block = state.is_pinned(now_ms);
         let thresholds = &ctx.tier_policy.risk_thresholds;
-        let action = decide(state.clamped_score, thresholds, override_block);
+        let action = if result.degraded {
+            // Store lost its authority (backend outage); the tier's declared
+            // fail mode decides instead of the unauthoritative score alone.
+            tracing::warn!(
+                target: "risk::degrade",
+                client_ip = %ctx.client_ip,
+                fail_mode = ?ctx.tier_policy.fail_mode,
+                score = state.clamped_score,
+                "risk store degraded; applying tier fail_mode"
+            );
+            degraded_action(
+                ctx.tier_policy.fail_mode,
+                state.clamped_score,
+                thresholds,
+                override_block,
+            )
+        } else {
+            decide(state.clamped_score, thresholds, override_block)
+        };
 
         Ok(ScorerResult {
             action,
@@ -456,6 +474,131 @@ mod tests {
         };
         let swap = Arc::new(ArcSwap::from(Arc::new(cfg)));
         Scorer::new(store, swap)
+    }
+
+    /// Store stub whose `apply` always reports a degraded backend with a
+    /// preset best-known score — deterministic outage without a Redis server.
+    struct DegradedStore {
+        score: u8,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::risk::store::RiskStore for DegradedStore {
+        async fn read(&self, _key: &RiskKey) -> anyhow::Result<Option<crate::risk::state::RiskState>> {
+            anyhow::bail!("backend unreachable")
+        }
+
+        async fn apply(
+            &self,
+            _key: &RiskKey,
+            _deltas: &[Contributor],
+            now_ms: i64,
+        ) -> anyhow::Result<crate::risk::store::store_trait::ApplyResult> {
+            let mut state = crate::risk::state::RiskState::new(now_ms);
+            state.clamped_score = self.score;
+            Ok(crate::risk::store::store_trait::ApplyResult {
+                state,
+                is_new: self.score == 0,
+                degraded: true,
+            })
+        }
+
+        async fn force_max(&self, _key: &RiskKey, _until_ms: i64, _now_ms: i64) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn clear(&self, _key: &RiskKey) -> anyhow::Result<bool> {
+            Ok(false)
+        }
+
+        async fn purge_expired(&self, _ttl_ms: i64, _now_ms: i64) -> anyhow::Result<usize> {
+            Ok(0)
+        }
+
+        async fn reset_all(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn len(&self) -> usize {
+            0
+        }
+    }
+
+    fn make_degraded_scorer(score: u8) -> Scorer<DegradedStore> {
+        let cfg = RiskConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let swap = Arc::new(ArcSwap::from(Arc::new(cfg)));
+        Scorer::new(Arc::new(DegradedStore { score }), swap)
+    }
+
+    fn ctx_with_fail_mode(fail_mode: FailMode) -> RequestCtx {
+        let mut ctx = make_ctx();
+        ctx.tier_policy = Arc::new(TierPolicy {
+            fail_mode,
+            ddos_threshold_rps: 1000,
+            cache_policy: CachePolicy::NoCache,
+            risk_thresholds: RiskThresholds {
+                allow: 30,
+                challenge: 70,
+                block: 90,
+            },
+        });
+        ctx
+    }
+
+    #[tokio::test]
+    async fn degraded_fail_open_unknown_actor_allowed() {
+        let scorer = make_degraded_scorer(0);
+        let ctx = ctx_with_fail_mode(FailMode::Open);
+
+        let result = scorer.score(&ctx, None, &[], None, 1000).await.unwrap();
+        assert_eq!(result.score, 0);
+        assert!(matches!(result.action, WafAction::Allow));
+    }
+
+    #[tokio::test]
+    async fn degraded_fail_open_cached_high_score_still_blocks() {
+        let scorer = make_degraded_scorer(95);
+        let ctx = ctx_with_fail_mode(FailMode::Open);
+
+        let result = scorer.score(&ctx, None, &[], None, 1000).await.unwrap();
+        assert_eq!(result.score, 95, "cached score must not be reset by the outage");
+        assert!(matches!(result.action, WafAction::Block { status: 403, .. }));
+    }
+
+    #[tokio::test]
+    async fn degraded_fail_close_blocks_503_even_at_score_zero() {
+        let scorer = make_degraded_scorer(0);
+        let ctx = ctx_with_fail_mode(FailMode::Close);
+
+        let result = scorer.score(&ctx, None, &[], None, 1000).await.unwrap();
+        assert!(matches!(
+            result.action,
+            WafAction::Block {
+                status: 503,
+                body: None
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn healthy_store_ignores_fail_close() {
+        let store = Arc::new(MemoryRiskStore::new());
+        let cfg = RiskConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let swap = Arc::new(ArcSwap::from(Arc::new(cfg)));
+        let scorer = Scorer::new(store, swap);
+        let ctx = ctx_with_fail_mode(FailMode::Close);
+
+        let result = scorer.score(&ctx, None, &[], None, 1000).await.unwrap();
+        assert!(
+            matches!(result.action, WafAction::Allow),
+            "fail_mode must only apply during store degradation"
+        );
     }
 
     #[tokio::test]

--- a/crates/waf-engine/src/risk/store/memory.rs
+++ b/crates/waf-engine/src/risk/store/memory.rs
@@ -133,6 +133,7 @@ impl RiskStore for MemoryRiskStore {
             return Ok(ApplyResult {
                 state: RiskState::new(now_ms),
                 is_new: true,
+                degraded: false,
             });
         }
 
@@ -161,7 +162,11 @@ impl RiskStore for MemoryRiskStore {
         }
 
         let state = state_ref.read().clone();
-        Ok(ApplyResult { state, is_new })
+        Ok(ApplyResult {
+            state,
+            is_new,
+            degraded: false,
+        })
     }
 
     #[allow(clippy::option_if_let_else)]

--- a/crates/waf-engine/src/risk/store/redis.rs
+++ b/crates/waf-engine/src/risk/store/redis.rs
@@ -196,6 +196,13 @@ impl RedisRiskStore {
         self.cache.lock().get(&cache_key).map(|e| e.state.clone())
     }
 
+    /// Best-known substitute when Redis is unreachable: the last cached state
+    /// for this actor, else a fresh zero state. Always flagged `degraded` so
+    /// the caller applies its fail-mode policy instead of trusting the score.
+    fn degraded_apply_result(&self, key: &RiskKey, now_ms: i64) -> ApplyResult {
+        degraded_substitute(self.cache_lookup(key), now_ms)
+    }
+
     /// Update LRU cache with new state.
     fn cache_update(&self, key: &RiskKey, owner_id: &str, state: &RiskState) {
         let cache_key = Self::cache_key(key);
@@ -275,6 +282,24 @@ impl RedisRiskStore {
     }
 }
 
+/// Build the degraded `ApplyResult` from an optional cached state: the last
+/// known state when present (`is_new: false`), else a fresh zero state.
+/// `degraded` is always `true` — the score is a substitute, not authority.
+fn degraded_substitute(cached: Option<RiskState>, now_ms: i64) -> ApplyResult {
+    cached.map_or_else(
+        || ApplyResult {
+            state: RiskState::new(now_ms),
+            is_new: true,
+            degraded: true,
+        },
+        |state| ApplyResult {
+            state,
+            is_new: false,
+            degraded: true,
+        },
+    )
+}
+
 /// Response from apply Lua script.
 #[derive(serde::Deserialize)]
 struct ApplyResponse {
@@ -312,10 +337,9 @@ impl RiskStore for RedisRiskStore {
                 }
                 Ok(max_state.map(|(_, state)| state))
             }
-            Err(e) => {
-                warn!(error = %e, "risk redis: read failed, checking cache");
-                Ok(self.cache_lookup(key))
-            }
+            // Faithful error: read is advisory (not on the enforcement gate),
+            // so callers must see the outage instead of a stale cache value.
+            Err(e) => Err(e.context("risk redis: read")),
         }
     }
 
@@ -324,6 +348,7 @@ impl RiskStore for RedisRiskStore {
             return Ok(ApplyResult {
                 state: RiskState::new(now_ms),
                 is_new: true,
+                degraded: false,
             });
         }
 
@@ -357,29 +382,18 @@ impl RiskStore for RedisRiskStore {
                 Ok(ApplyResult {
                     state: response.state,
                     is_new: response.is_new,
+                    degraded: false,
                 })
             }
             Ok(Err(e)) => {
                 self.record_fail();
-                warn!(error = %e, "risk redis: apply failed, using cache fallback");
-                if let Some(state) = self.cache_lookup(key) {
-                    return Ok(ApplyResult { state, is_new: false });
-                }
-                Ok(ApplyResult {
-                    state: RiskState::new(now_ms),
-                    is_new: true,
-                })
+                warn!(error = %e, "risk redis: apply failed, degraded fallback");
+                Ok(self.degraded_apply_result(key, now_ms))
             }
             Err(_) => {
                 self.record_fail();
-                warn!("risk redis: apply timeout, using cache fallback");
-                if let Some(state) = self.cache_lookup(key) {
-                    return Ok(ApplyResult { state, is_new: false });
-                }
-                Ok(ApplyResult {
-                    state: RiskState::new(now_ms),
-                    is_new: true,
-                })
+                warn!("risk redis: apply timeout, degraded fallback");
+                Ok(self.degraded_apply_result(key, now_ms))
             }
         }
     }
@@ -602,6 +616,67 @@ mod tests {
         cache.push("a".to_string(), cache_entry("owner-a2"));
         assert_eq!(cache.len(), 2);
         assert_eq!(cache.get(&"a".to_string()).unwrap().owner_id, "owner-a2");
+    }
+
+    #[test]
+    fn degraded_substitute_keeps_cached_score() {
+        let mut cached = RiskState::new(0);
+        cached.clamped_score = 87;
+
+        let result = degraded_substitute(Some(cached), 5000);
+        assert!(result.degraded, "cache hit during outage is still degraded");
+        assert!(!result.is_new);
+        assert_eq!(
+            result.state.clamped_score, 87,
+            "last known score must survive the outage"
+        );
+    }
+
+    #[test]
+    fn degraded_substitute_without_cache_is_flagged_not_authoritative() {
+        let result = degraded_substitute(None, 5000);
+        assert!(
+            result.degraded,
+            "fresh zero state during outage must carry the degraded flag"
+        );
+        assert!(result.is_new);
+        assert_eq!(result.state.clamped_score, 0);
+    }
+
+    /// Timeout arm of `apply` + faithful `read` error — runs only when
+    /// `REDIS_TEST_URL` is set. A 1ns op timeout forces every round-trip
+    /// through the failure arms against a real server.
+    #[tokio::test]
+    async fn outage_apply_degrades_and_read_errors() {
+        use crate::risk::key::RiskKey;
+        use std::net::Ipv4Addr;
+
+        let Ok(url) = std::env::var("REDIS_TEST_URL") else {
+            tracing::info!("skipping: REDIS_TEST_URL unset");
+            return;
+        };
+
+        let store = RedisRiskStore::new(RedisRiskConfig {
+            url,
+            key_prefix: unique_prefix(),
+            ttl_secs: 3600,
+            op_timeout: Duration::from_nanos(1),
+            breaker_threshold: 5,
+            cache_capacity: 100,
+        })
+        .await
+        .expect("connect to REDIS_TEST_URL");
+
+        let key = RiskKey::from_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 101)));
+
+        let result = store.apply(&key, &[], 1000).await.unwrap();
+        assert!(result.degraded, "timed-out apply must be flagged degraded");
+        assert_eq!(result.state.clamped_score, 0);
+
+        assert!(
+            store.read(&key).await.is_err(),
+            "read must surface the outage, not the cache"
+        );
     }
 
     fn unique_prefix() -> String {

--- a/crates/waf-engine/src/risk/store/store_trait.rs
+++ b/crates/waf-engine/src/risk/store/store_trait.rs
@@ -16,6 +16,11 @@ pub struct ApplyResult {
     pub state: RiskState,
     /// True if this was a new entry (not an update to existing).
     pub is_new: bool,
+    /// True when the backend could not reach its authority and `state` is a
+    /// best-known substitute (last cached value or a fresh zero state). Set
+    /// only by backends that can transiently fail; callers must apply their
+    /// fail-mode policy instead of trusting the score as authoritative.
+    pub degraded: bool,
 }
 
 /// Async trait for risk state storage.
@@ -157,6 +162,7 @@ mod tests {
             Ok(ApplyResult {
                 state: RiskState::new(now_ms),
                 is_new: true,
+                degraded: false,
             })
         }
 
@@ -231,6 +237,7 @@ mod tests {
         let r = ApplyResult {
             state: RiskState::new(42),
             is_new: true,
+            degraded: false,
         };
         let r2 = r.clone();
         assert_eq!(r2.state.created_ms, 42);

--- a/crates/waf-engine/src/risk/threshold.rs
+++ b/crates/waf-engine/src/risk/threshold.rs
@@ -4,7 +4,7 @@
 //! thresholds. Uses the tier's `RiskThresholds` (allow, challenge, block).
 
 use waf_common::WafAction;
-use waf_common::tier::RiskThresholds;
+use waf_common::tier::{FailMode, RiskThresholds};
 
 /// Decide the action based on the score and thresholds.
 ///
@@ -38,6 +38,26 @@ pub fn decide(score: u8, thresholds: &RiskThresholds, override_block: bool) -> W
     WafAction::Challenge
 }
 
+/// Decide the action when the risk store is degraded (backend unreachable).
+///
+/// The score is a best-known substitute, not authority, so the tier's
+/// declared fail mode picks the policy:
+///
+/// - `FailMode::Open`  → [`decide`] on the best-known score: a cached high
+///   score still defends; an unknown actor (score 0) is allowed.
+/// - `FailMode::Close` → `Block { 503 }` regardless of score — never trust
+///   a stale or absent score on a fail-closed tier.
+#[must_use]
+pub fn degraded_action(fail_mode: FailMode, score: u8, thresholds: &RiskThresholds, override_block: bool) -> WafAction {
+    match fail_mode {
+        FailMode::Open => decide(score, thresholds, override_block),
+        FailMode::Close => WafAction::Block {
+            status: 503,
+            body: None,
+        },
+    }
+}
+
 /// Check if a score would result in Allow.
 #[must_use]
 pub const fn is_allowed(score: u8, thresholds: &RiskThresholds) -> bool {
@@ -67,6 +87,63 @@ mod tests {
             challenge: 70,
             block: 90,
         }
+    }
+
+    #[test]
+    fn degraded_open_trusts_best_known_score_across_bands() {
+        let t = default_thresholds();
+        // Same mapping as `decide` in every band: unknown actor allowed,
+        // cached mid score challenged, cached high score blocked.
+        assert!(matches!(
+            degraded_action(FailMode::Open, 0, &t, false),
+            WafAction::Allow
+        ));
+        assert!(matches!(
+            degraded_action(FailMode::Open, 29, &t, false),
+            WafAction::Allow
+        ));
+        assert!(matches!(
+            degraded_action(FailMode::Open, 30, &t, false),
+            WafAction::Challenge
+        ));
+        assert!(matches!(
+            degraded_action(FailMode::Open, 89, &t, false),
+            WafAction::Challenge
+        ));
+        assert!(matches!(
+            degraded_action(FailMode::Open, 90, &t, false),
+            WafAction::Block { status: 403, .. }
+        ));
+        assert!(matches!(
+            degraded_action(FailMode::Open, 100, &t, false),
+            WafAction::Block { status: 403, .. }
+        ));
+        // Pinned actor blocks even at a low cached score.
+        assert!(matches!(
+            degraded_action(FailMode::Open, 0, &t, true),
+            WafAction::Block { status: 403, .. }
+        ));
+    }
+
+    #[test]
+    fn degraded_close_blocks_503_regardless_of_score() {
+        let t = default_thresholds();
+        for score in [0u8, 29, 30, 89, 90, 100] {
+            assert!(
+                matches!(
+                    degraded_action(FailMode::Close, score, &t, false),
+                    WafAction::Block {
+                        status: 503,
+                        body: None
+                    }
+                ),
+                "fail-closed tier must block at score {score}"
+            );
+        }
+        assert!(matches!(
+            degraded_action(FailMode::Close, 0, &t, true),
+            WafAction::Block { status: 503, .. }
+        ));
     }
 
     #[test]

--- a/docs/journals/2026-07-05-gh-201-redis-failmode-policy-implementation.md
+++ b/docs/journals/2026-07-05-gh-201-redis-failmode-policy-implementation.md
@@ -1,0 +1,58 @@
+# 2026-07-05 — GH-201: redis fail-mode policy (implementation)
+
+## What
+
+A Redis outage silently faked health: `RedisRiskStore::apply` swallowed
+errors/timeouts and returned a cache-hit or fresh zero state with no signal,
+and `read` fabricated `Ok(cached)` on failure. `TierPolicy.fail_mode` was
+never consulted — a fail-closed tier stayed wide open during an outage.
+
+Three-part fix:
+
+- **Store signaling** (`store_trait.rs`, `redis.rs`, `memory.rs`):
+  `ApplyResult` gains `degraded: bool`. The redis error/timeout arms return
+  the best-known substitute (last cached state, else fresh zero state) via
+  `degraded_substitute`, always flagged `degraded: true`. `read` now returns
+  the error faithfully (it is advisory — no production callers; verified by
+  grep). Memory store always sets `degraded: false`.
+- **Policy** (`threshold.rs`): pure `degraded_action(fail_mode, score,
+  thresholds, override_block)` — `Open` → normal `decide` on the best-known
+  score (a cached high score still defends), `Close` → `Block { 503, None }`
+  (parity with the DDoS degrade path).
+- **Scorer wiring** (`scorer.rs`): `score_with_l2` branches on
+  `result.degraded`, logs `warn!(target: "risk::degrade", ...)` with client
+  IP, fail mode, and score, then routes through `degraded_action`.
+
+The plan's optional breaker fast-fail short-circuit was deliberately dropped:
+short-circuiting at the top of `apply` would prevent `record_ok` from ever
+firing after Redis recovers, latching the breaker open permanently.
+
+## How it was verified
+
+- Pure unit tests for `degraded_substitute` (cached score survives, fresh
+  state flagged) and exhaustive `degraded_action` band tests (Open across
+  allow/challenge/block/pinned; Close always 503).
+- Deterministic mock-store acceptance tests in scorer tests (`DegradedStore`
+  whose `apply` always returns `degraded: true`): Open + score 0 → Allow;
+  Open + cached 95 → Block 403 (no score reset); Close + score 0 → Block 503;
+  healthy `MemoryRiskStore` + Close tier → Allow (fail_mode only applies
+  during degradation). The 503 assertion can only come from the new path —
+  `decide` never emits 503.
+- `REDIS_TEST_URL`-gated test drives the real timeout arm (1ns `op_timeout`
+  against a live server) → `degraded: true` + `read` → `Err`.
+- `cargo test -p waf-engine --lib --features redis-store "risk::"`: 260
+  passed, 0 failed (docker-gated `engine::tests` set excluded as
+  pre-established). Existing `redis_failover` suite unchanged and green.
+- `cargo clippy --all-targets --features redis-store` clean;
+  `cargo fmt --all --check` clean.
+
+## Gotchas
+
+- `RedisRiskStore::new` PINGs on construction, so an unreachable-URL store
+  cannot be built in the default test suite — that is why the degraded logic
+  is factored into the pure `degraded_substitute` free function and the
+  outage test is REDIS_TEST_URL-gated instead.
+- The redis store module is behind the `redis-store` cargo feature; a bare
+  `cargo test risk::store` silently skips it (13 vs 21 tests).
+- clippy pedantic `similar_names` fires on `store`/`score` bindings in the
+  same fn.

--- a/plans/260705-0958-gh-201-redis-failmode-policy/plan.md
+++ b/plans/260705-0958-gh-201-redis-failmode-policy/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "GH-201 redis risk store: propagate errors, honor TierPolicy fail_mode on outage"
 description: "Redis store stops silently faking score-0 on outage; apply signals an explicit degraded flag, the Scorer maps store failure to the tier's FailMode (Open → allow with degraded telemetry, Close → block/challenge)."
-status: pending
+status: completed
 priority: P2
 branch: "main-harness"
 tags: [bug, area:engine, risk, redis, security, gh-201]
@@ -57,9 +57,9 @@ Established repo pattern to follow: a small pure `resolve`-style mapping
 
 | Phase | Name | Status |
 |-------|------|--------|
-| 1 | [Store faithful failure signaling (degraded ApplyResult + faithful Err)](./phase-01-store-faithful-failure-signaling-degraded-applyresult-faithf.md) | Pending |
-| 2 | [Scorer honors TierPolicy fail_mode on store failure](./phase-02-scorer-honors-tierpolicy-fail-mode-on-store-failure.md) | Pending |
-| 3 | [Acceptance tests + quality gates](./phase-03-acceptance-tests-quality-gates.md) | Pending |
+| 1 | [Store faithful failure signaling (degraded ApplyResult + faithful Err)](./phase-01-store-faithful-failure-signaling-degraded-applyresult-faithf.md) | Completed |
+| 2 | [Scorer honors TierPolicy fail_mode on store failure](./phase-02-scorer-honors-tierpolicy-fail-mode-on-store-failure.md) | Completed |
+| 3 | [Acceptance tests + quality gates](./phase-03-acceptance-tests-quality-gates.md) | Completed |
 
 ## Key Decisions
 
@@ -124,11 +124,11 @@ Established repo pattern to follow: a small pure `resolve`-style mapping
 
 ## Acceptance Criteria (from issue)
 
-- [ ] Store errors surface as an explicit degraded indicator (`apply`) or faithful
+- [x] Store errors surface as an explicit degraded indicator (`apply`) or faithful
       `Err` (`read`) — no silent score-0 substitution [Phase 1].
-- [ ] Scorer applies `TierPolicy.fail_mode` on store failure; `FailMode::Close`
+- [x] Scorer applies `TierPolicy.fail_mode` on store failure; `FailMode::Close`
       blocks/challenges, `FailMode::Open` allows on best-known score [Phase 2].
-- [ ] Test: simulated Redis outage → fail-open tier allows (degraded telemetry),
+- [x] Test: simulated Redis outage → fail-open tier allows (degraded telemetry),
       fail-closed tier does not [Phase 3].
 
 ## Validation


### PR DESCRIPTION
Closes #201.

## Problem

A Redis outage was invisible to the risk pipeline:

- `RedisRiskStore::apply` swallowed errors and timeouts, returning the LRU-cached state or a fresh zero state with no signal that the backend was gone.
- `read` fabricated `Ok(cached)` on failure.
- `TierPolicy.fail_mode` was never consulted — a fail-**closed** tier stayed wide open for the entire outage.

## Fix

- **Store signaling** — `ApplyResult` gains a `degraded: bool`. The redis error/timeout arms return the best-known substitute (last cached state for the actor, else a fresh zero state) via a pure `degraded_substitute` helper, always flagged `degraded: true`. `read` now surfaces errors faithfully (advisory path — no production callers). The memory store always reports `degraded: false`.
- **Policy** — new pure `degraded_action(fail_mode, score, thresholds, override_block)` beside `decide` in `threshold.rs`: `Open` → normal threshold decision on the best-known score (a cached high score still defends); `Close` → `Block { 503 }` regardless of score, matching the DDoS degrade path.
- **Scorer wiring** — `score_with_l2` branches on `result.degraded`, logs `warn!(target: "risk::degrade", client_ip, fail_mode, score, ...)`, then routes through `degraded_action`. Healthy path unchanged.

The plan's optional breaker fast-fail short-circuit was deliberately **not** added: short-circuiting at the top of `apply` would prevent `record_ok` from ever firing after Redis recovers, latching the breaker open permanently.

## Verification

- Pure unit tests: `degraded_substitute` (cached score survives; fresh state flagged) and exhaustive `degraded_action` bands (Open across allow/challenge/block/pinned; Close always 503).
- Deterministic mock-store acceptance tests (no Redis needed): Open + unknown actor → Allow; Open + cached 95 → Block 403 (no score reset); Close + score 0 → Block 503; healthy store + Close tier → Allow (fail_mode applies only during degradation). The 503 assertion can only come from the new path — `decide` never emits 503.
- `REDIS_TEST_URL`-gated test drives the real timeout arm (1ns op timeout against a live server) → `degraded: true`, `read` → `Err`.
- `cargo test -p waf-engine --lib --features redis-store "risk::"` → 260 passed, 0 failed; existing `redis_failover` suite green and unchanged.
- `cargo clippy --all-targets --features redis-store` clean; `cargo fmt --check` clean.

## Stacking

Based on `fix/gh-200-canary-before-seed-early-return` (PR #214) so the diff shows only this issue's commit. GitHub will retarget to `main-harness` automatically once the parent squash-merges and its branch is deleted.

> Note: Coverage (prx-waf), Security Audit, and License & Supply Chain failures are pre-existing on `main-harness` and unrelated to this change.
