### PR TITLE
fix(risk): enforce per-request delta cap, honor decay config, validate risk config

### DIFF
--- a/crates/waf-engine/benches/risk_anomaly.rs
+++ b/crates/waf-engine/benches/risk_anomaly.rs
@@ -147,7 +147,13 @@ fn bench_decay(c: &mut Criterion) {
                 state.clean_streak = 15;
                 state
             },
-            |mut state| black_box(apply_decay(&mut state, 2000)),
+            |mut state| {
+                black_box(apply_decay(
+                    &mut state,
+                    2000,
+                    &waf_engine::risk::config::DecayConfig::default(),
+                ))
+            },
             criterion::BatchSize::SmallInput,
         )
     });

--- a/crates/waf-engine/src/engine.rs
+++ b/crates/waf-engine/src/engine.rs
@@ -340,7 +340,7 @@ impl WafEngine {
         if cfg.store.backend == "redis" {
             #[cfg(feature = "redis-store")]
             {
-                let runtime_cfg = cfg.store.redis.to_runtime_config(cfg.ttl_secs);
+                let runtime_cfg = cfg.store.redis.to_runtime_config(cfg.ttl_secs, cfg.decay.clone());
                 // Bound the initial connect: ConnectionManager retries with
                 // backoff internally, which can stall startup for minutes
                 // when the host silently drops packets. Fail-soft needs a
@@ -365,7 +365,7 @@ impl WafEngine {
             #[cfg(not(feature = "redis-store"))]
             warn!("risk: store.backend=redis requires the redis-store build feature; using memory store");
         }
-        let store = Arc::new(MemoryRiskStore::new());
+        let store = Arc::new(MemoryRiskStore::with_decay(cfg.decay.clone()));
         // The purge loop needs the concrete `Arc<MemoryRiskStore>`; start it
         // before the Arc is unsized to `Arc<dyn RiskStore>`.
         let ttl_ms = i64::try_from(cfg.ttl_secs.saturating_mul(1000)).unwrap_or(i64::MAX);

--- a/crates/waf-engine/src/risk/config.rs
+++ b/crates/waf-engine/src/risk/config.rs
@@ -72,7 +72,7 @@ pub struct RiskConfig {
 }
 
 /// Store backend selection.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StoreConfig {
     /// Backend type: "memory" or "redis" (redis requires feature flag).
     #[serde(default = "default_backend")]
@@ -81,6 +81,15 @@ pub struct StoreConfig {
     /// Redis configuration (only used when backend = "redis").
     #[serde(default)]
     pub redis: RedisStoreConfig,
+}
+
+impl Default for StoreConfig {
+    fn default() -> Self {
+        Self {
+            backend: default_backend(),
+            redis: RedisStoreConfig::default(),
+        }
+    }
 }
 
 /// Redis store configuration (Phase 7).
@@ -119,7 +128,7 @@ impl RedisStoreConfig {
     /// Convert to runtime `RedisRiskConfig` (requires `redis-store` feature).
     #[cfg(feature = "redis-store")]
     #[must_use]
-    pub fn to_runtime_config(&self, ttl_secs: u64) -> crate::risk::store::redis::RedisRiskConfig {
+    pub fn to_runtime_config(&self, ttl_secs: u64, decay: DecayConfig) -> crate::risk::store::redis::RedisRiskConfig {
         crate::risk::store::redis::RedisRiskConfig {
             url: self.url.clone(),
             key_prefix: self.key_prefix.clone(),
@@ -128,6 +137,7 @@ impl RedisStoreConfig {
             op_timeout: std::time::Duration::from_millis(self.op_timeout_ms),
             breaker_threshold: self.breaker_threshold,
             cache_capacity: self.cache_capacity,
+            decay,
         }
     }
 }
@@ -379,7 +389,45 @@ impl RiskConfig {
         let doc: RiskDocument = serde_yaml::from_str(&content)
             .with_context(|| format!("failed to parse risk config: {}", path.display()))?;
 
+        doc.risk
+            .validate()
+            .with_context(|| format!("invalid risk config: {}", path.display()))?;
+
         Ok(Arc::new(doc.risk))
+    }
+
+    /// Reject values that are verified-harmful at runtime.
+    ///
+    /// Checks: zero TTL (every actor expires instantly), zero GC interval
+    /// (panics `tokio::time::interval`), zero ingest channel capacity (panics
+    /// the bounded mpsc), unknown store backend, and a decay floor above the
+    /// score range. `decay_rate: 0` (decay disabled) and `min_clean_streak: 0`
+    /// (decay eligible immediately) are valid. Risk thresholds
+    /// (allow/challenge/block) live in `TierPolicy.risk_thresholds` and are
+    /// not validated here.
+    pub fn validate(&self) -> Result<()> {
+        if self.ttl_secs == 0 {
+            anyhow::bail!("risk config: ttl_secs must be > 0");
+        }
+        if self.gc_interval_secs == 0 {
+            anyhow::bail!("risk config: gc_interval_secs must be > 0");
+        }
+        if self.ingest.channel_capacity == 0 {
+            anyhow::bail!("risk config: ingest.channel_capacity must be > 0");
+        }
+        if !matches!(self.store.backend.as_str(), "memory" | "redis") {
+            anyhow::bail!(
+                "risk config: store.backend must be \"memory\" or \"redis\", got \"{}\"",
+                self.store.backend
+            );
+        }
+        if self.decay.max_decay > 100 {
+            anyhow::bail!(
+                "risk config: decay.max_decay must be <= 100, got {}",
+                self.decay.max_decay
+            );
+        }
+        Ok(())
     }
 
     /// TTL in milliseconds.
@@ -505,5 +553,67 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(cfg.ttl_ms(), 60_000);
+    }
+
+    #[test]
+    fn validate_accepts_default_config() {
+        assert!(RiskConfig::default().validate().is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_disabled_decay_and_zero_streak() {
+        let mut cfg = RiskConfig::default();
+        cfg.decay.decay_rate = 0;
+        cfg.decay.min_clean_streak = 0;
+        assert!(cfg.validate().is_ok(), "rate 0 and streak 0 are valid decay settings");
+    }
+
+    #[test]
+    fn validate_rejects_zero_ttl() {
+        let cfg = RiskConfig {
+            ttl_secs: 0,
+            ..Default::default()
+        };
+        assert!(cfg.validate().unwrap_err().to_string().contains("ttl_secs"));
+    }
+
+    #[test]
+    fn validate_rejects_zero_gc_interval() {
+        let cfg = RiskConfig {
+            gc_interval_secs: 0,
+            ..Default::default()
+        };
+        assert!(cfg.validate().unwrap_err().to_string().contains("gc_interval_secs"));
+    }
+
+    #[test]
+    fn validate_rejects_zero_channel_capacity() {
+        let mut cfg = RiskConfig::default();
+        cfg.ingest.channel_capacity = 0;
+        assert!(cfg.validate().unwrap_err().to_string().contains("channel_capacity"));
+    }
+
+    #[test]
+    fn validate_rejects_unknown_backend() {
+        let mut cfg = RiskConfig::default();
+        cfg.store.backend = "postgres".to_string();
+        assert!(cfg.validate().unwrap_err().to_string().contains("backend"));
+    }
+
+    #[test]
+    fn validate_rejects_decay_floor_above_score_range() {
+        let mut cfg = RiskConfig::default();
+        cfg.decay.max_decay = 101;
+        assert!(cfg.validate().unwrap_err().to_string().contains("max_decay"));
+    }
+
+    #[test]
+    fn from_path_rejects_zero_gc_interval_without_panic() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("risk.yaml");
+        std::fs::write(&path, "risk:\n  enabled: true\n  gc_interval_secs: 0\n").unwrap();
+
+        let err = RiskConfig::from_path(&path).unwrap_err();
+        assert!(format!("{err:#}").contains("gc_interval_secs"));
     }
 }

--- a/crates/waf-engine/src/risk/decay.rs
+++ b/crates/waf-engine/src/risk/decay.rs
@@ -5,69 +5,62 @@
 //! Decay has a floor of `MAX_DECAY` (50) — scores never drop below this via
 //! automatic decay (only explicit credits can go lower).
 
+use crate::risk::config::DecayConfig;
 use crate::risk::state::{Contributor, ContributorKind, RiskState};
 
-/// Maximum points that can be decayed away automatically.
+/// Default maximum points that can be decayed away automatically.
+///
 /// Scores above this floor require explicit credits to reduce further.
+/// Runtime decay reads `DecayConfig`; this const is a test/bench reference.
 pub const MAX_DECAY: i32 = 50;
 
-/// Minimum clean streak before decay kicks in.
+/// Default minimum clean streak before decay kicks in.
+/// Runtime decay reads `DecayConfig`; this const is a test/bench reference.
 pub const MIN_CLEAN_STREAK: u32 = 10;
 
-/// Points decayed per clean request after `MIN_CLEAN_STREAK`.
+/// Default points decayed per clean request after the clean streak.
+/// Runtime decay reads `DecayConfig`; this const is a test/bench reference.
 pub const DECAY_RATE: i16 = 1;
 
 /// Apply decay to the state if conditions are met.
 ///
 /// Returns the decay delta applied (0 if no decay). Mutates state in place.
-pub fn apply_decay(state: &mut RiskState, now_ms: i64) -> i16 {
-    if state.clean_streak < MIN_CLEAN_STREAK {
+/// `decay.decay_rate == 0` disables decay through the `available` arithmetic.
+pub fn apply_decay(state: &mut RiskState, now_ms: i64, decay: &DecayConfig) -> i16 {
+    let delta = preview_decay(state, now_ms, decay);
+    if delta == 0 {
         return 0;
     }
 
-    if state.is_pinned(now_ms) {
-        return 0;
-    }
-
-    let floor = MAX_DECAY;
-    if state.raw_score <= floor {
-        return 0;
-    }
-
-    let available = (state.raw_score - floor).min(i32::from(DECAY_RATE));
-    if available <= 0 {
-        return 0;
-    }
-
-    #[allow(clippy::cast_possible_truncation)]
-    let decay_delta = -(available as i16); // safe: available is clamped to DECAY_RATE (1)
-    state.raw_score = state.raw_score.saturating_add(i32::from(decay_delta));
-    state.push_contributor(Contributor::new(ContributorKind::Decay, decay_delta, now_ms));
+    state.raw_score = state.raw_score.saturating_add(i32::from(delta));
+    state.push_contributor(Contributor::new(ContributorKind::Decay, delta, now_ms));
     state.reclamp();
 
-    decay_delta
+    delta
 }
 
 /// Calculate how much decay would apply without mutating state.
 #[must_use]
-pub fn preview_decay(state: &RiskState, now_ms: i64) -> i16 {
-    if state.clean_streak < MIN_CLEAN_STREAK {
+pub fn preview_decay(state: &RiskState, now_ms: i64, decay: &DecayConfig) -> i16 {
+    if state.clean_streak < decay.min_clean_streak {
         return 0;
     }
     if state.is_pinned(now_ms) {
         return 0;
     }
-    let floor = MAX_DECAY;
+    // validate() enforces max_decay <= 100; the fallback keeps an
+    // unvalidated construction from panicking.
+    let floor = i32::try_from(decay.max_decay).unwrap_or(100);
     if state.raw_score <= floor {
         return 0;
     }
-    let available = (state.raw_score - floor).min(i32::from(DECAY_RATE));
+    let available = (state.raw_score - floor).min(i32::from(decay.decay_rate));
     if available <= 0 {
         return 0;
     }
     #[allow(clippy::cast_possible_truncation)]
     {
-        -(available as i16) // safe: available is clamped to DECAY_RATE (1)
+        -(available as i16) // safe: available is clamped to decay_rate (u16)
     }
 }
 
@@ -82,7 +75,7 @@ mod tests {
         state.clamped_score = 80;
         state.clean_streak = 5;
 
-        let decay = apply_decay(&mut state, 2000);
+        let decay = apply_decay(&mut state, 2000, &DecayConfig::default());
         assert_eq!(decay, 0);
         assert_eq!(state.raw_score, 80);
     }
@@ -94,7 +87,7 @@ mod tests {
         state.clamped_score = 80;
         state.clean_streak = 15;
 
-        let decay = apply_decay(&mut state, 2000);
+        let decay = apply_decay(&mut state, 2000, &DecayConfig::default());
         assert_eq!(decay, -1);
         assert_eq!(state.raw_score, 79);
         assert_eq!(state.clamped_score, 79);
@@ -107,11 +100,11 @@ mod tests {
         state.clamped_score = 51;
         state.clean_streak = 15;
 
-        let decay = apply_decay(&mut state, 2000);
+        let decay = apply_decay(&mut state, 2000, &DecayConfig::default());
         assert_eq!(decay, -1);
         assert_eq!(state.raw_score, 50);
 
-        let decay2 = apply_decay(&mut state, 3000);
+        let decay2 = apply_decay(&mut state, 3000, &DecayConfig::default());
         assert_eq!(decay2, 0);
         assert_eq!(state.raw_score, 50);
     }
@@ -124,7 +117,7 @@ mod tests {
         state.clean_streak = 15;
         state.pinned_until_ms = Some(5000);
 
-        let decay = apply_decay(&mut state, 2000);
+        let decay = apply_decay(&mut state, 2000, &DecayConfig::default());
         assert_eq!(decay, 0);
         assert_eq!(state.raw_score, 80);
     }
@@ -136,8 +129,8 @@ mod tests {
         state.clamped_score = 75;
         state.clean_streak = 20;
 
-        let preview = preview_decay(&state, 2000);
-        let actual = apply_decay(&mut state, 2000);
+        let preview = preview_decay(&state, 2000, &DecayConfig::default());
+        let actual = apply_decay(&mut state, 2000, &DecayConfig::default());
         assert_eq!(preview, actual);
     }
 }

--- a/crates/waf-engine/src/risk/ingest/worker.rs
+++ b/crates/waf-engine/src/risk/ingest/worker.rs
@@ -13,6 +13,7 @@ use crate::device_fp::types::FpKey;
 use crate::risk::ingest::metrics::IngestMetrics;
 use crate::risk::ingest::signal_to_contributor::{SignalWeights, signals_to_contributors};
 use crate::risk::key::RiskKey;
+use crate::risk::score::clamp_per_request_deltas;
 use crate::risk::store::RiskStore;
 
 /// Job submitted to the worker queue.
@@ -101,6 +102,10 @@ async fn process_job(
         metrics.record_processed(lag_ms as u64);
         return Ok(());
     }
+
+    // One job carries one request's signals — cap its positive delta sum
+    // like the sync path does.
+    let (contributors, _raw_sum) = clamp_per_request_deltas(&contributors);
 
     // Apply to store
     store.apply(&risk_key, &contributors, now_ms).await?;

--- a/crates/waf-engine/src/risk/scorer.rs
+++ b/crates/waf-engine/src/risk/scorer.rs
@@ -20,6 +20,7 @@ use crate::risk::canary::CanaryLayer;
 use crate::risk::challenge_credit::{ChallengeVerifier, VerifyOutcome};
 use crate::risk::config::RiskConfig;
 use crate::risk::key::{RiskKey, SessionId};
+use crate::risk::score::clamp_per_request_deltas;
 use crate::risk::seed::{SeedLayer, SeedVerdict};
 use crate::risk::state::{Contributor, ContributorKind, CreditOutcome};
 use crate::risk::store::RiskStore;
@@ -253,6 +254,10 @@ impl<S: RiskStore + ?Sized> Scorer<S> {
         if let Some(credit_delta) = self.evaluate_challenge_credit(ctx, &key, now_ms, cfg).await {
             all_deltas.push(credit_delta);
         }
+
+        // Cap this request's positive delta sum to MAX_PER_REQUEST_DELTA
+        // before the store fold (which only clamps the total score).
+        let (all_deltas, _raw_sum) = clamp_per_request_deltas(&all_deltas);
 
         // Apply to store (decay happens inside store.apply before fold)
         let result = self.store.apply(&key, &all_deltas, now_ms).await?;
@@ -650,6 +655,30 @@ mod tests {
 
         assert_eq!(result.score, 95);
         assert!(matches!(result.action, WafAction::Block { .. }));
+    }
+
+    #[tokio::test]
+    async fn oversized_positive_batch_capped_and_credit_preserved() {
+        use crate::risk::state::{ContributorKind, SeedKind};
+
+        let scorer = make_scorer();
+        let ctx = make_ctx();
+
+        // Positive deltas sum to 160 (> the per-request cap). The oldest
+        // positive is truncated so the newest 100 points land, and the
+        // negative credit survives the cap.
+        let deltas = vec![
+            Contributor::new(ContributorKind::Seed(SeedKind::Generic), 60, 1000),
+            Contributor::new(ContributorKind::AdminCredit, -20, 1000),
+            Contributor::new(ContributorKind::Seed(SeedKind::Generic), 60, 1000),
+            Contributor::new(ContributorKind::Seed(SeedKind::Generic), 40, 1000),
+        ];
+        let result = scorer.score(&ctx, None, &deltas, None, 1000).await.unwrap();
+
+        assert_eq!(
+            result.score, 80,
+            "cap keeps the newest 100 positive points; the credit still applies"
+        );
     }
 
     #[tokio::test]

--- a/crates/waf-engine/src/risk/store/conformance.rs
+++ b/crates/waf-engine/src/risk/store/conformance.rs
@@ -22,6 +22,7 @@ pub async fn run_all<S: RiskStore>(store: &S) {
     test_apply_divergent_score_convergence(store).await;
     test_apply_converges_axes(store).await;
     test_decay_contributor_roundtrip(store).await;
+    test_oversized_batch_clamps_to_cap(store).await;
     test_clear_removes_all_axes(store).await;
     test_admin_credit_reduces_score(store).await;
     test_reset_all(store).await;
@@ -231,6 +232,90 @@ pub async fn test_decay_contributor_roundtrip<S: RiskStore>(store: &S) {
     );
 }
 
+/// A single apply whose deltas sum past the score cap must clamp the visible
+/// score to 100 while the negative credit contributor still round-trips.
+async fn test_oversized_batch_clamps_to_cap<S: RiskStore>(store: &S) {
+    store.reset_all().await.unwrap();
+
+    let key = RiskKey::from_ip(IpAddr::V4(Ipv4Addr::new(10, 11, 11, 11)));
+    let deltas = vec![
+        make_contributor(60, 1000),
+        make_contributor(60, 1000),
+        Contributor::new(ContributorKind::AdminCredit, -20, 1000),
+        make_contributor(30, 1000),
+    ];
+    let result = store.apply(&key, &deltas, 1000).await.unwrap();
+    assert_eq!(result.state.clamped_score, 100, "visible score must clamp at 100");
+
+    let state = store.read(&key).await.unwrap().expect("state must persist");
+    assert_eq!(state.clamped_score, 100);
+    assert!(
+        state
+            .contributors
+            .iter()
+            .any(|c| matches!(c.kind, ContributorKind::AdminCredit)),
+        "credit contributor must survive the round-trip"
+    );
+}
+
+/// Decay must honor a non-default configured rate.
+///
+/// Call with a store built with `decay_rate = 3` and otherwise-default decay
+/// settings (memory: `MemoryRiskStore::with_decay`, redis: `RedisRiskConfig.decay`).
+pub async fn test_decay_honors_configured_rate<S: RiskStore>(store: &S) {
+    use crate::risk::decay::{MAX_DECAY, MIN_CLEAN_STREAK};
+
+    store.reset_all().await.unwrap();
+
+    let key = RiskKey::from_ip(IpAddr::V4(Ipv4Addr::new(10, 12, 12, 12)));
+    let seed = i16::try_from(MAX_DECAY).unwrap() + 40;
+    store.apply(&key, &[make_contributor(seed, 1000)], 1000).await.unwrap();
+
+    // Build the clean streak; decay checks the streak BEFORE folding, so no
+    // decay fires while the streak climbs to the threshold.
+    let mut now_ms = 1000;
+    for _ in 0..MIN_CLEAN_STREAK {
+        now_ms += 1000;
+        store.apply(&key, &[], now_ms).await.unwrap();
+    }
+
+    now_ms += 1000;
+    let result = store.apply(&key, &[], now_ms).await.unwrap();
+    assert_eq!(
+        i32::from(result.state.clamped_score),
+        i32::from(seed) - 3,
+        "decay must subtract the configured rate, not the default"
+    );
+}
+
+/// A store built with `decay_rate = 0` must never decay, no matter how long
+/// the clean streak grows.
+pub async fn test_decay_disabled_when_rate_zero<S: RiskStore>(store: &S) {
+    store.reset_all().await.unwrap();
+
+    let key = RiskKey::from_ip(IpAddr::V4(Ipv4Addr::new(10, 13, 13, 13)));
+    store.apply(&key, &[make_contributor(90, 1000)], 1000).await.unwrap();
+
+    let mut now_ms = 1000;
+    for _ in 0..30 {
+        now_ms += 1000;
+        let result = store.apply(&key, &[], now_ms).await.unwrap();
+        assert_eq!(
+            result.state.clamped_score, 90,
+            "decay_rate 0 must leave the score untouched"
+        );
+    }
+
+    let state = store.read(&key).await.unwrap().expect("state must persist");
+    assert!(
+        !state
+            .contributors
+            .iter()
+            .any(|c| matches!(c.kind, ContributorKind::Decay)),
+        "decay_rate 0 must not append Decay contributors"
+    );
+}
+
 /// Admin clear must remove the state so no axis resurrects the old score.
 pub async fn test_clear_removes_all_axes<S: RiskStore>(store: &S) {
     store.reset_all().await.unwrap();
@@ -334,11 +419,30 @@ async fn test_purge_expired<S: RiskStore>(store: &S) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::risk::config::DecayConfig;
     use crate::risk::store::MemoryRiskStore;
 
     #[tokio::test]
     async fn memory_store_passes_conformance() {
         let store = MemoryRiskStore::new();
         run_all(&store).await;
+    }
+
+    #[tokio::test]
+    async fn memory_store_decay_honors_configured_rate() {
+        let store = MemoryRiskStore::with_decay(DecayConfig {
+            decay_rate: 3,
+            ..Default::default()
+        });
+        test_decay_honors_configured_rate(&store).await;
+    }
+
+    #[tokio::test]
+    async fn memory_store_decay_disabled_when_rate_zero() {
+        let store = MemoryRiskStore::with_decay(DecayConfig {
+            decay_rate: 0,
+            ..Default::default()
+        });
+        test_decay_disabled_when_rate_zero(&store).await;
     }
 }

--- a/crates/waf-engine/src/risk/store/memory.rs
+++ b/crates/waf-engine/src/risk/store/memory.rs
@@ -14,6 +14,7 @@ use parking_lot::RwLock;
 use tokio::time::interval;
 use tracing::{debug, info};
 
+use crate::risk::config::DecayConfig;
 use crate::risk::decay::apply_decay;
 use crate::risk::key::RiskKey;
 use crate::risk::score::fold;
@@ -28,15 +29,23 @@ pub struct MemoryRiskStore {
     by_ip: DashMap<IpAddr, StateRef>,
     by_fp: DashMap<u64, StateRef>,
     by_session: DashMap<Vec<u8>, StateRef>,
+    decay: DecayConfig,
 }
 
 impl MemoryRiskStore {
     #[must_use]
     pub fn new() -> Self {
+        Self::with_decay(DecayConfig::default())
+    }
+
+    /// Build a store whose decay follows the given config instead of defaults.
+    #[must_use]
+    pub fn with_decay(decay: DecayConfig) -> Self {
         Self {
             by_ip: DashMap::new(),
             by_fp: DashMap::new(),
             by_session: DashMap::new(),
+            decay,
         }
     }
 
@@ -151,7 +160,7 @@ impl RiskStore for MemoryRiskStore {
             let mut state = state_ref.write();
             // Decay BEFORE fold (FR-025 §4): read state → decay → fold new deltas
             if !is_new {
-                apply_decay(&mut state, now_ms);
+                apply_decay(&mut state, now_ms, &self.decay);
             }
             fold(&mut state, deltas, now_ms);
         }

--- a/crates/waf-engine/src/risk/store/redis.rs
+++ b/crates/waf-engine/src/risk/store/redis.rs
@@ -29,7 +29,7 @@ use tokio::time::timeout;
 use tracing::{debug, warn};
 
 use super::redis_lua::{APPLY_SCRIPT, CLEAR_SCRIPT, FORCE_MAX_SCRIPT};
-use crate::risk::decay::{DECAY_RATE, MAX_DECAY, MIN_CLEAN_STREAK};
+use crate::risk::config::DecayConfig;
 use crate::risk::key::RiskKey;
 use crate::risk::state::{Contributor, RiskState};
 use crate::risk::store::store_trait::{ApplyResult, RiskStore};
@@ -49,6 +49,8 @@ pub struct RedisRiskConfig {
     pub breaker_threshold: u32,
     /// LRU cache capacity for fail-open fallback (default: 10000).
     pub cache_capacity: usize,
+    /// Decay parameters fed into the Lua apply script.
+    pub decay: DecayConfig,
 }
 
 impl Default for RedisRiskConfig {
@@ -60,6 +62,7 @@ impl Default for RedisRiskConfig {
             op_timeout: Duration::from_millis(100),
             breaker_threshold: 5,
             cache_capacity: 10_000,
+            decay: DecayConfig::default(),
         }
     }
 }
@@ -367,9 +370,9 @@ impl RiskStore for RedisRiskStore {
             .arg(now_ms)
             .arg(&deltas_json)
             .arg(self.cfg.ttl_secs)
-            .arg(MIN_CLEAN_STREAK)
-            .arg(DECAY_RATE)
-            .arg(MAX_DECAY);
+            .arg(self.cfg.decay.min_clean_streak)
+            .arg(self.cfg.decay.decay_rate)
+            .arg(self.cfg.decay.max_decay);
 
         let res = timeout(self.cfg.op_timeout, invocation.invoke_async::<String>(&mut conn)).await;
 
@@ -663,6 +666,7 @@ mod tests {
             op_timeout: Duration::from_nanos(1),
             breaker_threshold: 5,
             cache_capacity: 100,
+            decay: DecayConfig::default(),
         })
         .await
         .expect("connect to REDIS_TEST_URL");
@@ -705,6 +709,7 @@ mod tests {
             op_timeout: Duration::from_millis(500),
             breaker_threshold: 5,
             cache_capacity: 100,
+            decay: DecayConfig::default(),
         })
         .await
         .expect("connect to REDIS_TEST_URL");
@@ -741,6 +746,7 @@ mod tests {
             op_timeout: Duration::from_millis(500),
             breaker_threshold: 5,
             cache_capacity: 100,
+            decay: DecayConfig::default(),
         })
         .await
         .expect("connect to REDIS_TEST_URL");

--- a/crates/waf-engine/src/risk/tests/conformance_redis.rs
+++ b/crates/waf-engine/src/risk/tests/conformance_redis.rs
@@ -7,7 +7,8 @@
 
 use std::time::Duration;
 
-use crate::risk::store::conformance::run_all;
+use crate::risk::config::DecayConfig;
+use crate::risk::store::conformance::{run_all, test_decay_disabled_when_rate_zero, test_decay_honors_configured_rate};
 use crate::risk::store::redis::{RedisRiskConfig, RedisRiskStore};
 
 fn unique_prefix() -> String {
@@ -32,11 +33,64 @@ async fn redis_store_passes_conformance() {
         op_timeout: Duration::from_millis(500),
         breaker_threshold: 5,
         cache_capacity: 1000,
+        decay: DecayConfig::default(),
     })
     .await
     .expect("connect to REDIS_TEST_URL");
 
     run_all(&store).await;
+}
+
+/// The Lua apply script must decay by the configured rate, not the default.
+#[tokio::test]
+async fn redis_decay_honors_configured_rate() {
+    let Ok(url) = std::env::var("REDIS_TEST_URL") else {
+        tracing::info!("skipping: REDIS_TEST_URL unset");
+        return;
+    };
+
+    let store = RedisRiskStore::new(RedisRiskConfig {
+        url,
+        key_prefix: unique_prefix(),
+        ttl_secs: 3600,
+        op_timeout: Duration::from_millis(500),
+        breaker_threshold: 5,
+        cache_capacity: 1000,
+        decay: DecayConfig {
+            decay_rate: 3,
+            ..Default::default()
+        },
+    })
+    .await
+    .expect("connect to REDIS_TEST_URL");
+
+    test_decay_honors_configured_rate(&store).await;
+}
+
+/// The Lua apply script must not decay at all when `decay_rate` is 0.
+#[tokio::test]
+async fn redis_decay_disabled_when_rate_zero() {
+    let Ok(url) = std::env::var("REDIS_TEST_URL") else {
+        tracing::info!("skipping: REDIS_TEST_URL unset");
+        return;
+    };
+
+    let store = RedisRiskStore::new(RedisRiskConfig {
+        url,
+        key_prefix: unique_prefix(),
+        ttl_secs: 3600,
+        op_timeout: Duration::from_millis(500),
+        breaker_threshold: 5,
+        cache_capacity: 1000,
+        decay: DecayConfig {
+            decay_rate: 0,
+            ..Default::default()
+        },
+    })
+    .await
+    .expect("connect to REDIS_TEST_URL");
+
+    test_decay_disabled_when_rate_zero(&store).await;
 }
 
 /// Test that multiple applies accumulate correctly.
@@ -58,6 +112,7 @@ async fn redis_apply_accumulates_score() {
         op_timeout: Duration::from_millis(500),
         breaker_threshold: 5,
         cache_capacity: 1000,
+        decay: DecayConfig::default(),
     })
     .await
     .expect("connect");
@@ -101,6 +156,7 @@ async fn redis_triple_key_converges() {
         op_timeout: Duration::from_millis(500),
         breaker_threshold: 5,
         cache_capacity: 1000,
+        decay: DecayConfig::default(),
     })
     .await
     .expect("connect");
@@ -163,6 +219,7 @@ async fn redis_force_max_pins_score() {
         op_timeout: Duration::from_millis(500),
         breaker_threshold: 5,
         cache_capacity: 1000,
+        decay: DecayConfig::default(),
     })
     .await
     .expect("connect");
@@ -203,6 +260,7 @@ async fn redis_reset_all_clears_store() {
         op_timeout: Duration::from_millis(500),
         breaker_threshold: 5,
         cache_capacity: 1000,
+        decay: DecayConfig::default(),
     })
     .await
     .expect("connect");

--- a/crates/waf-engine/src/risk/tests/lifecycle.rs
+++ b/crates/waf-engine/src/risk/tests/lifecycle.rs
@@ -200,7 +200,7 @@ fn decay_respects_max_decay_floor() {
     // Decay should bring score down but not below MAX_DECAY
     for i in 0..20 {
         let ts = 2000 + i64::from(i) * 100;
-        apply_decay(&mut state, ts);
+        apply_decay(&mut state, ts, &crate::risk::config::DecayConfig::default());
     }
 
     assert!(

--- a/crates/waf-engine/src/risk/tests/redis_failover.rs
+++ b/crates/waf-engine/src/risk/tests/redis_failover.rs
@@ -7,6 +7,7 @@
 
 use std::time::Duration;
 
+use crate::risk::config::DecayConfig;
 use crate::risk::key::RiskKey;
 use crate::risk::state::{Contributor, ContributorKind, SeedKind};
 use crate::risk::store::RiskStore;
@@ -40,6 +41,7 @@ async fn cache_fallback_on_redis_failure() {
         op_timeout: Duration::from_millis(500),
         breaker_threshold: 5,
         cache_capacity: 1000,
+        decay: DecayConfig::default(),
     })
     .await
     .expect("connect");
@@ -154,6 +156,7 @@ async fn len_counts_state_keys() {
         op_timeout: Duration::from_millis(500),
         breaker_threshold: 5,
         cache_capacity: 1000,
+        decay: DecayConfig::default(),
     })
     .await
     .expect("connect");
@@ -191,6 +194,7 @@ async fn concurrent_applies_are_safe() {
             op_timeout: Duration::from_millis(500),
             breaker_threshold: 5,
             cache_capacity: 1000,
+            decay: DecayConfig::default(),
         })
         .await
         .expect("connect"),

--- a/docs/journals/2026-07-05-gh-204-risk-delta-cap-decay-config-implementation.md
+++ b/docs/journals/2026-07-05-gh-204-risk-delta-cap-decay-config-implementation.md
@@ -1,0 +1,58 @@
+# 2026-07-05 — GH-204: risk per-request delta cap + configurable decay + config validation
+
+## What
+
+Three fixes on branch `fix/gh-204-risk-delta-cap-decay-config` (stacked on
+`fix/gh-201-redis-failmode-policy`):
+
+1. **Per-request delta cap enforced.** `clamp_per_request_deltas` existed but was
+   never called. Now wired into both entry points: `Scorer::score_with_l2` (sync
+   path, after seed/anomaly/velocity/credit deltas are gathered) and the ingest
+   worker's `process_job` (async path). Cap bounds one request's positive delta
+   sum to 100 while preserving negative credits; the store fold's total-score
+   clamp is a distinct, complementary op. Canary `force_max` stays uncapped by
+   design (pin, not delta).
+2. **`DecayConfig` honored by both backends.** `apply_decay`/`preview_decay` now
+   take `&DecayConfig` instead of reading the `MAX_DECAY`/`MIN_CLEAN_STREAK`/
+   `DECAY_RATE` consts. `MemoryRiskStore` gains `with_decay(DecayConfig)`
+   (constructor injection — no `RiskStore` trait change); `RedisRiskConfig` gains
+   a `decay` field fed into the Lua apply script ARGVs.
+   `RedisStoreConfig::to_runtime_config(ttl, decay)` and the engine's
+   `build_risk_store` thread the config through both backends. Decay settings are
+   store-lifetime (no hot-reload; YAGNI). `decay_rate: 0` disables decay through
+   the existing arithmetic — no special branch.
+3. **`RiskConfig::validate()` wired into `from_path`.** Rejects `ttl_secs == 0`,
+   `gc_interval_secs == 0` (would panic `tokio::time::interval`),
+   `ingest.channel_capacity == 0` (would panic the bounded mpsc), unknown
+   `store.backend`, and `decay.max_decay > 100`. `decay_rate: 0` and
+   `min_clean_streak: 0` are valid. `reload.rs` is already fail-soft, so a bad
+   YAML edit keeps the previous snapshot. Risk thresholds live in
+   `TierPolicy.risk_thresholds` — out of scope here.
+
+## Verified
+
+- `cargo test -p waf-engine --lib --features redis-store "risk::"` → 273 passed.
+- New tests: scorer end-to-end cap test (160 positive + −20 credit → score 80);
+  conformance `test_oversized_batch_clamps_to_cap` added to `run_all` (both
+  backends); `test_decay_honors_configured_rate` (rate 3) and
+  `test_decay_disabled_when_rate_zero` as pub conformance fns — memory via
+  `with_decay`, redis via `REDIS_TEST_URL`-gated tests; 8 validate() unit tests
+  plus a `from_path` reject-without-panic test.
+- `cargo clippy --workspace --all-targets` and `-p waf-engine --features
+  redis-store` clean; `cargo build -p prx-waf` green.
+- Full lib suite: 1449 passed; 6 `engine::tests::*` failures are the known
+  docker-gated testcontainer set (no docker socket locally; CI covers).
+
+## Gotchas
+
+- **`StoreConfig` derived `Default` yielded `backend: ""`** — inconsistent with
+  the serde default `"memory"`. Harmless before (engine only checks `== "redis"`)
+  but `validate()` exposed it: `RiskConfig::default().validate()` failed. Fixed
+  with a manual `Default` impl using `default_backend()`.
+- The decay consts (`MAX_DECAY` etc.) remain as test/bench references and as the
+  `DecayConfig` default values; runtime reads only the config.
+- sed-inserting the `decay` field after `cache_capacity:` lines also matched the
+  `Default for RedisRiskConfig` impl → duplicate field (E0062). Prefer targeted
+  edits over blanket seds on struct-literal patterns.
+- clippy `too_long_first_doc_paragraph` fires on 3-line first paragraphs — split
+  doc comments with a blank `///` line.

--- a/plans/260705-0958-gh-204-risk-delta-cap-decay-config/phase-01-enforce-per-request-delta-cap-in-the-scoring-pipeline.md
+++ b/plans/260705-0958-gh-204-risk-delta-cap-decay-config/phase-01-enforce-per-request-delta-cap-in-the-scoring-pipeline.md
@@ -1,7 +1,7 @@
 ---
 phase: 1
 title: "Enforce per-request delta cap in the scoring pipeline"
-status: pending
+status: completed
 effort: 1h
 ---
 

--- a/plans/260705-0958-gh-204-risk-delta-cap-decay-config/phase-02-honor-decayconfig-across-memory-and-redis-backends.md
+++ b/plans/260705-0958-gh-204-risk-delta-cap-decay-config/phase-02-honor-decayconfig-across-memory-and-redis-backends.md
@@ -1,7 +1,7 @@
 ---
 phase: 2
 title: "Honor DecayConfig across memory and redis backends"
-status: pending
+status: completed
 effort: 2h
 ---
 

--- a/plans/260705-0958-gh-204-risk-delta-cap-decay-config/phase-03-add-riskconfig-validate-wired-into-config-load.md
+++ b/plans/260705-0958-gh-204-risk-delta-cap-decay-config/phase-03-add-riskconfig-validate-wired-into-config-load.md
@@ -1,7 +1,7 @@
 ---
 phase: 3
 title: "Add RiskConfig::validate wired into config load"
-status: pending
+status: completed
 effort: 1h
 ---
 

--- a/plans/260705-0958-gh-204-risk-delta-cap-decay-config/phase-04-acceptance-tests-and-quality-gates.md
+++ b/plans/260705-0958-gh-204-risk-delta-cap-decay-config/phase-04-acceptance-tests-and-quality-gates.md
@@ -1,7 +1,7 @@
 ---
 phase: 4
 title: "Acceptance tests and quality gates"
-status: pending
+status: completed
 effort: 1h
 ---
 

--- a/plans/260705-0958-gh-204-risk-delta-cap-decay-config/plan.md
+++ b/plans/260705-0958-gh-204-risk-delta-cap-decay-config/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "GH-204 risk: enforce per-request delta cap, honor DecayConfig, add RiskConfig::validate"
 description: "Wire the defined-but-unused per-request delta cap into the scorer, thread DecayConfig into both store backends so it stops being dead config, and add RiskConfig::validate at the parse boundary"
-status: pending
+status: completed
 priority: P2
 effort: 5h
 branch: "main-harness"


### PR DESCRIPTION
Closes #204

**Stacked PR** — based on `fix/gh-200-canary-before-seed-early-return` (PR #214, which now also carries the squash-merged #215). Merge order: #212 → #213 → #214 → this. GitHub retargets automatically when the parent squash-merges and its branch is deleted.

## What

Three fixes from the committed plan (`plans/260705-0958-gh-204-risk-delta-cap-decay-config/`):

1. **Per-request delta cap enforced.** `clamp_per_request_deltas` existed but was never called. It is now wired into both scoring entry points: the sync scorer path (`Scorer::score_with_l2`, after seed/anomaly/velocity/credit deltas are collected) and the async ingest worker (`process_job`). One request's positive delta sum is capped at 100 (newest deltas win); negative credits always survive. The store fold's total-score clamp is a distinct, complementary operation. Canary `force_max` stays uncapped by design (score pin, not a delta).
2. **`DecayConfig` honored by both store backends.** `apply_decay`/`preview_decay` take `&DecayConfig` instead of hardcoded consts. `MemoryRiskStore::with_decay(DecayConfig)` injects it (no `RiskStore` trait change); `RedisRiskConfig` gains a `decay` field fed into the Lua apply script ARGVs. `RedisStoreConfig::to_runtime_config(ttl, decay)` and `WafEngine::build_risk_store` thread the loaded config through both backends. `decay_rate: 0` disables decay via the existing arithmetic. Decay settings are store-lifetime (stores are built at startup; no hot-reload).
3. **`RiskConfig::validate()` wired into `from_path`.** Rejects `ttl_secs == 0`, `gc_interval_secs == 0` (would panic `tokio::time::interval`), `ingest.channel_capacity == 0` (would panic the bounded mpsc), unknown `store.backend`, and `decay.max_decay > 100`. `decay_rate: 0` and `min_clean_streak: 0` remain valid. `reload.rs` is already fail-soft, so an invalid YAML edit keeps the previous snapshot. Also fixes `StoreConfig`'s derived `Default` yielding `backend: ""` (now matches the serde default `"memory"`).

## Tests

- Scorer end-to-end: oversized positive batch (160) + −20 credit → score 80 (cap bound, credit preserved).
- Conformance `run_all` gains `test_oversized_batch_clamps_to_cap` (memory always, redis under `REDIS_TEST_URL`).
- New pub conformance cases `test_decay_honors_configured_rate` (rate 3) and `test_decay_disabled_when_rate_zero`, run against `MemoryRiskStore::with_decay` and `REDIS_TEST_URL`-gated `RedisRiskStore`.
- 8 `validate()` unit tests + a `from_path` reject-without-panic test.

## Gates

- `cargo test -p waf-engine --lib --features redis-store "risk::"` → 273 passed.
- Full lib suite 1449 passed; the 6 `engine::tests::*` failures are the known docker-gated testcontainer set (no docker socket locally; CI covers).
- `cargo clippy --workspace --all-targets` clean (also with `--features redis-store`).
- `cargo build -p prx-waf` green.
