### PR TITLE
fix(waf-engine): key ddos risk bumps by client ip via sync submit seam

### DIFF
--- a/crates/waf-api/src/access_lists_api.rs
+++ b/crates/waf-api/src/access_lists_api.rs
@@ -12,44 +12,9 @@ use axum::{
 use serde::Deserialize;
 use serde_json::{Value, json};
 
-use crate::error::{ApiError, ApiResult};
+use crate::config_files::{read_yaml_opt, resolve_path, write_yaml};
+use crate::error::ApiResult;
 use crate::state::AppState;
-
-fn resolve_path(state: &AppState, relative: &str) -> std::path::PathBuf {
-    state.main_config_file.as_ref().map_or_else(
-        || std::path::PathBuf::from(relative),
-        |main| {
-            let p = std::path::Path::new(main.as_str());
-            let root = p
-                .parent()
-                .and_then(|c| c.parent())
-                .unwrap_or_else(|| std::path::Path::new("."));
-            root.join(relative)
-        },
-    )
-}
-
-async fn read_yaml_opt(path: &std::path::Path) -> Option<Value> {
-    let raw = tokio::fs::read_to_string(path).await.ok()?;
-    serde_yaml::from_str::<Value>(&raw).ok()
-}
-
-async fn write_yaml(path: &std::path::Path, value: &Value) -> Result<(), ApiError> {
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .map_err(|e| ApiError::Internal(anyhow::anyhow!("mkdir: {e}")))?;
-    }
-    let s = serde_yaml::to_string(value).map_err(|e| ApiError::Internal(anyhow::anyhow!("{e}")))?;
-    let tmp = path.with_extension("yaml.tmp");
-    tokio::fs::write(&tmp, s.as_bytes())
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("write: {e}")))?;
-    tokio::fs::rename(&tmp, path)
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("rename: {e}")))?;
-    Ok(())
-}
 
 fn default_access_config() -> Value {
     json!({

--- a/crates/waf-api/src/challenge_api.rs
+++ b/crates/waf-api/src/challenge_api.rs
@@ -9,48 +9,17 @@ use std::sync::Arc;
 use axum::{Json, extract::State, http::header, response::IntoResponse};
 use serde_json::{Value, json};
 
+use crate::config_files::{resolve_path, write_yaml};
 use crate::error::{ApiError, ApiResult};
 use crate::state::AppState;
 
-// ─── Path helper ─────────────────────────────────────────────────────────────
-
-fn resolve_path(state: &AppState, relative: &str) -> std::path::PathBuf {
-    state.main_config_file.as_ref().map_or_else(
-        || std::path::PathBuf::from(relative),
-        |main| {
-            let p = std::path::Path::new(main.as_str());
-            let root = p
-                .parent()
-                .and_then(|c| c.parent())
-                .unwrap_or_else(|| std::path::Path::new("."));
-            root.join(relative)
-        },
-    )
-}
-
+/// Unlike the shared `read_yaml_opt`, a present-but-malformed file surfaces
+/// as `BadRequest` here instead of silently falling back to defaults.
 async fn read_yaml(path: &std::path::Path) -> Result<Value, ApiError> {
     tokio::fs::read_to_string(path).await.map_or_else(
         |_| Ok(Value::Null),
         |raw| serde_yaml::from_str::<Value>(&raw).map_err(|e| ApiError::BadRequest(format!("parse YAML: {e}"))),
     )
-}
-
-async fn write_yaml(path: &std::path::Path, value: &Value) -> Result<(), ApiError> {
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .map_err(|e| ApiError::Internal(anyhow::anyhow!("mkdir: {e}")))?;
-    }
-    let s = serde_yaml::to_string(value).map_err(|e| ApiError::Internal(anyhow::anyhow!("yaml: {e}")))?;
-    // Atomic write via temp file
-    let tmp = path.with_extension("yaml.tmp");
-    tokio::fs::write(&tmp, s.as_bytes())
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("write tmp: {e}")))?;
-    tokio::fs::rename(&tmp, path)
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("rename: {e}")))?;
-    Ok(())
 }
 
 // ─── Mapping helpers ──────────────────────────────────────────────────────────

--- a/crates/waf-api/src/config_files.rs
+++ b/crates/waf-api/src/config_files.rs
@@ -1,0 +1,58 @@
+//! Shared YAML config-file helpers for admin API modules.
+//!
+//! Every YAML-backed config endpoint resolves paths relative to the main
+//! config file's root and persists changes with the same atomic
+//! tmp-write-then-rename sequence. Defining the helpers once here means a
+//! fix to root resolution or write atomicity lands everywhere at once.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::error::ApiError;
+use crate::state::AppState;
+
+/// Resolve `relative` against the config root (two levels above the main
+/// config file). Falls back to `relative` as a bare path when no main
+/// config file is set.
+pub fn resolve_path(state: &AppState, relative: &str) -> PathBuf {
+    state.main_config_file.as_ref().map_or_else(
+        || PathBuf::from(relative),
+        |main| {
+            let p = Path::new(main.as_str());
+            let root = p.parent().and_then(|c| c.parent()).unwrap_or_else(|| Path::new("."));
+            root.join(relative)
+        },
+    )
+}
+
+/// Read and parse a YAML file. `None` when the file is missing, unreadable,
+/// or fails to parse — callers treat all three as "use defaults".
+pub async fn read_yaml_opt(path: &Path) -> Option<Value> {
+    let raw = tokio::fs::read_to_string(path).await.ok()?;
+    serde_yaml::from_str::<Value>(&raw).ok()
+}
+
+/// Atomically persist pre-serialized YAML: create the parent directory,
+/// write to `<stem>.yaml.tmp`, then rename over `path`.
+pub async fn write_yaml_str(path: &Path, contents: &str) -> Result<(), ApiError> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| ApiError::Internal(anyhow::anyhow!("mkdir: {e}")))?;
+    }
+    let tmp = path.with_extension("yaml.tmp");
+    tokio::fs::write(&tmp, contents.as_bytes())
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("write: {e}")))?;
+    tokio::fs::rename(&tmp, path)
+        .await
+        .map_err(|e| ApiError::Internal(anyhow::anyhow!("rename: {e}")))?;
+    Ok(())
+}
+
+/// Serialize `value` to YAML and persist it atomically via [`write_yaml_str`].
+pub async fn write_yaml(path: &Path, value: &Value) -> Result<(), ApiError> {
+    let s = serde_yaml::to_string(value).map_err(|e| ApiError::Internal(anyhow::anyhow!("{e}")))?;
+    write_yaml_str(path, &s).await
+}

--- a/crates/waf-api/src/ddos_api.rs
+++ b/crates/waf-api/src/ddos_api.rs
@@ -17,6 +17,7 @@ use serde_json::{Value, json};
 use waf_engine::checks::ddos::config::{DdosDocument, DdosFileConfig};
 
 use crate::auth::validate_access_token;
+use crate::config_files::{resolve_path, write_yaml_str};
 use crate::error::{ApiError, ApiResult};
 use crate::state::AppState;
 
@@ -32,20 +33,6 @@ fn now_epoch_ms() -> i64 {
 fn bearer_username(headers: &HeaderMap, secret: &str) -> Option<String> {
     let token = headers.get(AUTHORIZATION)?.to_str().ok()?.strip_prefix("Bearer ")?;
     validate_access_token(token, secret).ok().map(|c| c.sub)
-}
-
-fn resolve_path(state: &AppState, relative: &str) -> std::path::PathBuf {
-    state.main_config_file.as_ref().map_or_else(
-        || std::path::PathBuf::from(relative),
-        |main| {
-            let p = std::path::Path::new(main.as_str());
-            let root = p
-                .parent()
-                .and_then(|c| c.parent())
-                .unwrap_or_else(|| std::path::Path::new("."));
-            root.join(relative)
-        },
-    )
 }
 
 // ─── Handlers ─────────────────────────────────────────────────────────────────
@@ -71,18 +58,7 @@ pub async fn put_ddos_config(State(state): State<Arc<AppState>>, Json(body): Jso
     let path = resolve_path(&state, "configs/ddos.yaml");
     let yaml_str =
         serde_yaml::to_string(&doc).map_err(|e| ApiError::Internal(anyhow::anyhow!("serialize yaml: {e}")))?;
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .map_err(|e| ApiError::Internal(anyhow::anyhow!("mkdir: {e}")))?;
-    }
-    let tmp = path.with_extension("yaml.tmp");
-    tokio::fs::write(&tmp, yaml_str.as_bytes())
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("write: {e}")))?;
-    tokio::fs::rename(&tmp, &path)
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("rename: {e}")))?;
+    write_yaml_str(&path, &yaml_str).await?;
     let data =
         serde_json::to_value(&doc.ddos).map_err(|e| ApiError::Internal(anyhow::anyhow!("serialize response: {e}")))?;
     Ok(Json(json!({ "success": true, "data": data })))

--- a/crates/waf-api/src/device_fp_api.rs
+++ b/crates/waf-api/src/device_fp_api.rs
@@ -9,44 +9,9 @@ use std::sync::Arc;
 use axum::{Json, extract::State};
 use serde_json::{Value, json};
 
-use crate::error::{ApiError, ApiResult};
+use crate::config_files::{read_yaml_opt, resolve_path, write_yaml};
+use crate::error::ApiResult;
 use crate::state::AppState;
-
-fn resolve_path(state: &AppState, relative: &str) -> std::path::PathBuf {
-    state.main_config_file.as_ref().map_or_else(
-        || std::path::PathBuf::from(relative),
-        |main| {
-            let p = std::path::Path::new(main.as_str());
-            let root = p
-                .parent()
-                .and_then(|c| c.parent())
-                .unwrap_or_else(|| std::path::Path::new("."));
-            root.join(relative)
-        },
-    )
-}
-
-async fn read_yaml_opt(path: &std::path::Path) -> Option<Value> {
-    let raw = tokio::fs::read_to_string(path).await.ok()?;
-    serde_yaml::from_str::<Value>(&raw).ok()
-}
-
-async fn write_yaml(path: &std::path::Path, value: &Value) -> Result<(), ApiError> {
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .map_err(|e| ApiError::Internal(anyhow::anyhow!("mkdir: {e}")))?;
-    }
-    let s = serde_yaml::to_string(value).map_err(|e| ApiError::Internal(anyhow::anyhow!("{e}")))?;
-    let tmp = path.with_extension("yaml.tmp");
-    tokio::fs::write(&tmp, s.as_bytes())
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("write: {e}")))?;
-    tokio::fs::rename(&tmp, path)
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("rename: {e}")))?;
-    Ok(())
-}
 
 /// Convert YAML providers list → FE object keyed by provider name.
 /// Adds `enabled: true` for any entry that lacks it.

--- a/crates/waf-api/src/geo_api.rs
+++ b/crates/waf-api/src/geo_api.rs
@@ -13,53 +13,21 @@ use axum::{
 };
 use serde_json::{Value, json};
 
+use crate::config_files::{read_yaml_opt, resolve_path, write_yaml};
 use crate::error::{ApiError, ApiResult};
 use crate::state::AppState;
-
-// ─── Path helpers ──────────────────────────────────────────────────────────────
-
-fn rules_path(state: &AppState) -> std::path::PathBuf {
-    state.main_config_file.as_ref().map_or_else(
-        || std::path::PathBuf::from("configs/geo-rules.yaml"),
-        |main| {
-            let p = std::path::Path::new(main.as_str());
-            let root = p
-                .parent()
-                .and_then(|c| c.parent())
-                .unwrap_or_else(|| std::path::Path::new("."));
-            root.join("configs/geo-rules.yaml")
-        },
-    )
-}
 
 // ─── YAML helpers ─────────────────────────────────────────────────────────────
 
 async fn read_rules(path: &std::path::Path) -> Vec<Value> {
-    let Ok(raw) = tokio::fs::read_to_string(path).await else {
-        return vec![];
-    };
-    let Ok(doc) = serde_yaml::from_str::<Value>(&raw) else {
-        return vec![];
-    };
-    doc.get("rules").and_then(|v| v.as_array()).cloned().unwrap_or_default()
+    read_yaml_opt(path)
+        .await
+        .and_then(|doc| doc.get("rules").and_then(|v| v.as_array()).cloned())
+        .unwrap_or_default()
 }
 
 async fn write_rules(path: &std::path::Path, rules: &[Value]) -> Result<(), ApiError> {
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .map_err(|e| ApiError::Internal(anyhow::anyhow!("mkdir: {e}")))?;
-    }
-    let doc = json!({ "rules": rules });
-    let s = serde_yaml::to_string(&doc).map_err(|e| ApiError::Internal(anyhow::anyhow!("yaml serialize: {e}")))?;
-    let tmp = path.with_extension("yaml.tmp");
-    tokio::fs::write(&tmp, s.as_bytes())
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("write: {e}")))?;
-    tokio::fs::rename(&tmp, path)
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("rename: {e}")))?;
-    Ok(())
+    write_yaml(path, &json!({ "rules": rules })).await
 }
 
 fn next_id(rules: &[Value]) -> i64 {
@@ -74,14 +42,14 @@ fn next_id(rules: &[Value]) -> i64 {
 // ─── Handlers ─────────────────────────────────────────────────────────────────
 
 pub async fn list_geo_rules(State(state): State<Arc<AppState>>) -> ApiResult<Json<Value>> {
-    let path = rules_path(&state);
+    let path = resolve_path(&state, "configs/geo-rules.yaml");
     let rules = read_rules(&path).await;
     let total = rules.len();
     Ok(Json(json!({ "success": true, "data": rules, "total": total })))
 }
 
 pub async fn create_geo_rule(State(state): State<Arc<AppState>>, Json(body): Json<Value>) -> ApiResult<Json<Value>> {
-    let path = rules_path(&state);
+    let path = resolve_path(&state, "configs/geo-rules.yaml");
     let mut rules = read_rules(&path).await;
 
     let iso = body
@@ -97,6 +65,7 @@ pub async fn create_geo_rule(State(state): State<Arc<AppState>>, Json(body): Jso
         "action":       body.get("action").and_then(|v| v.as_str()).unwrap_or("block"),
         "scope":        body.get("scope").and_then(|v| v.as_str()).unwrap_or("global"),
         "enabled":      true,
+        "fail_closed":  body.get("fail_closed").and_then(Value::as_bool).unwrap_or(false),
         "created_at":   chrono::Utc::now().to_rfc3339(),
     });
 
@@ -110,7 +79,7 @@ pub async fn patch_geo_rule(
     Path(id): Path<i64>,
     Json(body): Json<Value>,
 ) -> ApiResult<Json<Value>> {
-    let path = rules_path(&state);
+    let path = resolve_path(&state, "configs/geo-rules.yaml");
     let mut rules = read_rules(&path).await;
 
     let idx = rules
@@ -119,7 +88,7 @@ pub async fn patch_geo_rule(
         .ok_or_else(|| ApiError::NotFound(format!("geo rule {id} not found")))?;
 
     if let Some(obj) = rules.get_mut(idx).and_then(Value::as_object_mut) {
-        for field in &["enabled", "action", "scope"] {
+        for field in &["enabled", "action", "scope", "fail_closed"] {
             if let Some(v) = body.get(*field) {
                 obj.insert((*field).to_owned(), v.clone());
             }
@@ -132,7 +101,7 @@ pub async fn patch_geo_rule(
 }
 
 pub async fn delete_geo_rule(State(state): State<Arc<AppState>>, Path(id): Path<i64>) -> ApiResult<Json<Value>> {
-    let path = rules_path(&state);
+    let path = resolve_path(&state, "configs/geo-rules.yaml");
     let mut rules = read_rules(&path).await;
     let before = rules.len();
     rules.retain(|r| r.get("id").and_then(Value::as_i64) != Some(id));

--- a/crates/waf-api/src/lib.rs
+++ b/crates/waf-api/src/lib.rs
@@ -4,6 +4,7 @@ pub mod bot_api;
 pub mod cache_api;
 pub mod challenge_api;
 pub mod cluster;
+mod config_files;
 pub mod crowdsec;
 pub mod ddos_api;
 pub mod device_fp_api;

--- a/crates/waf-api/src/relay_api.rs
+++ b/crates/waf-api/src/relay_api.rs
@@ -10,22 +10,9 @@ use axum::{Json, extract::State};
 use serde_json::{Value, json};
 use waf_engine::relay::config::{RelayConfig, RelayDetectionDocument};
 
+use crate::config_files::{resolve_path, write_yaml_str};
 use crate::error::{ApiError, ApiResult};
 use crate::state::AppState;
-
-fn resolve_path(state: &AppState, relative: &str) -> std::path::PathBuf {
-    state.main_config_file.as_ref().map_or_else(
-        || std::path::PathBuf::from(relative),
-        |main| {
-            let p = std::path::Path::new(main.as_str());
-            let root = p
-                .parent()
-                .and_then(|c| c.parent())
-                .unwrap_or_else(|| std::path::Path::new("."));
-            root.join(relative)
-        },
-    )
-}
 
 // ─── Handlers ─────────────────────────────────────────────────────────────────
 
@@ -50,18 +37,7 @@ pub async fn put_relay_config(State(state): State<Arc<AppState>>, Json(body): Js
     let path = resolve_path(&state, "configs/relay.yaml");
     let yaml_str =
         serde_yaml::to_string(&doc).map_err(|e| ApiError::Internal(anyhow::anyhow!("serialize yaml: {e}")))?;
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .map_err(|e| ApiError::Internal(anyhow::anyhow!("mkdir: {e}")))?;
-    }
-    let tmp = path.with_extension("yaml.tmp");
-    tokio::fs::write(&tmp, yaml_str.as_bytes())
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("write: {e}")))?;
-    tokio::fs::rename(&tmp, &path)
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("rename: {e}")))?;
+    write_yaml_str(&path, &yaml_str).await?;
     let data = serde_json::to_value(&doc.relay_detection)
         .map_err(|e| ApiError::Internal(anyhow::anyhow!("serialize response: {e}")))?;
     Ok(Json(json!({ "success": true, "data": data })))

--- a/crates/waf-api/src/risk_api.rs
+++ b/crates/waf-api/src/risk_api.rs
@@ -17,46 +17,9 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use waf_engine::risk::config::RiskConfig;
 
+use crate::config_files::{read_yaml_opt, resolve_path, write_yaml};
 use crate::error::{ApiError, ApiResult};
 use crate::state::AppState;
-
-// ─── Path helper (shared pattern) ────────────────────────────────────────────
-
-fn resolve_path(state: &AppState, relative: &str) -> std::path::PathBuf {
-    state.main_config_file.as_ref().map_or_else(
-        || std::path::PathBuf::from(relative),
-        |main| {
-            let p = std::path::Path::new(main.as_str());
-            let root = p
-                .parent()
-                .and_then(|c| c.parent())
-                .unwrap_or_else(|| std::path::Path::new("."));
-            root.join(relative)
-        },
-    )
-}
-
-async fn read_yaml_opt(path: &std::path::Path) -> Option<Value> {
-    let raw = tokio::fs::read_to_string(path).await.ok()?;
-    serde_yaml::from_str::<Value>(&raw).ok()
-}
-
-async fn write_yaml(path: &std::path::Path, value: &Value) -> Result<(), ApiError> {
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .map_err(|e| ApiError::Internal(anyhow::anyhow!("mkdir: {e}")))?;
-    }
-    let s = serde_yaml::to_string(value).map_err(|e| ApiError::Internal(anyhow::anyhow!("{e}")))?;
-    let tmp = path.with_extension("yaml.tmp");
-    tokio::fs::write(&tmp, s.as_bytes())
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("write: {e}")))?;
-    tokio::fs::rename(&tmp, path)
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("rename: {e}")))?;
-    Ok(())
-}
 
 // ─── Config helpers ───────────────────────────────────────────────────────────
 

--- a/crates/waf-api/src/tier_policies_api.rs
+++ b/crates/waf-api/src/tier_policies_api.rs
@@ -8,44 +8,9 @@ use std::sync::Arc;
 use axum::{Json, extract::State};
 use serde_json::{Value, json};
 
+use crate::config_files::{read_yaml_opt, resolve_path, write_yaml};
 use crate::error::{ApiError, ApiResult};
 use crate::state::AppState;
-
-fn resolve_path(state: &AppState, relative: &str) -> std::path::PathBuf {
-    state.main_config_file.as_ref().map_or_else(
-        || std::path::PathBuf::from(relative),
-        |main| {
-            let p = std::path::Path::new(main.as_str());
-            let root = p
-                .parent()
-                .and_then(|c| c.parent())
-                .unwrap_or_else(|| std::path::Path::new("."));
-            root.join(relative)
-        },
-    )
-}
-
-async fn read_yaml_opt(path: &std::path::Path) -> Option<Value> {
-    let raw = tokio::fs::read_to_string(path).await.ok()?;
-    serde_yaml::from_str::<Value>(&raw).ok()
-}
-
-async fn write_yaml(path: &std::path::Path, value: &Value) -> Result<(), ApiError> {
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .map_err(|e| ApiError::Internal(anyhow::anyhow!("mkdir: {e}")))?;
-    }
-    let s = serde_yaml::to_string(value).map_err(|e| ApiError::Internal(anyhow::anyhow!("{e}")))?;
-    let tmp = path.with_extension("yaml.tmp");
-    tokio::fs::write(&tmp, s.as_bytes())
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("write: {e}")))?;
-    tokio::fs::rename(&tmp, path)
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("rename: {e}")))?;
-    Ok(())
-}
 
 fn default_tier_config() -> Value {
     fn policy(fail: &str, rps: i64, cache: &str, allow: i64, challenge: i64, block: i64) -> Value {

--- a/crates/waf-api/src/tx_velocity_api.rs
+++ b/crates/waf-api/src/tx_velocity_api.rs
@@ -19,22 +19,9 @@ use serde_json::{Value, json};
 use waf_engine::checks::tx_velocity::config::{TxVelocityDocument, TxVelocityFileConfig};
 
 use crate::auth::validate_access_token;
+use crate::config_files::{resolve_path, write_yaml_str};
 use crate::error::{ApiError, ApiResult};
 use crate::state::AppState;
-
-fn resolve_path(state: &AppState, relative: &str) -> std::path::PathBuf {
-    state.main_config_file.as_ref().map_or_else(
-        || std::path::PathBuf::from(relative),
-        |main| {
-            let p = std::path::Path::new(main.as_str());
-            let root = p
-                .parent()
-                .and_then(|c| c.parent())
-                .unwrap_or_else(|| std::path::Path::new("."));
-            root.join(relative)
-        },
-    )
-}
 
 fn bearer_username(headers: &HeaderMap, secret: &str) -> Option<String> {
     let token = headers.get(AUTHORIZATION)?.to_str().ok()?.strip_prefix("Bearer ")?;
@@ -75,18 +62,7 @@ pub async fn put_tx_velocity_config(
         .map_err(|e| ApiError::BadRequest(format!("tx-velocity config validation: {e}")))?;
 
     let path = resolve_path(&state, "configs/tx-velocity.yaml");
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .map_err(|e| ApiError::Internal(anyhow::anyhow!("mkdir: {e}")))?;
-    }
-    let tmp = path.with_extension("yaml.tmp");
-    tokio::fs::write(&tmp, yaml_str.as_bytes())
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("write: {e}")))?;
-    tokio::fs::rename(&tmp, &path)
-        .await
-        .map_err(|e| ApiError::Internal(anyhow::anyhow!("rename: {e}")))?;
+    write_yaml_str(&path, &yaml_str).await?;
 
     // Audit the config mutation.
     let admin_username = bearer_username(&headers, &state.jwt_secret);

--- a/crates/waf-api/tests/handler_geo_rules.rs
+++ b/crates/waf-api/tests/handler_geo_rules.rs
@@ -131,3 +131,58 @@ async fn lookup_rejects_invalid_ip() {
         .expect("lookup send");
     assert_eq!(resp.status(), 400);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fail_closed_round_trips_through_create_and_patch() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let main_cfg = dir.path().join("config/waf.yaml");
+    let s = start_test_server_with_main_config(main_cfg.to_str().unwrap()).await;
+
+    let created: serde_json::Value = client()
+        .post(url_for(s.addr, "/api/geoip/rules"))
+        .bearer_auth(&s.admin_token)
+        .json(&json!({ "iso_code": "US", "action": "allow", "fail_closed": true }))
+        .send()
+        .await
+        .expect("create send")
+        .json()
+        .await
+        .expect("create json");
+    assert_eq!(created["data"]["fail_closed"], true);
+    let id = created["data"]["id"].as_i64().expect("rule id");
+
+    let listed: serde_json::Value = client()
+        .get(url_for(s.addr, "/api/geoip/rules"))
+        .bearer_auth(&s.admin_token)
+        .send()
+        .await
+        .expect("list send")
+        .json()
+        .await
+        .expect("list json");
+    assert_eq!(listed["data"][0]["fail_closed"], true);
+
+    // The persisted file must map to a fail-closed AllowOnly rule.
+    let rules_file = dir.path().join("configs/geo-rules.yaml");
+    let map = parse_geo_rules(&rules_file).expect("engine loader parses API file");
+    let rules = map.get("*").expect("global host rules");
+    assert_eq!(rules[0].mode, GeoRuleMode::AllowOnly);
+    assert!(rules[0].fail_closed);
+
+    // PATCH toggles it back to fail-open.
+    let patched: serde_json::Value = client()
+        .patch(url_for(s.addr, &format!("/api/geoip/rules/{id}")))
+        .bearer_auth(&s.admin_token)
+        .json(&json!({ "fail_closed": false }))
+        .send()
+        .await
+        .expect("patch send")
+        .json()
+        .await
+        .expect("patch json");
+    assert_eq!(patched["data"]["fail_closed"], false);
+
+    let map = parse_geo_rules(&rules_file).expect("engine loader parses patched file");
+    let rules = map.get("*").expect("global host rules");
+    assert!(!rules[0].fail_closed);
+}

--- a/crates/waf-engine/src/checks/ddos/action/ban.rs
+++ b/crates/waf-engine/src/checks/ddos/action/ban.rs
@@ -1,4 +1,4 @@
-//! FR-005 phase-05 — Ban action with TTL escalation.
+//! Ban action with TTL escalation.
 //!
 //! [`BanAction`] tracks offenses per IP and applies escalating bans:
 //! - 1st offense: 60s ban, +30 risk
@@ -335,7 +335,7 @@ impl ActionExecutor for BanAction {
             },
         );
 
-        // Structured logging per brainstorm §9
+        // Structured audit log for ban events
         warn!(
             action = "ban",
             ip = %ip,

--- a/crates/waf-engine/src/checks/ddos/action/mod.rs
+++ b/crates/waf-engine/src/checks/ddos/action/mod.rs
@@ -1,6 +1,6 @@
-//! FR-005 phase-05 — `DDoS` action executors (Command pattern).
+//! `DDoS` action executors (Command pattern).
 //!
-//! Decouples detection (phases 2-4) from side-effects (bans, risk bumps).
+//! Decouples detection from side-effects (bans, risk bumps).
 //! Each action implements [`ActionExecutor`] and produces an [`ActionResult`].
 
 use std::net::IpAddr;

--- a/crates/waf-engine/src/checks/ddos/action/risk.rs
+++ b/crates/waf-engine/src/checks/ddos/action/risk.rs
@@ -1,7 +1,9 @@
 //! FR-005 phase-05 — Risk bump action for `DDoS` verdicts.
 //!
 //! Submits risk signals to FR-010's [`RiskAggregator`] when `DDoS` violations
-//! are detected. Fire-and-forget semantics — no blocking on scorer response.
+//! are detected. Fire-and-forget via the sync `submit_ip` seam — the actor is
+//! the client IP on the `RiskKey` IP axis, so the request-path scorer joins
+//! the same state it reads for that IP. No blocking, no runtime required.
 
 use std::net::IpAddr;
 use std::sync::Arc;
@@ -11,14 +13,13 @@ use tracing::debug;
 use crate::checks::ddos::detector::DetectorVerdict;
 use crate::device_fp::aggregator::RiskAggregator;
 use crate::device_fp::signal::Signal;
-use crate::device_fp::types::FpKey;
 
 use super::{ActionExecutor, ActionResult};
 
 /// Risk bump action that submits `DDoS` signals to the risk aggregator.
 ///
-/// Uses the [`BurstInterval`](Signal::BurstInterval) signal variant to report
-/// `DDoS` burst detections. The aggregator handles scoring asynchronously.
+/// Uses [`Signal::DdosBurst`] to carry the detector-decided severity verbatim
+/// to the scorer. The aggregator handles scoring asynchronously.
 pub struct RiskBumpAction {
     aggregator: Arc<dyn RiskAggregator>,
 }
@@ -27,27 +28,6 @@ impl RiskBumpAction {
     #[must_use]
     pub fn new(aggregator: Arc<dyn RiskAggregator>) -> Self {
         Self { aggregator }
-    }
-
-    /// Build an [`FpKey`] from client IP for signal submission.
-    ///
-    /// `DDoS` detection operates on IPs, not TLS fingerprints. We create a
-    /// minimal [`FpKey`] with the IP encoded in JA3 field for keying purposes.
-    fn ip_to_fp_key(ip: IpAddr) -> FpKey {
-        use crate::device_fp::types::FingerprintValue;
-        FpKey {
-            ja3: Some(FingerprintValue::new(format!("ddos:{ip}"))),
-            ja4: None,
-            h2_akamai: None,
-        }
-    }
-
-    /// Build the signal for a `DDoS` burst detection.
-    fn burst_signal(risk_delta: u8) -> Signal {
-        // BurstInterval count field represents severity (clamped to u16)
-        Signal::BurstInterval {
-            count: u16::from(risk_delta),
-        }
     }
 }
 
@@ -68,16 +48,7 @@ impl ActionExecutor for RiskBumpAction {
             return ActionResult::noop();
         }
 
-        let fp_key = Self::ip_to_fp_key(ip);
-        let signal = Self::burst_signal(risk_delta);
-
-        // Fire-and-forget submission via block_in_place bridge
-        // The aggregator contract says submit MUST NOT block, so this is safe
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                self.aggregator.submit(&fp_key, &[signal]).await;
-            });
-        });
+        self.aggregator.submit_ip(ip, &[Signal::DdosBurst { risk_delta }]);
 
         debug!(
             action = "risk_bump",
@@ -105,8 +76,8 @@ mod tests {
         (agg, action)
     }
 
-    #[tokio::test]
-    async fn ignores_allow_verdict() {
+    #[test]
+    fn ignores_allow_verdict() {
         let (agg, action) = make_risk_action();
         let ip: IpAddr = "192.168.1.1".parse().unwrap();
 
@@ -115,8 +86,8 @@ mod tests {
         assert!(agg.is_empty());
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn submits_soft_anomaly() {
+    #[test]
+    fn submits_soft_anomaly() {
         let (agg, action) = make_risk_action();
         let ip: IpAddr = "10.0.0.1".parse().unwrap();
 
@@ -127,14 +98,15 @@ mod tests {
         let snap = agg.snapshot();
         assert_eq!(snap.len(), 1);
         let first = snap.first().expect("expected one submission");
+        assert_eq!(first.actor_ip, Some(ip));
         assert!(matches!(
             first.signals.as_slice(),
-            [Signal::BurstInterval { count: 50 }]
+            [Signal::DdosBurst { risk_delta: 50 }]
         ));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn submits_hard_burst_max_risk() {
+    #[test]
+    fn submits_hard_burst_max_risk() {
         let (agg, action) = make_risk_action();
         let ip: IpAddr = "172.16.0.1".parse().unwrap();
 
@@ -149,21 +121,15 @@ mod tests {
         let snap = agg.snapshot();
         assert_eq!(snap.len(), 1);
         let first = snap.first().expect("expected one submission");
+        assert_eq!(first.actor_ip, Some(ip));
         assert!(matches!(
             first.signals.as_slice(),
-            [Signal::BurstInterval { count: 100 }]
+            [Signal::DdosBurst { risk_delta: 100 }]
         ));
     }
 
-    #[tokio::test]
-    async fn fp_key_contains_ip() {
-        let ip: IpAddr = "8.8.8.8".parse().unwrap();
-        let key = RiskBumpAction::ip_to_fp_key(ip);
-        assert!(key.ja3.unwrap().as_str().contains("8.8.8.8"));
-    }
-
-    #[tokio::test]
-    async fn zero_soft_anomaly_is_noop() {
+    #[test]
+    fn zero_soft_anomaly_is_noop() {
         let (agg, action) = make_risk_action();
         let ip: IpAddr = "1.1.1.1".parse().unwrap();
 

--- a/crates/waf-engine/src/checks/ddos/action/risk.rs
+++ b/crates/waf-engine/src/checks/ddos/action/risk.rs
@@ -1,6 +1,6 @@
-//! FR-005 phase-05 — Risk bump action for `DDoS` verdicts.
+//! Risk bump action for `DDoS` verdicts.
 //!
-//! Submits risk signals to FR-010's [`RiskAggregator`] when `DDoS` violations
+//! Submits risk signals to the [`RiskAggregator`] when `DDoS` violations
 //! are detected. Fire-and-forget via the sync `submit_ip` seam — the actor is
 //! the client IP on the `RiskKey` IP axis, so the request-path scorer joins
 //! the same state it reads for that IP. No blocking, no runtime required.

--- a/crates/waf-engine/src/checks/ddos/check.rs
+++ b/crates/waf-engine/src/checks/ddos/check.rs
@@ -1,7 +1,7 @@
-//! FR-005 Phase 7 — `DdosCheck` pipeline integration.
+//! `DdosCheck` pipeline integration.
 //!
 //! Wires detectors (per-IP, per-FP, per-tier) into the WAF engine pipeline.
-//! Runs after allowlist phases (1-4) and before rate-limit (Phase 11).
+//! Runs after the allowlist checks and before rate-limit (`Phase::RateLimit`).
 //!
 //! ## Pipeline Behavior
 //! - Runs detectors in cheap-first order: `per_ip` → `per_fp` → `per_tier`
@@ -170,7 +170,7 @@ impl Check for DdosCheck {
                         self.metrics.inc_ban();
                     }
 
-                    // Structured audit log per FR-032
+                    // Structured audit log
                     warn!(
                         target: "ddos::audit",
                         request_id = %ctx.req_id,

--- a/crates/waf-engine/src/checks/ddos/config.rs
+++ b/crates/waf-engine/src/checks/ddos/config.rs
@@ -1,4 +1,4 @@
-//! FR-005 phase-01 — YAML schema + parser for `configs/ddos.yaml`.
+//! YAML schema + parser for `configs/ddos.yaml`.
 //!
 //! Pure data + validation, returns an `Arc<DdosConfig>` runtime snapshot.
 //! `deny_unknown_fields` everywhere — typos in operator YAML are loud, not
@@ -49,7 +49,7 @@ pub struct DdosFileConfig {
     #[serde(default = "default_max_keys")]
     pub max_keys: usize,
     /// Optional Redis backend. Absence ⇒ memory-only standalone mode.
-    /// Parsed but unused until phase 4.
+    /// Parsed and validated but not yet wired to a runtime store.
     #[serde(default)]
     pub redis: Option<RedisCfg>,
 }
@@ -109,7 +109,7 @@ pub struct TierThresholdCfg {
     pub per_tier_window_s: u32,
 }
 
-/// Optional Redis backend block (parsed but unused until phase 4).
+/// Optional Redis backend block (parsed and validated but not yet wired).
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RedisCfg {

--- a/crates/waf-engine/src/checks/ddos/degrade.rs
+++ b/crates/waf-engine/src/checks/ddos/degrade.rs
@@ -1,4 +1,4 @@
-//! FR-005 Phase 6 — Degrade & Circuit Breaker.
+//! Degrade & Circuit Breaker.
 //!
 //! `resolve` maps (`Tier`, `FailMode`, `ErrorKind`) → `DegradeAction` per the fail-mode
 //! matrix. `OverloadGuard` monitors runtime load via an in-flight call counter
@@ -39,7 +39,7 @@ pub enum DegradeAction {
 
 /// Resolve the degradation action based on tier, `fail_mode`, and error kind.
 ///
-/// ## Matrix (FR-036/037/038)
+/// ## Fail-mode matrix
 ///
 /// | Tier       | `StoreUnavailable` | `BackendOverload` | `ConfigStale` |
 /// |------------|------------------|-----------------|-------------|

--- a/crates/waf-engine/src/checks/ddos/detector/clock.rs
+++ b/crates/waf-engine/src/checks/ddos/detector/clock.rs
@@ -1,99 +1,10 @@
-//! Time abstraction for testable `DDoS` detectors.
+//! Re-export shim over [`crate::time`].
 //!
-//! The `Clock` trait allows detectors to use real wall-clock time in production
-//! while substituting mock clocks in tests for deterministic behavior.
+//! The clock abstraction lives in [`crate::time`] so the `DDoS` detectors and
+//! the risk ingest pipeline share one implementation. Existing
+//! `checks::ddos::detector::clock::*` paths keep working.
 
-use std::time::{SystemTime, UNIX_EPOCH};
-
-/// Trait for obtaining current time in milliseconds since UNIX epoch.
-///
-/// Production code uses `SystemClock`; tests use mock implementations
-/// to control time boundaries and window rollovers.
-pub trait Clock: Send + Sync {
-    /// Current time in milliseconds since UNIX epoch.
-    fn now_ms(&self) -> i64;
-}
-
-/// Real wall-clock implementation of `Clock`.
-///
-/// Uses `SystemTime::now()` — suitable for production use.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct SystemClock;
-
-impl Clock for SystemClock {
-    fn now_ms(&self) -> i64 {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
-    }
-}
+pub use crate::time::{Clock, SystemClock};
 
 #[cfg(test)]
-pub mod test_utils {
-    use super::*;
-    use std::sync::atomic::{AtomicI64, Ordering};
-
-    /// Mock clock with controllable time for testing.
-    ///
-    /// Call `set_ms()` or `advance_ms()` to control the returned time.
-    pub struct MockClock {
-        time_ms: AtomicI64,
-    }
-
-    impl MockClock {
-        pub fn new(initial_ms: i64) -> Self {
-            Self {
-                time_ms: AtomicI64::new(initial_ms),
-            }
-        }
-
-        pub fn set_ms(&self, ms: i64) {
-            self.time_ms.store(ms, Ordering::Relaxed);
-        }
-
-        pub fn advance_ms(&self, delta: i64) {
-            self.time_ms.fetch_add(delta, Ordering::Relaxed);
-        }
-    }
-
-    impl Clock for MockClock {
-        fn now_ms(&self) -> i64 {
-            self.time_ms.load(Ordering::Relaxed)
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn system_clock_returns_positive_value() {
-        let clock = SystemClock;
-        let now = clock.now_ms();
-        assert!(now > 0, "system clock should return positive epoch ms");
-    }
-
-    #[test]
-    fn system_clock_advances() {
-        let clock = SystemClock;
-        let t1 = clock.now_ms();
-        std::thread::sleep(std::time::Duration::from_millis(5));
-        let t2 = clock.now_ms();
-        assert!(t2 >= t1, "time should not go backwards");
-    }
-
-    #[test]
-    fn mock_clock_controllable() {
-        use test_utils::MockClock;
-
-        let clock = MockClock::new(1000);
-        assert_eq!(clock.now_ms(), 1000);
-
-        clock.set_ms(5000);
-        assert_eq!(clock.now_ms(), 5000);
-
-        clock.advance_ms(100);
-        assert_eq!(clock.now_ms(), 5100);
-    }
-}
+pub use crate::time::test_utils;

--- a/crates/waf-engine/src/checks/ddos/detector/mod.rs
+++ b/crates/waf-engine/src/checks/ddos/detector/mod.rs
@@ -37,7 +37,7 @@ pub enum DetectorVerdict {
         detector: &'static str,
         /// Rate (requests per detection window) associated with the burst.
         /// For `per_fp`/`per_tier` this is the **observed** count in the
-        /// window; for `per_ip` (backed by the FR-004 rate-limit store, which
+        /// window; for `per_ip` (backed by the shared rate-limit store, which
         /// only returns an allow/deny `Decision`) it is the configured
         /// **threshold** that was exceeded. Surfaced to the admin ban table as
         /// `last_rps`.

--- a/crates/waf-engine/src/checks/ddos/detector/per_fp.rs
+++ b/crates/waf-engine/src/checks/ddos/detector/per_fp.rs
@@ -16,15 +16,14 @@
 //!   which adds memory overhead proportional to (keys × `window_duration` / granularity).
 //!   For 100k fingerprints × 60s window, this is significant.
 //!
-//! For FR-005 v1, the fixed-window approximation is sufficient. Upgrade to
+//! For now, the fixed-window approximation is sufficient. Upgrade to
 //! precise sliding if edge-case exploitation becomes a real attack vector.
 //!
 //! # Current Limitation
 //!
-//! **GAP**: `RequestCtx` does not yet carry a `device_fp` field. Until phase 7
-//! wires device fingerprinting into the request pipeline, this detector will
-//! always return `Allow` for live traffic. The core logic is complete and
-//! tested via `evaluate_with_fp()`.
+//! **GAP**: `Detector::evaluate` does not yet read the device fingerprint
+//! from the request, so this detector always returns `Allow` for live
+//! traffic. The core logic is complete and tested via `evaluate_with_fp()`.
 
 use std::sync::Arc;
 
@@ -48,7 +47,7 @@ impl PerFpDetector {
     /// Create a new per-fingerprint detector backed by the given counter store.
     ///
     /// The store is typically `MemoryCounterStore` for standalone deployments
-    /// or a Redis-backed store for clustered deployments (phase 4).
+    /// or a Redis-backed store for clustered deployments.
     #[must_use]
     pub fn new(store: Arc<dyn CounterStore>) -> Self {
         Self { store }
@@ -64,8 +63,8 @@ impl PerFpDetector {
     /// Core evaluation logic with explicit fingerprint input.
     ///
     /// This method contains the actual detection logic. It's exposed separately
-    /// from `Detector::evaluate` because `RequestCtx` doesn't yet carry device
-    /// fingerprint data (that wiring happens in phase 7).
+    /// from `Detector::evaluate`, which does not yet read device fingerprint
+    /// data from the request.
     ///
     /// # Arguments
     /// - `fp_hash`: Device fingerprint hash. `None` or empty string → `Allow` (no signal).
@@ -80,8 +79,8 @@ impl PerFpDetector {
         now_ms: i64,
     ) -> DetectorVerdict {
         // Skip when fingerprint is absent or empty — no signal available.
-        // This happens when FR-010 device fingerprinting didn't run (e.g.,
-        // plain HTTP/1 without TLS extensions, or FR-010 disabled).
+        // This happens when device fingerprinting didn't run (e.g., plain
+        // HTTP/1 without TLS extensions, or fingerprinting disabled).
         let Some(fp) = fp_hash.filter(|s| !s.is_empty()) else {
             return DetectorVerdict::Allow;
         };
@@ -97,7 +96,7 @@ impl PerFpDetector {
             },
             Ok(_) => DetectorVerdict::Allow,
             Err(e) => {
-                // Degrade decision owned by phase 6 — here we warn and allow.
+                // Degrade decision owned by the degrade module — here we warn and allow.
                 warn!(
                     detector = "per_fp",
                     fp = %fp,
@@ -120,15 +119,14 @@ impl Detector for PerFpDetector {
     ///
     /// # Current Behavior
     ///
-    /// **Always returns `Allow`** because `RequestCtx` doesn't yet carry
-    /// `device_fp`. This is a documented gap — phase 7 wires device
-    /// fingerprinting into the request pipeline.
+    /// **Always returns `Allow`** — the device fingerprint is not yet read
+    /// from the request here; this is a documented gap.
     ///
-    /// Once phase 7 is complete, this will extract `ctx.device_fp.hash` and
+    /// Once the wiring lands, this will extract `ctx.device_fp.hash` and
     /// delegate to `evaluate_with_fp()`.
     fn evaluate(&self, _ctx: &RequestCtx, _cfg: &DdosTierCfg, _now_ms: i64) -> DetectorVerdict {
-        // GAP: RequestCtx.device_fp does not exist yet.
-        // Phase 7 will add it; then this becomes:
+        // GAP: the device fingerprint is not read from the request here yet.
+        // Once wired, this becomes:
         //   let fp = ctx.device_fp.as_ref().and_then(|f| f.hash.as_ref());
         //   self.evaluate_with_fp(fp.map(String::as_str), ctx, cfg, now_ms)
         DetectorVerdict::Allow
@@ -426,8 +424,8 @@ mod tests {
 
     #[test]
     fn detector_evaluate_returns_allow_gap_documented() {
-        // This tests the current behavior where RequestCtx.device_fp doesn't exist.
-        // The Detector::evaluate method always returns Allow until phase 7 wires it up.
+        // This tests the current behavior where the fingerprint is not wired up:
+        // the Detector::evaluate method always returns Allow.
         let store = TestCounterStore::new();
         let detector = PerFpDetector::new(store);
         let ctx = test_ctx(Tier::Medium);

--- a/crates/waf-engine/src/checks/ddos/detector/per_ip.rs
+++ b/crates/waf-engine/src/checks/ddos/detector/per_ip.rs
@@ -1,6 +1,6 @@
 //! Per-IP `DDoS` detector.
 //!
-//! Thin wrapper around `RateLimitStore` — delegates rate limiting math to FR-004,
+//! Thin wrapper around `RateLimitStore` — delegates the rate limiting math to it,
 //! only translates `Decision` → `DetectorVerdict`. No new counters or algorithms.
 
 use std::sync::Arc;
@@ -14,9 +14,9 @@ use super::{DdosTierCfg, Detector, DetectorVerdict, tier_str};
 
 /// Per-IP rate detector using the existing `RateLimitStore`.
 ///
-/// Reuses FR-004's token bucket + sliding window implementation to detect
+/// Reuses the rate limiter's token bucket + sliding window implementation to detect
 /// per-IP burst violations. Key format: `ddos:ip:{tier}:{ip}` to avoid
-/// collision with FR-004's `ip:{host}:{ip}` namespace.
+/// collision with the rate limiter's `ip:{host}:{ip}` namespace.
 pub struct PerIpDetector {
     store: Arc<dyn RateLimitStore>,
 }
@@ -30,7 +30,7 @@ impl PerIpDetector {
 
     /// Build the rate limit key for this IP + tier combination.
     ///
-    /// Format: `ddos:ip:{tier}:{ip}` — distinct from FR-004's `ip:{host}:{ip}`.
+    /// Format: `ddos:ip:{tier}:{ip}` — distinct from the rate limiter's `ip:{host}:{ip}`.
     fn build_key(ctx: &RequestCtx) -> String {
         format!("ddos:ip:{}:{}", tier_str(ctx.tier), ctx.client_ip)
     }
@@ -82,7 +82,7 @@ impl Detector for PerIpDetector {
                 rps: cfg.per_fp_threshold,
             },
             Err(e) => {
-                // Degrade decision owned by phase 6 — here we just warn and allow
+                // Degrade decision owned by the degrade module — here we just warn and allow
                 warn!(
                     detector = "per_ip",
                     ip = %ctx.client_ip,
@@ -247,7 +247,7 @@ mod tests {
         let ctx = test_ctx(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), Tier::CatchAll);
         let cfg = test_cfg();
 
-        // Error should degrade to Allow (fail-open for now, phase 6 owns degrade)
+        // Error should degrade to Allow (fail-open; the degrade module owns degrade)
         let verdict = detector.evaluate(&ctx, &cfg, 1000);
         assert_eq!(verdict, DetectorVerdict::Allow);
     }

--- a/crates/waf-engine/src/checks/ddos/metrics.rs
+++ b/crates/waf-engine/src/checks/ddos/metrics.rs
@@ -1,4 +1,4 @@
-//! FR-005 Phase 7 — `DDoS` observability metrics.
+//! `DDoS` observability metrics.
 //!
 //! Provides atomic counters for `DDoS` detection events. Uses `AtomicU64` for
 //! lock-free updates on the hot path. Counters are exposed via accessor methods

--- a/crates/waf-engine/src/checks/ddos/mod.rs
+++ b/crates/waf-engine/src/checks/ddos/mod.rs
@@ -1,14 +1,14 @@
-//! FR-005 `DDoS` protection module.
+//! `DDoS` protection module.
 //!
 //! Composed of:
 //! - [`store`]    — async `CounterStore` trait + in-memory backend
 //! - [`config`]   — YAML schema + parsing for `configs/ddos.yaml`
 //! - [`reload`]   — hot-reload watcher with `ArcSwap` snapshot
-//! - [`detector`] — `Detector` trait + per-IP detector (phase 2)
-//! - [`action`]   — action executors for bans and risk bumps (phase 5)
-//! - [`degrade`]  — circuit breaker & fail-mode resolution (phase 6)
-//! - [`check`]    — `DdosCheck` pipeline integration (phase 7)
-//! - [`metrics`]  — atomic counters for observability (phase 7)
+//! - [`detector`] — `Detector` trait + per-IP detector
+//! - [`action`]   — action executors for bans and risk bumps
+//! - [`degrade`]  — circuit breaker & fail-mode resolution
+//! - [`check`]    — `DdosCheck` pipeline integration
+//! - [`metrics`]  — atomic counters for observability
 
 use std::collections::HashMap;
 

--- a/crates/waf-engine/src/checks/ddos/reload.rs
+++ b/crates/waf-engine/src/checks/ddos/reload.rs
@@ -1,4 +1,4 @@
-//! FR-005 phase-01 — hot-reload watcher for `configs/ddos.yaml`.
+//! Hot-reload watcher for `configs/ddos.yaml`.
 //!
 //! Mirrors `rate_limit::reload`: parent-dir `notify` watcher on a sync
 //! `std::thread`, debounced, fail-soft on parse error (previous snapshot

--- a/crates/waf-engine/src/checks/ddos/store/redis.rs
+++ b/crates/waf-engine/src/checks/ddos/store/redis.rs
@@ -17,7 +17,7 @@
 //!
 //! Tracks consecutive failures via `AtomicU32`. Once `breaker_threshold` is reached,
 //! `breaker_open()` returns true. A single success resets the counter.
-//! The wrapping layer (phase 6) can route to memory fallback when breaker is open.
+//! The wrapping degrade layer can route to memory fallback when breaker is open.
 
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
@@ -107,7 +107,7 @@ impl RedisCounterStore {
 
     /// True once `breaker_threshold` consecutive failures have occurred.
     ///
-    /// The wrapping layer (phase 6) can read this to route to memory fallback.
+    /// The wrapping degrade layer can read this to route to memory fallback.
     #[must_use]
     pub fn breaker_open(&self) -> bool {
         self.consecutive_fails.load(Ordering::Relaxed) >= self.cfg.breaker_threshold

--- a/crates/waf-engine/src/checks/geo.rs
+++ b/crates/waf-engine/src/checks/geo.rs
@@ -28,6 +28,10 @@ pub struct GeoRule {
     pub iso_codes: HashSet<String>,
     /// Country names to match (case-insensitive).
     pub countries: HashSet<String>,
+    /// `AllowOnly` only: block when the request has no determinable country
+    /// (missing xdb / lookup failure / private IP). Default `false` =
+    /// fail-open. Ignored for `Block` rules.
+    pub fail_closed: bool,
 }
 
 /// Whether the rule blocks the listed countries or allows only them.
@@ -107,6 +111,41 @@ impl GeoCheck {
         None
     }
 
+    fn eval_fail_closed(&self, host_code: &str) -> Option<DetectionResult> {
+        // Host-specific rules first
+        if let Some(entry) = self.rules.get(host_code)
+            && let Some(r) = Self::match_fail_closed(&entry.rules)
+        {
+            return Some(r);
+        }
+        // Global rules
+        if let Some(entry) = self.rules.get("*")
+            && let Some(r) = Self::match_fail_closed(&entry.rules)
+        {
+            return Some(r);
+        }
+        None
+    }
+
+    /// With no determinable country only a fail-closed `AllowOnly` rule can
+    /// act; `Block` rules cannot match a specific country without data.
+    fn match_fail_closed(rules: &[GeoRule]) -> Option<DetectionResult> {
+        rules
+            .iter()
+            .find(|rule| rule.mode == GeoRuleMode::AllowOnly && rule.fail_closed)
+            .map(|rule| DetectionResult {
+                rule_id: Some(rule.id.clone()),
+                rule_name: rule.name.clone(),
+                phase: Phase::GeoIp,
+                detail: format!(
+                    "Blocked by geo allowlist '{}': geo data unavailable (fail-closed)",
+                    rule.name
+                ),
+                rule_action: None,
+                action_status: None,
+            })
+    }
+
     fn match_rules(geo: &waf_common::GeoIpInfo, rules: &[GeoRule]) -> Option<DetectionResult> {
         for rule in rules {
             let matched = Self::geo_matches(geo, rule);
@@ -169,15 +208,16 @@ impl Default for GeoCheck {
 
 impl Check for GeoCheck {
     fn check(&self, ctx: &mut RequestCtx) -> Option<DetectionResult> {
-        // If geo info was not populated (GeoIP disabled or xdb missing) skip.
-        let Some(geo) = &ctx.geo else {
-            return None;
-        };
-        // No useful info yet (e.g. private IP not in xdb)
-        if geo.country.is_empty() && geo.iso_code.is_empty() {
-            return None;
+        match &ctx.geo {
+            // Data present — unchanged matching path.
+            Some(geo) if !(geo.country.is_empty() && geo.iso_code.is_empty()) => {
+                self.eval_rules(&ctx.host_config.code, geo)
+            }
+            // Geo absent or empty (service disabled, missing xdb, lookup
+            // failure, private IP): fail-open unless a fail-closed AllowOnly
+            // rule applies to this host.
+            _ => self.eval_fail_closed(&ctx.host_config.code),
         }
-        self.eval_rules(&ctx.host_config.code, geo)
     }
 }
 
@@ -235,6 +275,7 @@ mod tests {
                 mode: GeoRuleMode::Block,
                 iso_codes: ["KP".to_string()].into(),
                 countries: HashSet::new(),
+                fail_closed: false,
             }],
         );
 
@@ -256,6 +297,7 @@ mod tests {
                 mode: GeoRuleMode::Block,
                 iso_codes: ["cn".to_string()].into(),
                 countries: HashSet::new(),
+                fail_closed: false,
             }],
         );
 
@@ -264,6 +306,88 @@ mod tests {
             check.check(&mut ctx).is_some(),
             "lowercase rule ISO code must match after load-time normalization"
         );
+    }
+
+    fn allow_only_us_rule(fail_closed: bool) -> GeoRule {
+        GeoRule {
+            id: "GEO-ALLOW".into(),
+            name: "Allow US".into(),
+            mode: GeoRuleMode::AllowOnly,
+            iso_codes: ["US".to_string()].into(),
+            countries: HashSet::new(),
+            fail_closed,
+        }
+    }
+
+    #[test]
+    fn allow_only_fail_closed_blocks_when_geo_is_none() {
+        let check = GeoCheck::new();
+        check.load_rules("*", vec![allow_only_us_rule(true)]);
+
+        let mut ctx = make_ctx("", "");
+        ctx.geo = None;
+        let result = check.check(&mut ctx).expect("fail-closed allowlist must block");
+        assert_eq!(result.phase, Phase::GeoIp);
+        assert_eq!(result.rule_id.as_deref(), Some("GEO-ALLOW"));
+        assert!(result.detail.contains("geo data unavailable"));
+    }
+
+    #[test]
+    fn allow_only_fail_closed_blocks_when_geo_is_empty() {
+        let check = GeoCheck::new();
+        check.load_rules("*", vec![allow_only_us_rule(true)]);
+
+        // Empty GeoIpInfo — private IP / lookup miss.
+        let mut ctx = make_ctx("", "");
+        assert!(check.check(&mut ctx).is_some());
+    }
+
+    #[test]
+    fn allow_only_fail_open_passes_when_geo_unavailable() {
+        let check = GeoCheck::new();
+        check.load_rules("*", vec![allow_only_us_rule(false)]);
+
+        let mut empty = make_ctx("", "");
+        assert!(check.check(&mut empty).is_none(), "fail-open on empty geo is unchanged");
+
+        let mut none = make_ctx("", "");
+        none.geo = None;
+        assert!(check.check(&mut none).is_none(), "fail-open on absent geo is unchanged");
+    }
+
+    #[test]
+    fn allow_only_fail_closed_with_geo_data_matches_as_before() {
+        let check = GeoCheck::new();
+        check.load_rules("*", vec![allow_only_us_rule(true)]);
+
+        let mut allowed = make_ctx("US", "United States");
+        assert!(check.check(&mut allowed).is_none(), "listed country passes");
+
+        let mut blocked = make_ctx("CN", "China");
+        assert!(check.check(&mut blocked).is_some(), "unlisted country still blocked");
+    }
+
+    #[test]
+    fn block_rule_never_fails_closed() {
+        let check = GeoCheck::new();
+        check.load_rules(
+            "*",
+            vec![GeoRule {
+                id: "GEO-BLOCK".into(),
+                name: "Block KP".into(),
+                mode: GeoRuleMode::Block,
+                iso_codes: ["KP".to_string()].into(),
+                countries: HashSet::new(),
+                fail_closed: true,
+            }],
+        );
+
+        let mut empty = make_ctx("", "");
+        assert!(check.check(&mut empty).is_none());
+
+        let mut none = make_ctx("", "");
+        none.geo = None;
+        assert!(check.check(&mut none).is_none());
     }
 
     #[test]
@@ -277,6 +401,7 @@ mod tests {
                 mode: GeoRuleMode::Block,
                 iso_codes: ["XX".to_string()].into(),
                 countries: HashSet::new(),
+                fail_closed: false,
             }],
         );
         let host_config = Arc::new(HostConfig::default());

--- a/crates/waf-engine/src/checks/geo_config.rs
+++ b/crates/waf-engine/src/checks/geo_config.rs
@@ -27,6 +27,11 @@ struct GeoRuleRow {
     scope: String,
     #[serde(default = "default_enabled")]
     enabled: bool,
+    /// Allow rows only: block the host when the request has no determinable
+    /// country. Any enabled allow row with `true` makes the host's unioned
+    /// `AllowOnly` rule fail-closed (most-restrictive wins).
+    #[serde(default)]
+    fail_closed: bool,
 }
 
 fn default_action() -> String {
@@ -56,8 +61,8 @@ pub fn parse_geo_rules(path: &Path) -> anyhow::Result<HashMap<String, Vec<GeoRul
     let file: GeoRulesFile =
         serde_yaml::from_str(&raw).with_context(|| format!("geo rules: parse {}", path.display()))?;
 
-    // Per host: (block iso set, allow iso set)
-    let mut hosts: HashMap<String, (HashSet<String>, HashSet<String>)> = HashMap::new();
+    // Per host: (block iso set, allow iso set, allow fail-closed accumulator)
+    let mut hosts: HashMap<String, (HashSet<String>, HashSet<String>, bool)> = HashMap::new();
     for row in file.rules {
         if !row.enabled {
             continue;
@@ -71,13 +76,16 @@ pub fn parse_geo_rules(path: &Path) -> anyhow::Result<HashMap<String, Vec<GeoRul
         let entry = hosts.entry(host).or_default();
         if row.action == "allow" {
             entry.1.insert(iso);
+            // Most-restrictive wins: any allow row asking for fail-closed
+            // makes the host's whole allowlist fail-closed.
+            entry.2 |= row.fail_closed;
         } else {
             entry.0.insert(iso);
         }
     }
 
     let mut out = HashMap::new();
-    for (host, (block, allow)) in hosts {
+    for (host, (block, allow, fail_closed)) in hosts {
         let mut rules = Vec::new();
         if !block.is_empty() {
             rules.push(GeoRule {
@@ -86,6 +94,7 @@ pub fn parse_geo_rules(path: &Path) -> anyhow::Result<HashMap<String, Vec<GeoRul
                 mode: GeoRuleMode::Block,
                 iso_codes: block,
                 countries: HashSet::new(),
+                fail_closed: false,
             });
         }
         if !allow.is_empty() {
@@ -95,6 +104,7 @@ pub fn parse_geo_rules(path: &Path) -> anyhow::Result<HashMap<String, Vec<GeoRul
                 mode: GeoRuleMode::AllowOnly,
                 iso_codes: allow,
                 countries: HashSet::new(),
+                fail_closed,
             });
         }
         if !rules.is_empty() {
@@ -203,6 +213,55 @@ rules:
         assert_eq!(rules.len(), 1, "allow rows must union into ONE AllowOnly rule");
         assert_eq!(rules[0].mode, GeoRuleMode::AllowOnly);
         assert_eq!(rules[0].iso_codes.len(), 2);
+    }
+
+    #[test]
+    fn any_fail_closed_allow_row_makes_host_allowlist_fail_closed() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let path = write_rules(
+            &dir,
+            r#"
+rules:
+  - { id: 1, iso_code: "US", action: "allow", scope: "global", enabled: true }
+  - { id: 2, iso_code: "CA", action: "allow", scope: "global", enabled: true, fail_closed: true }
+"#,
+        );
+        let map = parse_geo_rules(&path).expect("parse");
+        let rules = map.get("*").expect("global host");
+        assert_eq!(rules.len(), 1);
+        assert!(rules[0].fail_closed, "one fail-closed row flips the unioned rule");
+    }
+
+    #[test]
+    fn absent_fail_closed_defaults_to_fail_open() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let path = write_rules(
+            &dir,
+            r#"
+rules:
+  - { id: 1, iso_code: "US", action: "allow", scope: "global", enabled: true }
+  - { id: 2, iso_code: "CA", action: "allow", scope: "global", enabled: true, fail_closed: false }
+"#,
+        );
+        let map = parse_geo_rules(&path).expect("parse");
+        let rules = map.get("*").expect("global host");
+        assert!(!rules[0].fail_closed);
+    }
+
+    #[test]
+    fn fail_closed_on_block_row_does_not_affect_block_rule() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let path = write_rules(
+            &dir,
+            r#"
+rules:
+  - { id: 1, iso_code: "KP", action: "block", scope: "global", enabled: true, fail_closed: true }
+"#,
+        );
+        let map = parse_geo_rules(&path).expect("parse");
+        let rules = map.get("*").expect("global host");
+        assert_eq!(rules[0].mode, GeoRuleMode::Block);
+        assert!(!rules[0].fail_closed);
     }
 
     #[test]

--- a/crates/waf-engine/src/device_fp/aggregator.rs
+++ b/crates/waf-engine/src/device_fp/aggregator.rs
@@ -11,7 +11,11 @@
 //! ### Semantics
 //! - `submit` is async but **MUST NOT block** the caller. Implementations
 //!   forward to a bounded channel / queue and drop-with-warn on overflow.
-//! - Caller treats `submit` as fire-and-forget — no error path, no result.
+//! - `submit_ip` is the sync twin for callers on the request path that
+//!   identify the actor by client IP instead of a fingerprint. Same
+//!   contract: queue fan-out, drop-with-warn on overflow, never blocks —
+//!   callable without a runtime.
+//! - Caller treats both as fire-and-forget — no error path, no result.
 //! - `key` is borrowed; clone if the impl needs to retain it.
 //!
 //! ### Skeleton implementation
@@ -29,6 +33,7 @@
 //! }
 //! ```
 
+use std::net::IpAddr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -42,6 +47,11 @@ pub trait RiskAggregator: Send + Sync {
     /// Submit a batch of signals tied to one fingerprint key. Implementations
     /// MUST NOT block the caller — fan out to a queue/channel internally.
     async fn submit(&self, key: &FpKey, signals: &[Signal]);
+
+    /// Submit signals credited to an actor identified by client IP.
+    /// Sync and non-blocking by contract (queue fan-out, drop-with-warn on
+    /// overflow) — callable from the request path without a runtime.
+    fn submit_ip(&self, ip: IpAddr, signals: &[Signal]);
 }
 
 /// Default aggregator — discards all submissions. Used when no risk scorer
@@ -63,13 +73,24 @@ impl RiskAggregator for NoopAggregator {
             "noop aggregator: submission dropped"
         );
     }
+
+    fn submit_ip(&self, ip: IpAddr, signals: &[Signal]) {
+        tracing::debug!(
+            target: "device_fp::aggregator",
+            %ip,
+            count = signals.len(),
+            "noop aggregator: submission dropped"
+        );
+    }
 }
 
 /// One recorded submission — `(key, signals)` pair captured by
-/// [`LoggingAggregator`] for assertions in integration tests.
+/// [`LoggingAggregator`] for assertions in integration tests. IP-keyed
+/// submissions carry `actor_ip` and a default (empty) `key`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AggregatorSubmission {
     pub key: FpKey,
+    pub actor_ip: Option<IpAddr>,
     pub signals: Vec<Signal>,
 }
 
@@ -117,15 +138,30 @@ impl Default for LoggingAggregator {
     }
 }
 
-#[async_trait]
-impl RiskAggregator for LoggingAggregator {
-    async fn submit(&self, key: &FpKey, signals: &[Signal]) {
+impl LoggingAggregator {
+    fn record(&self, submission: AggregatorSubmission) {
         let mut q = self.inner.lock();
         if q.len() == self.cap {
             q.pop_front();
         }
-        q.push_back(AggregatorSubmission {
+        q.push_back(submission);
+    }
+}
+
+#[async_trait]
+impl RiskAggregator for LoggingAggregator {
+    async fn submit(&self, key: &FpKey, signals: &[Signal]) {
+        self.record(AggregatorSubmission {
             key: key.clone(),
+            actor_ip: None,
+            signals: signals.to_vec(),
+        });
+    }
+
+    fn submit_ip(&self, ip: IpAddr, signals: &[Signal]) {
+        self.record(AggregatorSubmission {
+            key: FpKey::default(),
+            actor_ip: Some(ip),
             signals: signals.to_vec(),
         });
     }
@@ -175,5 +211,33 @@ mod tests {
             agg.submit(&empty_key(), &[]).await;
         }
         assert_eq!(agg.len(), 2);
+    }
+
+    #[test]
+    fn logging_submit_ip_records_actor_ip() {
+        use std::net::Ipv4Addr;
+
+        let agg = LoggingAggregator::new(8);
+        let ip = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9));
+        agg.submit_ip(
+            ip,
+            &[Signal::H2Anomaly {
+                reason: H2AnomalyReason::BadSettings,
+            }],
+        );
+
+        let snap = agg.snapshot();
+        assert_eq!(snap.len(), 1);
+        let sub = snap.first().unwrap();
+        assert_eq!(sub.actor_ip, Some(ip));
+        assert!(sub.key.is_empty(), "IP submissions carry an empty fp key");
+        assert_eq!(sub.signals.len(), 1);
+    }
+
+    #[test]
+    fn noop_submit_ip_does_not_panic() {
+        use std::net::Ipv4Addr;
+
+        NoopAggregator.submit_ip(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 10)), &[]);
     }
 }

--- a/crates/waf-engine/src/device_fp/signal.rs
+++ b/crates/waf-engine/src/device_fp/signal.rs
@@ -54,6 +54,10 @@ pub enum Signal {
     /// FR-012 — burst of limit-change requests within `window_sec`.
     /// Same `count`/`ok_count` semantics as `WithdrawalVelocity`.
     LimitChangeBurst { count: u32, ok_count: u32, window_sec: u32 },
+    /// FR-005 — `DDoS` detector verdict credited to the offending actor.
+    /// `risk_delta` is the detector-decided severity (0-100), applied
+    /// verbatim as the contributor delta — never weight-table mapped.
+    DdosBurst { risk_delta: u8 },
 }
 
 /// Reason an HTTP/2 anomaly was flagged. Closed enum so risk scorer can
@@ -87,6 +91,7 @@ impl Signal {
             Self::TxSequenceTooFast { .. } => "tx_sequence_too_fast",
             Self::WithdrawalVelocity { .. } => "withdrawal_velocity",
             Self::LimitChangeBurst { .. } => "limit_change_burst",
+            Self::DdosBurst { .. } => "ddos_burst",
         }
     }
 }
@@ -112,5 +117,6 @@ mod tests {
         assert_eq!(Signal::Regularity { cv_x1000: 100 }.name(), "regularity");
         assert_eq!(Signal::ZeroDepth { samples: 4 }.name(), "zero_depth");
         assert_eq!(Signal::MissingReferer.name(), "missing_referer");
+        assert_eq!(Signal::DdosBurst { risk_delta: 50 }.name(), "ddos_burst");
     }
 }

--- a/crates/waf-engine/src/engine.rs
+++ b/crates/waf-engine/src/engine.rs
@@ -369,7 +369,7 @@ impl WafEngine {
         // The purge loop needs the concrete `Arc<MemoryRiskStore>`; start it
         // before the Arc is unsized to `Arc<dyn RiskStore>`.
         let ttl_ms = i64::try_from(cfg.ttl_secs.saturating_mul(1000)).unwrap_or(i64::MAX);
-        store.start_purge_loop(ttl_ms, cfg.gc_interval_secs);
+        store.start_purge_loop(ttl_ms, cfg.gc_interval_secs, Arc::new(crate::time::SystemClock));
         store
     }
 

--- a/crates/waf-engine/src/geoip.rs
+++ b/crates/waf-engine/src/geoip.rs
@@ -63,27 +63,47 @@ impl GeoIpService {
 
     /// Hot-reload xdb files from disk without service interruption.
     ///
-    /// Loads fresh `Searcher` instances from the original file paths and
-    /// atomically swaps them in via `ArcSwapOption::store`.  Any concurrent
-    /// in-flight lookups continue using the old searchers until they complete.
+    /// Each address family is decided independently: a freshly loaded
+    /// `Searcher` is atomically swapped in via `ArcSwapOption::store`; if the
+    /// new load fails but a working searcher is currently present, the old
+    /// searcher is **kept** (never replaced with `None`) and the failure is
+    /// surfaced as an `Err`. A family that was `None` and stays `None`
+    /// (first-time / degraded setup) is left untouched without error.
     ///
-    /// Returns `Ok(true)` after a successful reload.  Returns `Ok(false)` if
-    /// neither file exists (degraded / first-time-setup situation).
+    /// Returns `Ok(true)` when at least one family swapped in a new searcher,
+    /// `Ok(false)` when nothing loaded and nothing needed preserving, and
+    /// `Err` naming the families whose working searcher was preserved because
+    /// the new load failed.
     pub fn reload(&self) -> anyhow::Result<bool> {
-        let new_ipv4 = load_searcher(&self.ipv4_path, self.cache_policy, "IPv4");
-        let new_ipv6 = load_searcher(&self.ipv6_path, self.cache_policy, "IPv6");
+        let mut swapped = false;
+        let mut preserved: Vec<&str> = Vec::new();
 
-        let any_loaded = new_ipv4.is_some() || new_ipv6.is_some();
-
-        // Atomic swap — readers see either old or new, never a torn state.
-        self.ipv4.store(new_ipv4);
-        self.ipv6.store(new_ipv6);
-
-        if any_loaded {
-            info!("GeoIP: hot-reloaded xdb files from disk");
+        for (slot, path, label) in [
+            (&self.ipv4, self.ipv4_path.as_str(), "IPv4"),
+            (&self.ipv6, self.ipv6_path.as_str(), "IPv6"),
+        ] {
+            let new = load_searcher(path, self.cache_policy, label);
+            match family_reload(new, slot.load().is_some()) {
+                FamilyReload::Swap(searcher) => {
+                    // Atomic swap — readers see either old or new, never a torn state.
+                    slot.store(Some(searcher));
+                    swapped = true;
+                }
+                FamilyReload::Preserve => preserved.push(label),
+                FamilyReload::LeaveEmpty => {}
+            }
         }
 
-        Ok(any_loaded)
+        if !preserved.is_empty() {
+            anyhow::bail!(
+                "GeoIP reload: new load failed for {}; kept previous searcher(s)",
+                preserved.join(", ")
+            );
+        }
+        if swapped {
+            info!("GeoIP: hot-reloaded xdb files from disk");
+        }
+        Ok(swapped)
     }
 
     /// Look up the `GeoIP` information for `ip`.
@@ -123,6 +143,26 @@ impl GeoIpService {
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
+
+/// Per-family reload decision.
+enum FamilyReload<T> {
+    /// The new load succeeded — swap it in.
+    Swap(T),
+    /// The new load failed but a working searcher is present — keep it.
+    Preserve,
+    /// The new load failed and no searcher was present — stay empty.
+    LeaveEmpty,
+}
+
+/// Decide what a reload does for one address family. A working searcher is
+/// never replaced by a failed load; an empty slot stays empty without error.
+fn family_reload<T>(new: Option<T>, current_present: bool) -> FamilyReload<T> {
+    match new {
+        Some(searcher) => FamilyReload::Swap(searcher),
+        None if current_present => FamilyReload::Preserve,
+        None => FamilyReload::LeaveEmpty,
+    }
+}
 
 /// Attempt to open an xdb file and build a `Searcher`.
 ///
@@ -218,6 +258,47 @@ mod tests {
         let info = parse_region("");
         assert_eq!(info.country, "");
         assert_eq!(info.iso_code, "");
+    }
+
+    #[test]
+    fn family_reload_swaps_on_successful_load() {
+        assert!(matches!(family_reload(Some(1), true), FamilyReload::Swap(1)));
+        assert!(matches!(family_reload(Some(1), false), FamilyReload::Swap(1)));
+    }
+
+    #[test]
+    fn family_reload_preserves_working_searcher_on_failed_load() {
+        assert!(matches!(family_reload::<i32>(None, true), FamilyReload::Preserve));
+    }
+
+    #[test]
+    fn family_reload_leaves_empty_slot_empty() {
+        assert!(matches!(family_reload::<i32>(None, false), FamilyReload::LeaveEmpty));
+    }
+
+    #[test]
+    fn reload_with_no_files_and_no_searchers_is_ok_false() {
+        let svc = GeoIpService::init("/nonexistent/v4.xdb", "/nonexistent/v6.xdb", CachePolicy::NoCache).expect("init");
+        assert!(!svc.is_available());
+        let result = svc.reload().expect("degraded reload must not error");
+        assert!(!result, "nothing loaded and nothing preserved");
+        assert!(!svc.is_available());
+    }
+
+    #[test]
+    fn reload_with_corrupt_file_and_no_searcher_is_ok_false() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let path = dir.path().join("corrupt.xdb");
+        std::fs::write(&path, b"not a real xdb file").expect("write");
+        let path_str = path.to_str().expect("utf8 path");
+
+        let svc = GeoIpService::init(path_str, "/nonexistent/v6.xdb", CachePolicy::NoCache).expect("init");
+        assert!(!svc.is_available());
+        // The corrupt file fails to load and no working searcher exists, so
+        // this is the degraded first-time case — no error, slot stays empty.
+        let result = svc.reload().expect("no working searcher to preserve");
+        assert!(!result);
+        assert!(!svc.is_available());
     }
 
     #[test]

--- a/crates/waf-engine/src/geoip_updater.rs
+++ b/crates/waf-engine/src/geoip_updater.rs
@@ -13,10 +13,27 @@ use anyhow::{Context, Result};
 use tracing::{debug, info, warn};
 
 use crate::geoip::GeoIpService;
+use crate::relay::intel::atomic_swap::stream_to_tmp;
+use crate::validated_fetch::{USER_AGENT, build_validated_client};
 use waf_common::config::GeoIpAutoUpdateConfig;
 
 /// Default URL base for ip2region raw xdb files on GitHub.
 const DEFAULT_GITHUB_BASE_URL: &str = "https://raw.githubusercontent.com/lionsoul2014/ip2region/master/data";
+
+/// Maximum allowed xdb response body size (64 MiB — comfortable headroom over
+/// the ~20 MB full xdb files). Enforced via `Content-Length` fast-reject and a
+/// running cap while streaming to disk.
+const MAX_XDB_RESPONSE_SIZE: u64 = 64 * 1024 * 1024;
+
+/// Connection establishment timeout for updater requests.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Total request timeout for `HEAD` update checks.
+const HEAD_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Total request timeout for xdb downloads (~20 MB files on slow links).
+#[allow(clippy::duration_suboptimal_units)] // prefer `from_secs` over MSRV-gated `from_mins`
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(120);
 
 // ── Public types ──────────────────────────────────────────────────────────────
 
@@ -65,17 +82,20 @@ impl XdbUpdater {
     /// file is missing locally).  Returns `Ok(false)` when both local files
     /// match the remote sizes.  Network errors are propagated.
     pub async fn check_update(&self) -> Result<bool> {
-        let client = build_client(30)?;
-
+        // Missing file → definitely need to download; decided before any
+        // network access (and before the source URL is validated).
         for filename in &["ip2region_v4.xdb", "ip2region_v6.xdb"] {
-            let local_path = self.data_dir.join(filename);
-
-            // Missing file → definitely need to download.
-            if !local_path.exists() {
+            if !self.data_dir.join(filename).exists() {
                 debug!("GeoIP updater: {} not found locally — update needed", filename);
                 return Ok(true);
             }
+        }
 
+        // One validated client per cycle — both files share the base host.
+        let client = build_validated_client(&self.github_base_url, CONNECT_TIMEOUT, HEAD_TIMEOUT, USER_AGENT)?;
+
+        for filename in &["ip2region_v4.xdb", "ip2region_v6.xdb"] {
+            let local_path = self.data_dir.join(filename);
             let local_size = local_path.metadata().map_or(0, |m| m.len());
             let url = format!("{}/{}", self.github_base_url, filename);
 
@@ -120,7 +140,7 @@ impl XdbUpdater {
         std::fs::create_dir_all(&self.data_dir)
             .with_context(|| format!("Failed to create data dir: {}", self.data_dir.display()))?;
 
-        let client = build_client(120)?;
+        let client = build_validated_client(&self.github_base_url, CONNECT_TIMEOUT, DOWNLOAD_TIMEOUT, USER_AGENT)?;
 
         let (ipv4_updated, ipv4_size) = self.download_one(&client, "ip2region_v4.xdb").await?;
         let (ipv6_updated, ipv6_size) = self.download_one(&client, "ip2region_v6.xdb").await?;
@@ -182,15 +202,23 @@ impl XdbUpdater {
             return Err(anyhow::anyhow!("HTTP {} downloading {}", resp.status(), url));
         }
 
-        let bytes = resp
-            .bytes()
-            .await
-            .with_context(|| format!("Failed to read response body for {filename}"))?;
+        // Fast-reject a response that already advertises an oversized body.
+        if let Some(len) = resp.content_length()
+            && len > MAX_XDB_RESPONSE_SIZE
+        {
+            return Err(anyhow::anyhow!(
+                "GeoIP xdb response too large: {len} bytes (max {MAX_XDB_RESPONSE_SIZE}) for {url}"
+            ));
+        }
 
-        let size = bytes.len() as u64;
+        // Stream to the tmp file with a running byte cap — never buffer the
+        // whole body in memory.
+        if let Err(e) = stream_to_tmp(&tmp_path, resp, &(1..=MAX_XDB_RESPONSE_SIZE)).await {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(e.context(format!("Failed to download {filename}")));
+        }
 
-        // Write to tmp file first.
-        std::fs::write(&tmp_path, &bytes).with_context(|| format!("Failed to write {}", tmp_path.display()))?;
+        let size = tmp_path.metadata().map_or(0, |m| m.len());
 
         // Validate: try to open the tmp file as a Searcher.
         // Use NoCache policy to avoid loading ~20 MB into memory just for validation.
@@ -278,14 +306,6 @@ pub fn parse_duration(s: &str) -> Duration {
     };
 
     Duration::from_secs(secs)
-}
-
-/// Build a [`reqwest::Client`] with a given timeout (seconds).
-fn build_client(timeout_secs: u64) -> Result<reqwest::Client> {
-    reqwest::Client::builder()
-        .timeout(Duration::from_secs(timeout_secs))
-        .build()
-        .context("Failed to build HTTP client for GeoIP updater")
 }
 
 // ── Display helper ────────────────────────────────────────────────────────────
@@ -396,20 +416,152 @@ mod tests {
         assert_eq!(default.github_base_url, DEFAULT_GITHUB_BASE_URL);
     }
 
-    #[test]
-    fn build_client_succeeds_with_reasonable_timeout() {
-        let res = build_client(30);
-        assert!(res.is_ok());
-    }
-
     #[tokio::test]
     async fn check_update_returns_true_when_files_missing() {
         let tmp = tempfile::tempdir().expect("tmp");
         // Use a non-routable URL so HEAD requests never hit the network for
         // the size-comparison branch — but since both files are missing, the
-        // function returns Ok(true) before issuing a request.
+        // function returns Ok(true) before issuing a request (and before the
+        // source URL is validated).
         let updater = XdbUpdater::new(tmp.path().to_path_buf(), "http://127.0.0.1:1".to_string());
         let res = updater.check_update().await.expect("missing files → Ok(true)");
         assert!(res);
+    }
+
+    /// Place dummy local xdb files so `check_update` proceeds to the network phase.
+    fn write_dummy_xdb_files(dir: &Path) {
+        std::fs::write(dir.join("ip2region_v4.xdb"), b"v4").expect("write v4");
+        std::fs::write(dir.join("ip2region_v6.xdb"), b"v6").expect("write v6");
+    }
+
+    #[tokio::test]
+    async fn check_update_rejects_private_host() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        write_dummy_xdb_files(tmp.path());
+        let updater = XdbUpdater::new(tmp.path().to_path_buf(), "http://127.0.0.1:9/data".to_string());
+        let err = updater
+            .check_update()
+            .await
+            .expect_err("loopback source must be rejected");
+        assert!(err.to_string().contains("SSRF"), "unexpected error: {err:#}");
+    }
+
+    #[tokio::test]
+    async fn download_rejects_private_host() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let updater = XdbUpdater::new(tmp.path().to_path_buf(), "http://10.0.0.1/data".to_string());
+        let err = updater
+            .download()
+            .await
+            .expect_err("private-range source must be rejected");
+        assert!(err.to_string().contains("SSRF"), "unexpected error: {err:#}");
+        assert!(!tmp.path().join("ip2region_v4.xdb").exists());
+    }
+
+    #[tokio::test]
+    async fn download_rejects_imds_host() {
+        let tmp = tempfile::tempdir().expect("tmp");
+        let updater = XdbUpdater::new(tmp.path().to_path_buf(), "http://169.254.169.254/latest".to_string());
+        let err = updater.download().await.expect_err("IMDS source must be rejected");
+        assert!(err.to_string().contains("SSRF"), "unexpected error: {err:#}");
+    }
+
+    /// A production-shaped client for local-server tests.
+    ///
+    /// `build_validated_client` rejects loopback URLs by design, so the full
+    /// `download()` wiring cannot be pointed at a local test server. These
+    /// tests build the client through the same helper against a public
+    /// IP-literal placeholder (never contacted) — same redirect policy,
+    /// timeouts, and UA — then drive `download_one` at the local server.
+    fn production_shaped_client() -> reqwest::Client {
+        build_validated_client(
+            "http://93.184.216.34/",
+            CONNECT_TIMEOUT,
+            Duration::from_secs(30),
+            USER_AGENT,
+        )
+        .expect("public placeholder URL must validate")
+    }
+
+    #[tokio::test]
+    async fn download_one_rejects_oversized_response() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // Body one byte over the cap; the advertised Content-Length triggers
+        // the fast-reject before any body byte is read.
+        #[allow(clippy::cast_possible_truncation)]
+        let body = vec![0u8; MAX_XDB_RESPONSE_SIZE as usize + 1];
+        Mock::given(method("GET"))
+            .and(path("/ip2region_v4.xdb"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().expect("tmp");
+        let updater = XdbUpdater::new(tmp.path().to_path_buf(), server.uri());
+
+        let err = updater
+            .download_one(&production_shaped_client(), "ip2region_v4.xdb")
+            .await
+            .expect_err("oversized response must be rejected");
+        assert!(err.to_string().contains("too large"), "unexpected error: {err:#}");
+        assert!(!tmp.path().join("ip2region_v4.xdb").exists(), "no final file");
+        assert!(!tmp.path().join("ip2region_v4.xdb.tmp").exists(), "no tmp left behind");
+    }
+
+    #[tokio::test]
+    async fn download_one_does_not_follow_redirect() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/ip2region_v4.xdb"))
+            .respond_with(ResponseTemplate::new(302).insert_header("Location", "/elsewhere"))
+            .mount(&server)
+            .await;
+        // The redirect target must never be fetched (verified on server drop).
+        Mock::given(method("GET"))
+            .and(path("/elsewhere"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"payload".to_vec()))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().expect("tmp");
+        let updater = XdbUpdater::new(tmp.path().to_path_buf(), server.uri());
+
+        let err = updater
+            .download_one(&production_shaped_client(), "ip2region_v4.xdb")
+            .await
+            .expect_err("redirect must surface as an error");
+        assert!(err.to_string().contains("302"), "unexpected error: {err:#}");
+        assert!(!tmp.path().join("ip2region_v4.xdb").exists());
+    }
+
+    #[tokio::test]
+    async fn download_one_rejects_invalid_xdb_and_cleans_tmp() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/ip2region_v4.xdb"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"not a real xdb file".to_vec()))
+            .mount(&server)
+            .await;
+
+        let tmp = tempfile::tempdir().expect("tmp");
+        let updater = XdbUpdater::new(tmp.path().to_path_buf(), server.uri());
+
+        let err = updater
+            .download_one(&production_shaped_client(), "ip2region_v4.xdb")
+            .await
+            .expect_err("invalid xdb must fail Searcher validation");
+        assert!(err.to_string().contains("validation"), "unexpected error: {err:#}");
+        assert!(!tmp.path().join("ip2region_v4.xdb").exists(), "no final file");
+        assert!(!tmp.path().join("ip2region_v4.xdb.tmp").exists(), "tmp cleaned up");
     }
 }

--- a/crates/waf-engine/src/lib.rs
+++ b/crates/waf-engine/src/lib.rs
@@ -16,6 +16,8 @@ pub mod plugins;
 pub mod relay;
 pub mod risk;
 pub mod rules;
+pub mod time;
+pub mod validated_fetch;
 
 pub use checker::RuleStore;
 pub use checks::{AntiHotlinkCheck, GeoCheck, GeoRule, GeoRuleMode, OWASPCheck, SensitiveCheck};

--- a/crates/waf-engine/src/relay/intel/atomic_swap.rs
+++ b/crates/waf-engine/src/relay/intel/atomic_swap.rs
@@ -64,7 +64,10 @@ fn tmp_path_for(target: &Path) -> PathBuf {
     PathBuf::from(s)
 }
 
-async fn stream_to_tmp(tmp: &Path, response: Response, bounds: &SizeBounds) -> Result<()> {
+/// Stream `response` body to `tmp` with a running byte cap (`bounds` end) and
+/// a minimum-size check (`bounds` start). Shared with the `GeoIP` xdb updater,
+/// which needs the capped stream but validates and renames the tmp file itself.
+pub(crate) async fn stream_to_tmp(tmp: &Path, response: Response, bounds: &SizeBounds) -> Result<()> {
     let mut file = fs::File::create(tmp)
         .await
         .with_context(|| format!("creating {}", tmp.display()))?;

--- a/crates/waf-engine/src/risk/anomaly/mod.rs
+++ b/crates/waf-engine/src/risk/anomaly/mod.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 5: Anomaly detection layer (L2).
+//! Anomaly detection layer (L2).
 //!
 //! Inline synchronous anomaly detectors for per-request evaluation.
 //! Each detector emits risk deltas based on request characteristics.

--- a/crates/waf-engine/src/risk/canary.rs
+++ b/crates/waf-engine/src/risk/canary.rs
@@ -1,9 +1,9 @@
-//! FR-028 Canary Honeypot layer.
+//! Canary Honeypot layer.
 //!
 //! Configured canary paths (e.g., `/admin-test`, `/api-debug`) that no legitimate
 //! user should hit. When triggered:
 //! 1. `store.force_max()` — pins score to 100 with `pinned_until_ms`
-//! 2. Adds IP to dynamic ban table (FR-005 `DynamicBanTable`)
+//! 2. Adds IP to the dynamic ban table (`DynamicBanTable`)
 //! 3. Returns `Block` immediately, bypassing threshold gate
 //!
 //! Hot-reloadable via `ArcSwap<HashSet<String>>` for path list updates.

--- a/crates/waf-engine/src/risk/challenge_credit/mod.rs
+++ b/crates/waf-engine/src/risk/challenge_credit/mod.rs
@@ -1,4 +1,4 @@
-//! FR-006/FR-025 Phase 8: Challenge Credit Token System.
+//! Challenge Credit Token System.
 //!
 //! Issues HMAC-signed credit tokens on successful challenge completion (e.g., JS-PoW).
 //! Tokens are single-use and bound to the actor identity to prevent replay and sharing.
@@ -63,7 +63,7 @@ impl std::fmt::Display for InvalidReason {
 
 /// Issues challenge credit tokens.
 ///
-/// Called by the challenge page (FR-006) on successful `PoW` completion.
+/// Called by the challenge page on successful `PoW` completion.
 pub struct ChallengeIssuer {
     secret: Arc<HmacSecret>,
     ttl_secs: u32,

--- a/crates/waf-engine/src/risk/challenge_credit/secret.rs
+++ b/crates/waf-engine/src/risk/challenge_credit/secret.rs
@@ -1,7 +1,7 @@
 //! HMAC secret bootstrap for challenge credit tokens.
 //!
 //! Loads secret from disk; generates 32 random bytes on first boot if absent.
-//! Never auto-rotates (Iron Rule §11) — secret persists across restarts.
+//! Never auto-rotates — secret persists across restarts.
 
 use std::fs;
 use std::io::Write;

--- a/crates/waf-engine/src/risk/config.rs
+++ b/crates/waf-engine/src/risk/config.rs
@@ -1,4 +1,4 @@
-//! FR-025 risk scoring configuration.
+//! Risk scoring configuration.
 //!
 //! YAML schema for `configs/risk.yaml`. Hot-reload via `ArcSwap` + `notify`.
 
@@ -58,15 +58,15 @@ pub struct RiskConfig {
     #[serde(default)]
     pub seed: SeedConfig,
 
-    /// Async ingest pipeline configuration (Phase 4).
+    /// Async ingest pipeline configuration.
     #[serde(default)]
     pub ingest: IngestConfig,
 
-    /// FR-028 canary honeypot configuration (Phase 6).
+    /// Canary honeypot configuration.
     #[serde(default)]
     pub canary: CanaryConfig,
 
-    /// FR-006/FR-025 Phase 8 challenge credit configuration.
+    /// Challenge credit configuration.
     #[serde(default)]
     pub challenge: ChallengeConfig,
 }
@@ -92,7 +92,7 @@ impl Default for StoreConfig {
     }
 }
 
-/// Redis store configuration (Phase 7).
+/// Redis store configuration.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RedisStoreConfig {
     /// Redis URL, e.g. `redis://127.0.0.1:6379`.
@@ -242,7 +242,7 @@ impl SeedConfig {
     }
 }
 
-/// Async ingest pipeline configuration (Phase 4).
+/// Async ingest pipeline configuration.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct IngestConfig {
     /// Whether async ingest is enabled.
@@ -259,7 +259,7 @@ pub struct IngestConfig {
     pub signal_weights: HashMap<String, i16>,
 }
 
-/// FR-028 Canary honeypot configuration (Phase 6).
+/// Canary honeypot configuration.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CanaryConfig {
     /// Whether canary detection is enabled.
@@ -276,7 +276,7 @@ pub struct CanaryConfig {
     pub ban_ttl_secs: u32,
 }
 
-/// FR-006/FR-025 Phase 8 Challenge credit configuration.
+/// Challenge credit configuration.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ChallengeConfig {
     /// Whether challenge credit verification is enabled.

--- a/crates/waf-engine/src/risk/decay.rs
+++ b/crates/waf-engine/src/risk/decay.rs
@@ -1,4 +1,4 @@
-//! FR-025 pure decay function.
+//! Pure decay function.
 //!
 //! Applies time-based decay to risk scores. Clean requests (no risk events)
 //! accumulate a streak; after enough clean requests, the score decays.

--- a/crates/waf-engine/src/risk/ingest/aggregator_impl.rs
+++ b/crates/waf-engine/src/risk/ingest/aggregator_impl.rs
@@ -3,6 +3,7 @@
 //! Implements `RiskAggregator` by forwarding signals to a bounded MPSC channel.
 //! Fire-and-forget semantics: `submit` never blocks, drops with warning on overflow.
 
+use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -59,19 +60,12 @@ impl ScoringAggregator {
     pub const fn metrics(&self) -> &Arc<IngestMetrics> {
         &self.metrics
     }
-}
 
-#[async_trait]
-impl RiskAggregator for ScoringAggregator {
-    async fn submit(&self, key: &FpKey, signals: &[Signal]) {
-        if signals.is_empty() {
-            return;
-        }
+    /// Enqueue a job without blocking — `try_send` only, drop-with-warn on
+    /// overflow. Sync so both submit seams share one code path.
+    fn enqueue(&self, job: Job) {
+        let signal_count = job.signals.len();
 
-        let now_ms = unix_now_ms();
-        let job = Job::new(key.clone(), signals.to_vec(), now_ms);
-
-        // try_send is non-blocking — contract says submit MUST NOT block
         match self.tx.try_send(job) {
             Ok(()) => {
                 self.metrics.inc_queue_depth();
@@ -80,7 +74,7 @@ impl RiskAggregator for ScoringAggregator {
                 self.metrics.inc_dropped_channel_full();
                 warn!(
                     target: "risk::ingest",
-                    signals = signals.len(),
+                    signals = signal_count,
                     "queue full, dropping risk signals"
                 );
             }
@@ -92,6 +86,25 @@ impl RiskAggregator for ScoringAggregator {
                 );
             }
         }
+    }
+}
+
+#[async_trait]
+impl RiskAggregator for ScoringAggregator {
+    async fn submit(&self, key: &FpKey, signals: &[Signal]) {
+        if signals.is_empty() {
+            return;
+        }
+
+        self.enqueue(Job::for_fp(key.clone(), signals.to_vec(), unix_now_ms()));
+    }
+
+    fn submit_ip(&self, ip: IpAddr, signals: &[Signal]) {
+        if signals.is_empty() {
+            return;
+        }
+
+        self.enqueue(Job::for_ip(ip, signals.to_vec(), unix_now_ms()));
     }
 }
 
@@ -178,6 +191,29 @@ mod tests {
 
         // Some should have been dropped
         assert!(agg.metrics().dropped_channel_full() > 0);
+
+        drop(agg);
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn submit_ip_enqueues_without_blocking() {
+        use std::net::Ipv4Addr;
+
+        use crate::risk::key::RiskKey;
+
+        let store: Arc<dyn RiskStore> = Arc::new(MemoryRiskStore::new());
+        let (agg, handle) = ScoringAggregator::start(Arc::clone(&store), SignalWeights::default());
+
+        let ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 42));
+        // Sync call — no .await, must work from non-async contexts.
+        agg.submit_ip(ip, &[Signal::FpConflict { distinct_uas: 3 }]);
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        assert_eq!(agg.metrics().processed_total(), 1);
+        let state = store.read(&RiskKey::from_ip(ip)).await.unwrap();
+        assert!(state.is_some(), "IP-keyed submission must land on the IP axis");
 
         drop(agg);
         handle.await.unwrap();

--- a/crates/waf-engine/src/risk/ingest/aggregator_impl.rs
+++ b/crates/waf-engine/src/risk/ingest/aggregator_impl.rs
@@ -1,11 +1,10 @@
-//! FR-025 Phase 4 — `ScoringAggregator` implementation.
+//! `ScoringAggregator` implementation.
 //!
 //! Implements `RiskAggregator` by forwarding signals to a bounded MPSC channel.
 //! Fire-and-forget semantics: `submit` never blocks, drops with warning on overflow.
 
 use std::net::IpAddr;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use tokio::sync::mpsc;
@@ -18,17 +17,19 @@ use crate::risk::ingest::metrics::IngestMetrics;
 use crate::risk::ingest::signal_to_contributor::SignalWeights;
 use crate::risk::ingest::worker::{Job, spawn_worker};
 use crate::risk::store::RiskStore;
+use crate::time::{Clock, SystemClock};
 
-/// Default channel capacity (65536 per plan).
+/// Default channel capacity.
 pub const DEFAULT_CHANNEL_CAPACITY: usize = 65536;
 
 /// Async risk aggregator that forwards signals to the ingest worker.
 ///
 /// Bounded channel prevents unbounded memory growth under load. Overflow
-/// triggers drop-with-warn (best-effort semantics per §3.3 of the plan).
+/// triggers drop-with-warn (best-effort semantics).
 pub struct ScoringAggregator {
     tx: mpsc::Sender<Job>,
     metrics: Arc<IngestMetrics>,
+    clock: Arc<dyn Clock>,
 }
 
 impl ScoringAggregator {
@@ -48,11 +49,23 @@ impl ScoringAggregator {
         weights: SignalWeights,
         capacity: usize,
     ) -> (Self, tokio::task::JoinHandle<()>) {
+        Self::start_with_clock(store, weights, capacity, Arc::new(SystemClock))
+    }
+
+    /// Start with an injected clock — submit timestamps and worker lag
+    /// measurements both read it, so tests can drive time deterministically.
+    #[must_use]
+    pub fn start_with_clock(
+        store: Arc<dyn RiskStore>,
+        weights: SignalWeights,
+        capacity: usize,
+        clock: Arc<dyn Clock>,
+    ) -> (Self, tokio::task::JoinHandle<()>) {
         let (tx, rx) = mpsc::channel(capacity);
         let metrics = Arc::new(IngestMetrics::new());
-        let handle = spawn_worker(rx, store, weights, Arc::clone(&metrics));
+        let handle = spawn_worker(rx, store, weights, Arc::clone(&metrics), Arc::clone(&clock));
 
-        (Self { tx, metrics }, handle)
+        (Self { tx, metrics, clock }, handle)
     }
 
     /// Get a reference to the metrics for external monitoring.
@@ -96,7 +109,7 @@ impl RiskAggregator for ScoringAggregator {
             return;
         }
 
-        self.enqueue(Job::for_fp(key.clone(), signals.to_vec(), unix_now_ms()));
+        self.enqueue(Job::for_fp(key.clone(), signals.to_vec(), self.clock.now_ms()));
     }
 
     fn submit_ip(&self, ip: IpAddr, signals: &[Signal]) {
@@ -104,21 +117,8 @@ impl RiskAggregator for ScoringAggregator {
             return;
         }
 
-        self.enqueue(Job::for_ip(ip, signals.to_vec(), unix_now_ms()));
+        self.enqueue(Job::for_ip(ip, signals.to_vec(), self.clock.now_ms()));
     }
-}
-
-#[allow(clippy::cast_possible_truncation)]
-fn unix_now_ms() -> i64 {
-    SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |d| {
-        // as_millis returns u128; we saturate to i64::MAX (292M years — safe)
-        let ms = d.as_millis();
-        if ms > i64::MAX as u128 {
-            i64::MAX
-        } else {
-            ms as i64 // safe: guarded by if
-        }
-    })
 }
 
 #[cfg(test)]

--- a/crates/waf-engine/src/risk/ingest/metrics.rs
+++ b/crates/waf-engine/src/risk/ingest/metrics.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 4 — Async ingest pipeline metrics.
+//! Async ingest pipeline metrics.
 //!
 //! Atomic counters for ingest queue health and processing. Uses `AtomicU64`
 //! for lock-free updates. Counters exposed via accessor methods for external

--- a/crates/waf-engine/src/risk/ingest/mod.rs
+++ b/crates/waf-engine/src/risk/ingest/mod.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 4 — Async ingest pipeline.
+//! Async ingest pipeline.
 //!
 //! Replaces `NoopAggregator` with `ScoringAggregator` — bounded MPSC channel +
 //! worker that translates `Signal` → `Contributor`, builds `RiskKey` from

--- a/crates/waf-engine/src/risk/ingest/signal_to_contributor.rs
+++ b/crates/waf-engine/src/risk/ingest/signal_to_contributor.rs
@@ -12,7 +12,7 @@ use crate::risk::state::{Contributor, ContributorKind};
 
 /// Configurable weights for signal → delta mapping.
 ///
-/// Default values match the plan table. Operators can override via
+/// Operators can override the default values via
 /// `risk.signal_weights` in the config YAML.
 #[derive(Clone, Debug)]
 pub struct SignalWeights {

--- a/crates/waf-engine/src/risk/ingest/signal_to_contributor.rs
+++ b/crates/waf-engine/src/risk/ingest/signal_to_contributor.rs
@@ -148,6 +148,10 @@ pub fn signal_to_contributor(signal: &Signal, weights: &SignalWeights, ts_ms: i6
             ContributorKind::Signal("limit_change_burst".into()),
             weights.get("limit_change_burst"),
         ),
+
+        // Passthrough by design: the DDoS detector already quantifies
+        // severity, so a static weight would flatten it.
+        Signal::DdosBurst { risk_delta } => (ContributorKind::Signal("ddos_burst".into()), i16::from(*risk_delta)),
     };
 
     Contributor::new(kind, delta, ts_ms)
@@ -200,6 +204,7 @@ mod tests {
                 ok_count: 3,
                 window_sec: 60,
             },
+            Signal::DdosBurst { risk_delta: 50 },
         ];
 
         for signal in &signals {
@@ -243,6 +248,15 @@ mod tests {
 
         let contrib = signal_to_contributor(&Signal::FpConflict { distinct_uas: 2 }, &weights, 0);
         assert_eq!(contrib.delta, 50);
+    }
+
+    #[test]
+    fn ddos_burst_delta_is_passthrough() {
+        let weights = SignalWeights::default();
+        let soft = signal_to_contributor(&Signal::DdosBurst { risk_delta: 37 }, &weights, 0);
+        let hard = signal_to_contributor(&Signal::DdosBurst { risk_delta: 100 }, &weights, 0);
+        assert_eq!(soft.delta, 37);
+        assert_eq!(hard.delta, 100);
     }
 
     #[test]

--- a/crates/waf-engine/src/risk/ingest/worker.rs
+++ b/crates/waf-engine/src/risk/ingest/worker.rs
@@ -4,6 +4,7 @@
 //! and applies them to the risk store. Best-effort: job errors are logged but
 //! don't stop the worker.
 
+use std::net::IpAddr;
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
@@ -16,19 +17,35 @@ use crate::risk::key::RiskKey;
 use crate::risk::score::clamp_per_request_deltas;
 use crate::risk::store::RiskStore;
 
-/// Job submitted to the worker queue.
+/// Job submitted to the worker queue. Carries at least one actor axis:
+/// a fingerprint key (device-fp submissions) or a client IP (request-path
+/// submissions that must join the scorer's IP-keyed actor).
 #[derive(Debug)]
 pub struct Job {
-    pub fp_key: FpKey,
+    pub fp_key: Option<FpKey>,
+    pub actor_ip: Option<IpAddr>,
     pub signals: Vec<crate::device_fp::signal::Signal>,
     pub submitted_ms: i64,
 }
 
 impl Job {
+    /// Job keyed by fingerprint (device-fp pipeline).
     #[must_use]
-    pub const fn new(fp_key: FpKey, signals: Vec<crate::device_fp::signal::Signal>, submitted_ms: i64) -> Self {
+    pub const fn for_fp(fp_key: FpKey, signals: Vec<crate::device_fp::signal::Signal>, submitted_ms: i64) -> Self {
         Self {
-            fp_key,
+            fp_key: Some(fp_key),
+            actor_ip: None,
+            signals,
+            submitted_ms,
+        }
+    }
+
+    /// Job keyed by client IP (sync request-path submissions).
+    #[must_use]
+    pub const fn for_ip(ip: IpAddr, signals: Vec<crate::device_fp::signal::Signal>, submitted_ms: i64) -> Self {
+        Self {
+            fp_key: None,
+            actor_ip: Some(ip),
             signals,
             submitted_ms,
         }
@@ -76,20 +93,21 @@ async fn process_job(
     let now_ms = chrono::Utc::now().timestamp_millis();
     let lag_ms = now_ms.saturating_sub(job.submitted_ms).max(0);
 
-    // Build RiskKey from FpKey — using fp_hash only (IP from sync path)
-    let Some(fp_hash) = RiskKey::hash_fp_key(&job.fp_key) else {
-        // Empty FpKey can't be resolved to a RiskKey
+    // Resolve the actor axes the job carries; a job with neither a hashable
+    // fingerprint nor an IP cannot be credited to anyone.
+    let fp_hash = job.fp_key.as_ref().and_then(RiskKey::hash_fp_key);
+    if job.actor_ip.is_none() && fp_hash.is_none() {
         metrics.inc_dropped_key_unresolved();
         debug!(
             target: "risk::ingest",
-            "dropping job: FpKey is empty, cannot resolve to RiskKey"
+            "dropping job: no actor axis (empty FpKey, no IP), cannot resolve to RiskKey"
         );
         return Ok(());
-    };
+    }
 
     let risk_key = RiskKey {
-        ip: None, // Async path uses fp_hash only; sync path handles IP
-        fp_hash: Some(fp_hash),
+        ip: job.actor_ip,
+        fp_hash,
         session: None,
     };
 
@@ -145,7 +163,7 @@ mod tests {
         let weights = SignalWeights::default();
         let metrics = Arc::new(IngestMetrics::new());
 
-        let job = Job::new(
+        let job = Job::for_fp(
             test_fp_key("test-ja3"),
             vec![Signal::FpConflict { distinct_uas: 3 }],
             chrono::Utc::now().timestamp_millis(),
@@ -154,7 +172,7 @@ mod tests {
         process_job(&job, &store, &weights, &metrics).await.unwrap();
 
         // Verify state was updated
-        let fp_hash = RiskKey::hash_fp_key(&job.fp_key).unwrap();
+        let fp_hash = RiskKey::hash_fp_key(job.fp_key.as_ref().unwrap()).unwrap();
         let key = RiskKey {
             ip: None,
             fp_hash: Some(fp_hash),
@@ -171,8 +189,8 @@ mod tests {
         let weights = SignalWeights::default();
         let metrics = Arc::new(IngestMetrics::new());
 
-        let job = Job::new(
-            FpKey::default(), // Empty key
+        let job = Job::for_fp(
+            FpKey::default(), // Empty key — and no IP axis
             vec![Signal::FpConflict { distinct_uas: 3 }],
             chrono::Utc::now().timestamp_millis(),
         );
@@ -181,6 +199,31 @@ mod tests {
 
         assert_eq!(metrics.dropped_key_unresolved(), 1);
         assert_eq!(metrics.processed_total(), 0);
+    }
+
+    #[tokio::test]
+    async fn ip_keyed_job_applies_to_ip_axis() {
+        use std::net::Ipv4Addr;
+
+        let store: Arc<dyn RiskStore> = Arc::new(MemoryRiskStore::new());
+        let weights = SignalWeights::default();
+        let metrics = Arc::new(IngestMetrics::new());
+
+        let ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7));
+        let job = Job::for_ip(
+            ip,
+            vec![Signal::FpConflict { distinct_uas: 3 }],
+            chrono::Utc::now().timestamp_millis(),
+        );
+
+        process_job(&job, &store, &weights, &metrics).await.unwrap();
+
+        // The delta must land on the same IP axis the request-path scorer
+        // reads via `RiskKey::from_ip`.
+        let state = store.read(&RiskKey::from_ip(ip)).await.unwrap();
+        assert!(state.is_some(), "IP-keyed job must be readable at RiskKey::from_ip");
+        assert!(state.unwrap().clamped_score > 0);
+        assert_eq!(metrics.processed_total(), 1);
     }
 
     #[tokio::test]
@@ -195,7 +238,7 @@ mod tests {
         // Send jobs
         for i in 0..5 {
             metrics.inc_queue_depth();
-            tx.send(Job::new(
+            tx.send(Job::for_fp(
                 test_fp_key(&format!("key-{i}")),
                 vec![Signal::H2Anomaly {
                     reason: H2AnomalyReason::BadSettings,

--- a/crates/waf-engine/src/risk/ingest/worker.rs
+++ b/crates/waf-engine/src/risk/ingest/worker.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 4 — Async ingest worker loop.
+//! Async ingest worker loop.
 //!
 //! Single tokio task that drains the job queue, maps signals to contributors,
 //! and applies them to the risk store. Best-effort: job errors are logged but
@@ -16,6 +16,7 @@ use crate::risk::ingest::signal_to_contributor::{SignalWeights, signals_to_contr
 use crate::risk::key::RiskKey;
 use crate::risk::score::clamp_per_request_deltas;
 use crate::risk::store::RiskStore;
+use crate::time::Clock;
 
 /// Job submitted to the worker queue. Carries at least one actor axis:
 /// a fingerprint key (device-fp submissions) or a client IP (request-path
@@ -61,8 +62,9 @@ pub fn spawn_worker(
     store: Arc<dyn RiskStore>,
     weights: SignalWeights,
     metrics: Arc<IngestMetrics>,
+    clock: Arc<dyn Clock>,
 ) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(supervised_worker_loop(rx, store, weights, metrics))
+    tokio::spawn(supervised_worker_loop(rx, store, weights, metrics, clock))
 }
 
 async fn supervised_worker_loop(
@@ -70,13 +72,14 @@ async fn supervised_worker_loop(
     store: Arc<dyn RiskStore>,
     weights: SignalWeights,
     metrics: Arc<IngestMetrics>,
+    clock: Arc<dyn Clock>,
 ) {
     // Simple worker loop — errors are handled gracefully per-job, no panic restart needed.
     // Individual job failures are logged but don't kill the worker.
     while let Some(job) = rx.recv().await {
         metrics.dec_queue_depth();
 
-        if let Err(err) = process_job(&job, &store, &weights, &metrics).await {
+        if let Err(err) = process_job(&job, &store, &weights, &metrics, clock.as_ref()).await {
             warn!(target: "risk::ingest", ?err, "job processing failed");
         }
     }
@@ -89,8 +92,9 @@ async fn process_job(
     store: &Arc<dyn RiskStore>,
     weights: &SignalWeights,
     metrics: &Arc<IngestMetrics>,
+    clock: &dyn Clock,
 ) -> anyhow::Result<()> {
-    let now_ms = chrono::Utc::now().timestamp_millis();
+    let now_ms = clock.now_ms();
     let lag_ms = now_ms.saturating_sub(job.submitted_ms).max(0);
 
     // Resolve the actor axes the job carries; a job with neither a hashable
@@ -148,6 +152,8 @@ mod tests {
     use crate::device_fp::signal::{H2AnomalyReason, Signal};
     use crate::device_fp::types::FingerprintValue;
     use crate::risk::store::MemoryRiskStore;
+    use crate::time::SystemClock;
+    use crate::time::test_utils::MockClock;
 
     fn test_fp_key(tag: &str) -> FpKey {
         FpKey {
@@ -166,10 +172,12 @@ mod tests {
         let job = Job::for_fp(
             test_fp_key("test-ja3"),
             vec![Signal::FpConflict { distinct_uas: 3 }],
-            chrono::Utc::now().timestamp_millis(),
+            SystemClock.now_ms(),
         );
 
-        process_job(&job, &store, &weights, &metrics).await.unwrap();
+        process_job(&job, &store, &weights, &metrics, &SystemClock)
+            .await
+            .unwrap();
 
         // Verify state was updated
         let fp_hash = RiskKey::hash_fp_key(job.fp_key.as_ref().unwrap()).unwrap();
@@ -192,10 +200,12 @@ mod tests {
         let job = Job::for_fp(
             FpKey::default(), // Empty key — and no IP axis
             vec![Signal::FpConflict { distinct_uas: 3 }],
-            chrono::Utc::now().timestamp_millis(),
+            SystemClock.now_ms(),
         );
 
-        process_job(&job, &store, &weights, &metrics).await.unwrap();
+        process_job(&job, &store, &weights, &metrics, &SystemClock)
+            .await
+            .unwrap();
 
         assert_eq!(metrics.dropped_key_unresolved(), 1);
         assert_eq!(metrics.processed_total(), 0);
@@ -210,13 +220,11 @@ mod tests {
         let metrics = Arc::new(IngestMetrics::new());
 
         let ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7));
-        let job = Job::for_ip(
-            ip,
-            vec![Signal::FpConflict { distinct_uas: 3 }],
-            chrono::Utc::now().timestamp_millis(),
-        );
+        let job = Job::for_ip(ip, vec![Signal::FpConflict { distinct_uas: 3 }], SystemClock.now_ms());
 
-        process_job(&job, &store, &weights, &metrics).await.unwrap();
+        process_job(&job, &store, &weights, &metrics, &SystemClock)
+            .await
+            .unwrap();
 
         // The delta must land on the same IP axis the request-path scorer
         // reads via `RiskKey::from_ip`.
@@ -233,7 +241,13 @@ mod tests {
         let metrics = Arc::new(IngestMetrics::new());
 
         let (tx, rx) = mpsc::channel(16);
-        let handle = spawn_worker(rx, Arc::clone(&store), weights, Arc::clone(&metrics));
+        let handle = spawn_worker(
+            rx,
+            Arc::clone(&store),
+            weights,
+            Arc::clone(&metrics),
+            Arc::new(SystemClock),
+        );
 
         // Send jobs
         for i in 0..5 {
@@ -243,7 +257,7 @@ mod tests {
                 vec![Signal::H2Anomaly {
                     reason: H2AnomalyReason::BadSettings,
                 }],
-                chrono::Utc::now().timestamp_millis(),
+                SystemClock.now_ms(),
             ))
             .await
             .unwrap();
@@ -257,5 +271,27 @@ mod tests {
 
         assert_eq!(metrics.processed_total(), 5);
         assert_eq!(metrics.queue_depth(), 0);
+    }
+
+    #[tokio::test]
+    async fn lag_is_deterministic_under_mock_clock() {
+        let store: Arc<dyn RiskStore> = Arc::new(MemoryRiskStore::new());
+        let weights = SignalWeights::default();
+        let metrics = Arc::new(IngestMetrics::new());
+        let clock = MockClock::new(1_000_000);
+
+        // Stamp the job at submit time, then advance the shared clock before
+        // the worker measures — lag must be exactly the advance, no wall-clock.
+        let job = Job::for_fp(
+            test_fp_key("lag-key"),
+            vec![Signal::FpConflict { distinct_uas: 3 }],
+            clock.now_ms(),
+        );
+        clock.advance_ms(250);
+
+        process_job(&job, &store, &weights, &metrics, &clock).await.unwrap();
+
+        assert_eq!(metrics.processed_total(), 1);
+        assert_eq!(metrics.avg_lag_ms(), 250);
     }
 }

--- a/crates/waf-engine/src/risk/key.rs
+++ b/crates/waf-engine/src/risk/key.rs
@@ -1,4 +1,4 @@
-//! FR-025 risk identity key types.
+//! Risk identity key types.
 //!
 //! `RiskKey` bundles the three identity axes (IP, fingerprint hash, session)
 //! used to look up / update risk state. Not all axes are always present —

--- a/crates/waf-engine/src/risk/mod.rs
+++ b/crates/waf-engine/src/risk/mod.rs
@@ -1,8 +1,8 @@
-//! FR-025 cumulative risk scoring subsystem.
+//! Cumulative risk scoring subsystem.
 //!
 //! Tracks per-actor (IP, fingerprint, session) risk state and applies a
 //! threshold gate to emit Allow / Challenge / Block decisions. Mirrors the
-//! FR-010 device-fingerprinting architecture: `ArcSwap<RiskConfig>` snapshot,
+//! device-fingerprinting architecture: `ArcSwap<RiskConfig>` snapshot,
 //! hot-reload via `notify`, and a store trait with in-memory + Redis backends.
 //!
 //! Module structure:

--- a/crates/waf-engine/src/risk/reload.rs
+++ b/crates/waf-engine/src/risk/reload.rs
@@ -1,4 +1,4 @@
-//! FR-025 hot-reload watcher for `configs/risk.yaml`.
+//! Hot-reload watcher for `configs/risk.yaml`.
 //!
 //! Mirrors `device_fp::reload` pattern: per-path sync thread + mpsc, parent-dir
 //! watch, debounced reload, fail-soft on parse error.

--- a/crates/waf-engine/src/risk/score.rs
+++ b/crates/waf-engine/src/risk/score.rs
@@ -1,4 +1,4 @@
-//! FR-025 pure score-fold function.
+//! Pure score-fold function.
 //!
 //! Takes a `RiskState` and a list of deltas, returns the updated state.
 //! No I/O, no side effects — pure transformation.
@@ -34,7 +34,7 @@ pub fn sum_deltas(deltas: &[Contributor]) -> i32 {
     deltas.iter().map(|c| i32::from(c.delta)).sum()
 }
 
-/// FR-025: Maximum per-request raw delta sum.
+/// Maximum per-request raw delta sum.
 pub const MAX_PER_REQUEST_DELTA: i32 = 100;
 
 /// Convert rule engine `RiskDelta` to a `Contributor` for the risk store.

--- a/crates/waf-engine/src/risk/scorer.rs
+++ b/crates/waf-engine/src/risk/scorer.rs
@@ -1,11 +1,11 @@
-//! FR-025 Scorer orchestrator.
+//! Scorer orchestrator.
 //!
 //! Builds `RiskKey` from request context, calls store, applies threshold gate,
 //! sets `X-WAF-Risk-Score` header, returns `WafAction`.
 //!
-//! Phase 5 adds L2 detectors (anomaly + velocity) evaluated inline.
-//! Phase 6 adds canary honeypot layer (FR-028) for scanner detection.
-//! Phase 8 adds challenge credit verification (FR-006 wiring).
+//! L2 detectors (anomaly + velocity) are evaluated inline, along with the
+//! canary honeypot layer (scanner detection) and challenge credit
+//! verification.
 
 use std::sync::Arc;
 
@@ -41,16 +41,15 @@ pub struct ScorerResult {
 /// Scorer orchestrator for the risk scoring pipeline.
 ///
 /// Owns a reference to the store and config snapshot. Thread-safe via `Arc`.
-/// Phase 5 adds L2 detectors: anomaly layer and velocity layer.
-/// Phase 6 adds canary honeypot layer (FR-028).
-/// Phase 8 adds challenge credit verifier (FR-006).
+/// Also owns the L2 detectors (anomaly + velocity layers), the canary
+/// honeypot layer, and the challenge credit verifier.
 pub struct Scorer<S: RiskStore + ?Sized> {
     store: Arc<S>,
     cfg: Arc<ArcSwap<RiskConfig>>,
     seed: Option<Arc<SeedLayer>>,
-    /// FR-028 canary honeypot layer for scanner detection.
+    /// Canary honeypot layer for scanner detection.
     pub canary: Option<Arc<CanaryLayer>>,
-    /// FR-006 challenge credit verifier.
+    /// Challenge credit verifier.
     challenge_verifier: Option<Arc<ChallengeVerifier>>,
     /// L2 anomaly detection layer (JA4↔UA mismatch, XFF, header sanity).
     anomaly: AnomalyLayer,
@@ -70,34 +69,6 @@ impl<S: RiskStore + ?Sized> Scorer<S> {
             challenge_verifier: None,
             anomaly: AnomalyLayer::new(),
             velocity: VelocityLayer::with_defaults(),
-        }
-    }
-
-    /// Create a scorer with seed layer.
-    #[must_use]
-    pub fn with_seed(store: Arc<S>, cfg: Arc<ArcSwap<RiskConfig>>, seed: Arc<SeedLayer>) -> Self {
-        Self {
-            store,
-            cfg,
-            seed: Some(seed),
-            canary: None,
-            challenge_verifier: None,
-            anomaly: AnomalyLayer::new(),
-            velocity: VelocityLayer::with_defaults(),
-        }
-    }
-
-    /// Create a scorer with custom velocity threshold.
-    #[must_use]
-    pub fn with_velocity_threshold(store: Arc<S>, cfg: Arc<ArcSwap<RiskConfig>>, threshold: u32) -> Self {
-        Self {
-            store,
-            cfg,
-            seed: None,
-            canary: None,
-            challenge_verifier: None,
-            anomaly: AnomalyLayer::new(),
-            velocity: VelocityLayer::new(threshold),
         }
     }
 
@@ -250,7 +221,7 @@ impl<S: RiskStore + ?Sized> Scorer<S> {
         let velocity_deltas = self.velocity.evaluate(&key, tx_endpoint, now_ms);
         all_deltas.extend(velocity_deltas);
 
-        // FR-006 Challenge credit verification
+        // Challenge credit verification
         if let Some(credit_delta) = self.evaluate_challenge_credit(ctx, &key, now_ms, cfg).await {
             all_deltas.push(credit_delta);
         }

--- a/crates/waf-engine/src/risk/seed/asn.rs
+++ b/crates/waf-engine/src/risk/seed/asn.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 2: ASN classification loader.
+//! ASN classification loader.
 //!
 //! Loads ASN classification data from a CSV file into a radix trie for
 //! longest-prefix matching. Format: `cidr,asn,classification`.

--- a/crates/waf-engine/src/risk/seed/mod.rs
+++ b/crates/waf-engine/src/risk/seed/mod.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 2: L0 Reputation Seed Layer.
+//! L0 Reputation Seed Layer.
 //!
 //! Classifies IPs via whitelist (short-circuit), Tor exit list, and ASN
 //! classification before any expensive detection layers run. Uses `ArcSwap`

--- a/crates/waf-engine/src/risk/seed/reload.rs
+++ b/crates/waf-engine/src/risk/seed/reload.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 2: Hot-reload watcher for seed data files.
+//! Hot-reload watcher for seed data files.
 //!
 //! Watches tor-exits.txt, asn-classes.csv, and risk-whitelist.txt for changes.
 //! On any change, reloads all files and swaps `SeedTables` atomically.

--- a/crates/waf-engine/src/risk/seed/tables.rs
+++ b/crates/waf-engine/src/risk/seed/tables.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 2: Seed data tables for L0 reputation layer.
+//! Seed data tables for the L0 reputation layer.
 //!
 //! Bundles Tor exit set, ASN classification trie, and whitelist CIDR trie
 //! into a single `SeedTables` struct for atomic hot-reload via `ArcSwap`.

--- a/crates/waf-engine/src/risk/seed/tor.rs
+++ b/crates/waf-engine/src/risk/seed/tor.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 2: Tor exit list loader.
+//! Tor exit list loader.
 //!
 //! Loads Tor exit node IPs from a newline-delimited file into a `HashSet`
 //! for O(1) lookup. Malformed lines are logged and skipped.

--- a/crates/waf-engine/src/risk/seed/whitelist.rs
+++ b/crates/waf-engine/src/risk/seed/whitelist.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 2: Whitelist CIDR loader.
+//! Whitelist CIDR loader.
 //!
 //! Loads whitelist CIDRs from a newline-delimited file. Malformed lines are
 //! logged and skipped — never panics.

--- a/crates/waf-engine/src/risk/state.rs
+++ b/crates/waf-engine/src/risk/state.rs
@@ -1,4 +1,4 @@
-//! FR-025 risk state types.
+//! Risk state types.
 //!
 //! `RiskState` holds the accumulated risk for a single actor identity.
 //! `Contributor` records individual risk events (rule hits, anomalies, signals)
@@ -20,7 +20,7 @@ pub enum SeedKind {
     BadASN,
 }
 
-/// Outcome of challenge credit verification (FR-006).
+/// Outcome of challenge credit verification.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CreditOutcome {
     /// Valid challenge token — grant credit.
@@ -38,7 +38,7 @@ pub enum CreditOutcome {
 pub enum ContributorKind {
     /// A WAF rule matched (`rule_id` stored).
     Rule(String),
-    /// Behavioral anomaly detected (FR-011).
+    /// Behavioral anomaly detected.
     Anomaly,
     /// L0 seed layer classification (Tor exit, datacenter ASN, bad ASN).
     Seed(SeedKind),
@@ -48,7 +48,7 @@ pub enum ContributorKind {
     Override,
     /// Decay credit applied.
     Decay,
-    /// FR-006 challenge credit verification result.
+    /// Challenge credit verification result.
     ChallengeCredit(CreditOutcome),
     /// Admin API credit — operator-issued score reduction.
     AdminCredit,
@@ -88,7 +88,7 @@ pub struct RiskState {
     pub contributors: SmallVec<[Contributor; 8]>,
     /// Consecutive "clean" requests (no risk events) — used for decay.
     pub clean_streak: u32,
-    /// FR-028 honeypot: floor the score until this timestamp (ms).
+    /// Canary honeypot: floor the score until this timestamp (ms).
     pub pinned_until_ms: Option<i64>,
 }
 

--- a/crates/waf-engine/src/risk/store/conformance.rs
+++ b/crates/waf-engine/src/risk/store/conformance.rs
@@ -1,7 +1,7 @@
-//! FR-025 store conformance suite.
+//! Store conformance suite.
 //!
 //! Shared test cases that any `RiskStore` implementation must pass.
-//! Memory backend tests call this; Redis backend (P7) will reuse.
+//! Memory backend tests call this; the Redis backend reuses it.
 
 use std::net::{IpAddr, Ipv4Addr};
 

--- a/crates/waf-engine/src/risk/store/memory.rs
+++ b/crates/waf-engine/src/risk/store/memory.rs
@@ -1,4 +1,4 @@
-//! FR-025 in-memory risk store with triple-index pattern.
+//! In-memory risk store with triple-index pattern.
 //!
 //! Three `DashMap` indices keyed independently (IP, `fp_hash`, session) share
 //! `Arc<RwLock<RiskState>>`. On collision (different Arcs for same actor),
@@ -20,6 +20,7 @@ use crate::risk::key::RiskKey;
 use crate::risk::score::fold;
 use crate::risk::state::{Contributor, RiskState};
 use crate::risk::store::store_trait::{ApplyResult, RiskStore};
+use crate::time::Clock;
 
 type StateRef = Arc<RwLock<RiskState>>;
 
@@ -50,13 +51,13 @@ impl MemoryRiskStore {
     }
 
     /// Spawn a background task that periodically purges expired entries.
-    pub fn start_purge_loop(self: &Arc<Self>, ttl_ms: i64, interval_secs: u64) {
+    pub fn start_purge_loop(self: &Arc<Self>, ttl_ms: i64, interval_secs: u64, clock: Arc<dyn Clock>) {
         let store = Arc::clone(self);
         tokio::spawn(async move {
             let mut tick = interval(Duration::from_secs(interval_secs));
             loop {
                 tick.tick().await;
-                let now_ms = chrono::Utc::now().timestamp_millis();
+                let now_ms = clock.now_ms();
                 match store.purge_expired(ttl_ms, now_ms).await {
                     Ok(n) if n > 0 => debug!(purged = n, "risk store: purged expired entries"),
                     Ok(_) => {}
@@ -158,7 +159,7 @@ impl RiskStore for MemoryRiskStore {
         // Apply decay then fold deltas under write lock (atomic)
         {
             let mut state = state_ref.write();
-            // Decay BEFORE fold (FR-025 §4): read state → decay → fold new deltas
+            // Decay BEFORE fold: read state → decay → fold new deltas
             if !is_new {
                 apply_decay(&mut state, now_ms, &self.decay);
             }
@@ -196,7 +197,7 @@ impl RiskStore for MemoryRiskStore {
         {
             let mut state = state_ref.write();
             state.raw_score = 100;
-            state.clamped_score = 100;
+            state.reclamp();
             state.pinned_until_ms = Some(until_ms);
             state.last_updated_ms = now_ms;
         }

--- a/crates/waf-engine/src/risk/store/mod.rs
+++ b/crates/waf-engine/src/risk/store/mod.rs
@@ -1,7 +1,7 @@
-//! FR-025 risk store backends.
+//! Risk store backends.
 //!
-//! Phase 1 ships the [`RiskStore`] trait + in-memory backend. Phase 7 adds
-//! Redis backend behind `redis-store` feature flag for cluster-wide state.
+//! The [`RiskStore`] trait has an in-memory backend, plus a Redis backend
+//! behind the `redis-store` feature flag for cluster-wide state.
 
 pub mod memory;
 pub mod store_trait;

--- a/crates/waf-engine/src/risk/store/redis.rs
+++ b/crates/waf-engine/src/risk/store/redis.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 7: Redis-backed `RiskStore` for cluster-wide risk state.
+//! Redis-backed `RiskStore` for cluster-wide risk state.
 //!
 //! Key layout:
 //! - `waf:risk:state:{owner_id}` → JSON-encoded `RiskState` (TTL: `ttl_secs`)

--- a/crates/waf-engine/src/risk/store/redis_lua.rs
+++ b/crates/waf-engine/src/risk/store/redis_lua.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 7: Embedded Lua scripts for Redis risk store.
+//! Embedded Lua scripts for the Redis risk store.
 //!
 //! All scripts are atomic single-RTT operations: owner resolution (mint or
 //! max-score convergence across index keys) and state mutation happen inside

--- a/crates/waf-engine/src/risk/store/store_trait.rs
+++ b/crates/waf-engine/src/risk/store/store_trait.rs
@@ -1,13 +1,11 @@
-//! FR-025 risk store trait.
+//! Risk store trait.
 //!
 //! Defines the async interface for risk state persistence. Implementations
 //! must be `Send + Sync` for use in the async pipeline.
 
-use std::net::IpAddr;
-
 use async_trait::async_trait;
 
-use crate::risk::key::{RiskKey, SessionId};
+use crate::risk::key::RiskKey;
 use crate::risk::state::{Contributor, RiskState};
 
 /// Result of an `apply` operation — the post-update state.
@@ -52,7 +50,7 @@ pub trait RiskStore: Send + Sync {
 
     /// Force the state to max score (100) until `until_ms`.
     ///
-    /// Used for honeypot traps (FR-028). Sets `pinned_until_ms` and floors
+    /// Used for honeypot traps. Sets `pinned_until_ms` and floors
     /// the score at 100 regardless of decay.
     async fn force_max(&self, key: &RiskKey, until_ms: i64, now_ms: i64) -> anyhow::Result<()>;
 
@@ -84,55 +82,12 @@ pub trait RiskStore: Send + Sync {
     }
 }
 
-/// Builder for `RiskKey` from request context.
-pub struct RiskKeyBuilder {
-    key: RiskKey,
-}
-
-impl RiskKeyBuilder {
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            key: RiskKey::default(),
-        }
-    }
-
-    #[must_use]
-    pub const fn with_ip(mut self, ip: IpAddr) -> Self {
-        self.key.ip = Some(ip);
-        self
-    }
-
-    #[must_use]
-    pub const fn with_fp_hash(mut self, hash: u64) -> Self {
-        self.key.fp_hash = Some(hash);
-        self
-    }
-
-    #[must_use]
-    pub fn with_session(mut self, session: SessionId) -> Self {
-        self.key.session = Some(session);
-        self
-    }
-
-    #[must_use]
-    pub fn build(self) -> RiskKey {
-        self.key
-    }
-}
-
-impl Default for RiskKeyBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[cfg(test)]
 #[allow(clippy::redundant_clone, clippy::uninlined_format_args)]
 mod tests {
     use super::*;
     use crate::risk::state::RiskState;
-    use std::net::Ipv4Addr;
+    use std::net::{IpAddr, Ipv4Addr};
 
     /// Minimal `RiskStore` impl that only implements required methods —
     /// drives default `is_empty` impl through the trait.
@@ -210,26 +165,6 @@ mod tests {
         assert_eq!(s.purge_expired(0, 0).await.unwrap(), 0);
         assert_eq!(s.len().await, 0);
         assert!(s.is_empty().await);
-    }
-
-    #[test]
-    fn key_builder_with_each_axis() {
-        use crate::risk::key::SessionId;
-        let key = RiskKeyBuilder::new()
-            .with_ip(IpAddr::V4(Ipv4Addr::LOCALHOST))
-            .with_fp_hash(0xDEAD_BEEF)
-            .with_session(SessionId::new(b"abc".to_vec()))
-            .build();
-        assert_eq!(key.axis_count(), 3);
-        assert!(key.ip.is_some());
-        assert!(key.fp_hash.is_some());
-        assert!(key.session.is_some());
-    }
-
-    #[test]
-    fn key_builder_default_is_empty() {
-        let key = RiskKeyBuilder::default().build();
-        assert!(key.is_empty());
     }
 
     #[test]

--- a/crates/waf-engine/src/risk/tests/anomaly_combos.rs
+++ b/crates/waf-engine/src/risk/tests/anomaly_combos.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 5: Anomaly detector combination tests.
+//! Anomaly detector combination tests.
 //!
 //! Verifies each detector emits correct deltas and that combinations
 //! accumulate properly without exceeding individual caps.

--- a/crates/waf-engine/src/risk/tests/canary.rs
+++ b/crates/waf-engine/src/risk/tests/canary.rs
@@ -1,4 +1,4 @@
-//! FR-028 Canary Honeypot integration tests.
+//! Canary Honeypot integration tests.
 //!
 //! Tests verify:
 //! - Canary path triggers score=100 and Block decision

--- a/crates/waf-engine/src/risk/tests/conformance_redis.rs
+++ b/crates/waf-engine/src/risk/tests/conformance_redis.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 7: Redis store conformance tests.
+//! Redis store conformance tests.
 //!
 //! Runs the shared conformance suite against `RedisRiskStore`. Only executes
 //! when `REDIS_TEST_URL` is set (e.g. `redis://127.0.0.1:6379`).

--- a/crates/waf-engine/src/risk/tests/lifecycle.rs
+++ b/crates/waf-engine/src/risk/tests/lifecycle.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 5: Risk lifecycle tests.
+//! Risk lifecycle tests.
 //!
 //! Verifies the rise → decay → floor behavior end-to-end:
 //! - Attack signals raise score

--- a/crates/waf-engine/src/risk/tests/mod.rs
+++ b/crates/waf-engine/src/risk/tests/mod.rs
@@ -1,4 +1,4 @@
-//! FR-025 Integration tests for risk scoring lifecycle.
+//! Integration tests for the risk scoring lifecycle.
 
 mod anomaly_combos;
 mod canary;

--- a/crates/waf-engine/src/risk/tests/redis_failover.rs
+++ b/crates/waf-engine/src/risk/tests/redis_failover.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 7: Redis failover and circuit breaker tests.
+//! Redis failover and circuit breaker tests.
 //!
 //! Tests fail-open behavior when Redis is unavailable or times out.
 //! Uses cache fallback to maintain continuity during outages.

--- a/crates/waf-engine/src/risk/threshold.rs
+++ b/crates/waf-engine/src/risk/threshold.rs
@@ -1,4 +1,4 @@
-//! FR-025 pure threshold gate.
+//! Pure threshold gate.
 //!
 //! Maps a clamped risk score (0..=100) to a `WafAction` based on configured
 //! thresholds. Uses the tier's `RiskThresholds` (allow, challenge, block).

--- a/crates/waf-engine/src/risk/velocity/mod.rs
+++ b/crates/waf-engine/src/risk/velocity/mod.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 5: Velocity detection layer (L2).
+//! Velocity detection layer (L2).
 //!
 //! Tracks request velocity and transaction sequences per actor.
 //!

--- a/crates/waf-engine/src/risk/velocity/sequence.rs
+++ b/crates/waf-engine/src/risk/velocity/sequence.rs
@@ -5,7 +5,8 @@
 //! - Impossible-fast transitions (e.g., Login→OTP in <1.5s)
 //!
 //! Emits +30 delta on violation. Sync-side only — fires when sequence
-//! completes in a single request chain (FR-012 async handles cross-request).
+//! completes in a single request chain (the async transaction-velocity
+//! signals handle cross-request sequences).
 
 use dashmap::DashMap;
 

--- a/crates/waf-engine/src/rules/manager.rs
+++ b/crates/waf-engine/src/rules/manager.rs
@@ -449,44 +449,21 @@ const MAX_RULES_RESPONSE_SIZE: u64 = 10 * 1024 * 1024;
 /// Fetch the text content of a remote URL with SSRF protection.
 ///
 /// Safety measures applied:
-/// - URL is validated against private/reserved IP ranges before fetching.
-/// - The HTTP client is pinned to the IPs resolved at validation time via
-///   `resolve_to_addrs`, closing the DNS-rebinding TOCTOU window.
-/// - HTTP redirects are disabled to prevent redirect-based SSRF.
-/// - A 30-second total timeout and 10-second connect timeout cap slow connections.
+/// - The client comes from [`crate::validated_fetch::build_validated_client`]:
+///   URL validated against private/reserved IP ranges, client pinned to the
+///   IPs resolved at validation time (DNS-rebinding TOCTOU), redirects
+///   disabled, 30-second total and 10-second connect timeouts.
 /// - Response body is capped at [`MAX_RULES_RESPONSE_SIZE`] to prevent OOM.
 ///
 /// Returns the response body as a UTF-8 string.
 async fn fetch_remote_content(url: &str) -> Result<String> {
-    // Validate the URL against SSRF targets (private IPs, loopback, IMDS, etc.)
-    // before opening any network connection.  The returned `validated_url` and
-    // `resolved_addrs` are used below to pin the client and close the
-    // DNS-rebinding TOCTOU gap.
-    let (validated_url, resolved_addrs) = waf_common::url_validator::validate_public_url_with_ips(url)
-        .with_context(|| format!("Remote rule URL failed SSRF validation: {url}"))?;
-
-    let mut builder = reqwest::Client::builder()
-        // Disable all redirects — a redirect could point to an internal endpoint.
-        .redirect(reqwest::redirect::Policy::none())
-        // Total request timeout (connect + read).
-        .timeout(std::time::Duration::from_secs(30))
-        // Connection establishment timeout only.
-        .connect_timeout(std::time::Duration::from_secs(10));
-
-    // Pin the client to the IPs validated above.  Only applies when the URL
-    // contains a DNS hostname; IP-literal URLs return an empty `resolved_addrs`.
-    // Re-use the already-parsed `validated_url` to extract the host, avoiding
-    // a redundant parse and removing the need to import `url` directly in this
-    // crate.
-    if !resolved_addrs.is_empty()
-        && let Some(host) = validated_url.host_str()
-    {
-        builder = builder.resolve_to_addrs(host, &resolved_addrs);
-    }
-
-    let client = builder
-        .build()
-        .with_context(|| "Failed to build SSRF-safe HTTP client")?;
+    let client = crate::validated_fetch::build_validated_client(
+        url,
+        std::time::Duration::from_secs(10),
+        std::time::Duration::from_secs(30),
+        crate::validated_fetch::USER_AGENT,
+    )
+    .with_context(|| format!("Remote rule URL failed SSRF validation: {url}"))?;
 
     let response = client
         .get(url)

--- a/crates/waf-engine/src/time.rs
+++ b/crates/waf-engine/src/time.rs
@@ -1,0 +1,99 @@
+//! Time abstraction shared by `DDoS` detectors and the risk ingest pipeline.
+//!
+//! The `Clock` trait allows production code to use real wall-clock time while
+//! substituting mock clocks in tests for deterministic behavior.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Trait for obtaining current time in milliseconds since UNIX epoch.
+///
+/// Production code uses `SystemClock`; tests use mock implementations
+/// to control time boundaries and window rollovers.
+pub trait Clock: Send + Sync {
+    /// Current time in milliseconds since UNIX epoch.
+    fn now_ms(&self) -> i64;
+}
+
+/// Real wall-clock implementation of `Clock`.
+///
+/// Uses `SystemTime::now()` — suitable for production use.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now_ms(&self) -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+    }
+}
+
+#[cfg(test)]
+pub mod test_utils {
+    use super::*;
+    use std::sync::atomic::{AtomicI64, Ordering};
+
+    /// Mock clock with controllable time for testing.
+    ///
+    /// Call `set_ms()` or `advance_ms()` to control the returned time.
+    pub struct MockClock {
+        time_ms: AtomicI64,
+    }
+
+    impl MockClock {
+        pub fn new(initial_ms: i64) -> Self {
+            Self {
+                time_ms: AtomicI64::new(initial_ms),
+            }
+        }
+
+        pub fn set_ms(&self, ms: i64) {
+            self.time_ms.store(ms, Ordering::Relaxed);
+        }
+
+        pub fn advance_ms(&self, delta: i64) {
+            self.time_ms.fetch_add(delta, Ordering::Relaxed);
+        }
+    }
+
+    impl Clock for MockClock {
+        fn now_ms(&self) -> i64 {
+            self.time_ms.load(Ordering::Relaxed)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn system_clock_returns_positive_value() {
+        let clock = SystemClock;
+        let now = clock.now_ms();
+        assert!(now > 0, "system clock should return positive epoch ms");
+    }
+
+    #[test]
+    fn system_clock_advances() {
+        let clock = SystemClock;
+        let t1 = clock.now_ms();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let t2 = clock.now_ms();
+        assert!(t2 >= t1, "time should not go backwards");
+    }
+
+    #[test]
+    fn mock_clock_controllable() {
+        use test_utils::MockClock;
+
+        let clock = MockClock::new(1000);
+        assert_eq!(clock.now_ms(), 1000);
+
+        clock.set_ms(5000);
+        assert_eq!(clock.now_ms(), 5000);
+
+        clock.advance_ms(100);
+        assert_eq!(clock.now_ms(), 5100);
+    }
+}

--- a/crates/waf-engine/src/validated_fetch.rs
+++ b/crates/waf-engine/src/validated_fetch.rs
@@ -1,0 +1,94 @@
+//! Shared SSRF-hardened HTTP client construction for outbound fetches.
+//!
+//! Both the remote rule-source loader and the `GeoIP` xdb updater fetch
+//! operator-configured URLs from inside the WAF process, which makes them
+//! SSRF targets. This module is the single place that encodes the hardened
+//! posture so the two callers cannot drift:
+//!
+//! - The URL is validated against private / reserved / loopback / IMDS
+//!   ranges before any connection is opened.
+//! - The client is pinned to the IPs resolved at validation time via
+//!   `resolve_to_addrs`, closing the DNS-rebinding TOCTOU window.
+//! - HTTP redirects are disabled — a followed redirect escapes the pin.
+//! - Connect and total timeouts plus a stable User-Agent are always set.
+//!
+//! Response-body size caps stay a caller concern (rules cap text in memory,
+//! the xdb updater streams to a file), so they are not baked in here.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+
+/// Stable User-Agent sent by validated outbound fetches.
+pub const USER_AGENT: &str = concat!("mini-waf/", env!("CARGO_PKG_VERSION"));
+
+/// Build an SSRF-validated, IP-pinned, redirect-disabled [`reqwest::Client`]
+/// for `url`.
+///
+/// Validates `url` against private/reserved ranges, pins the client to the
+/// addresses resolved at validation time (closing the DNS-rebinding TOCTOU
+/// gap), and disables redirects (a followed redirect escapes the pin).
+/// Callers must issue their requests against the same host as `url`.
+pub fn build_validated_client(
+    url: &str,
+    connect_timeout: Duration,
+    total_timeout: Duration,
+    user_agent: &str,
+) -> Result<reqwest::Client> {
+    let (validated_url, resolved_addrs) = waf_common::url_validator::validate_public_url_with_ips(url)
+        .with_context(|| format!("URL failed SSRF validation: {url}"))?;
+
+    let mut builder = reqwest::Client::builder()
+        // Disable all redirects — a redirect could point to an internal endpoint.
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(total_timeout)
+        .connect_timeout(connect_timeout)
+        .user_agent(user_agent);
+
+    // Pin the client to the IPs validated above.  Only applies when the URL
+    // contains a DNS hostname; IP-literal URLs return an empty `resolved_addrs`.
+    if !resolved_addrs.is_empty()
+        && let Some(host) = validated_url.host_str()
+    {
+        builder = builder.resolve_to_addrs(host, &resolved_addrs);
+    }
+
+    builder.build().context("Failed to build SSRF-safe HTTP client")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build(url: &str) -> Result<reqwest::Client> {
+        build_validated_client(url, Duration::from_secs(5), Duration::from_secs(30), USER_AGENT)
+    }
+
+    #[test]
+    fn rejects_private_range_url() {
+        assert!(build("http://10.0.0.1/").is_err());
+        assert!(build("http://192.168.1.1/data").is_err());
+    }
+
+    #[test]
+    fn rejects_loopback_url() {
+        assert!(build("http://127.0.0.1:8080/xdb").is_err());
+    }
+
+    #[test]
+    fn rejects_imds_url() {
+        assert!(build("http://169.254.169.254/latest/meta-data").is_err());
+    }
+
+    #[test]
+    fn accepts_public_ip_literal_url() {
+        // IP-literal public host: validation is deterministic (no DNS) and
+        // resolved_addrs is empty, so no pin is applied.
+        assert!(build("http://93.184.216.34/file.xdb").is_ok());
+    }
+
+    #[test]
+    fn rejects_non_http_scheme() {
+        assert!(build("file:///etc/passwd").is_err());
+    }
+}

--- a/crates/waf-engine/tests/ddos_risk_bump_acceptance.rs
+++ b/crates/waf-engine/tests/ddos_risk_bump_acceptance.rs
@@ -1,0 +1,123 @@
+//! End-to-end proof that `DDoS` risk bumps land on the actor the request-path
+//! scorer actually reads: `RiskBumpAction` → sync `submit_ip` → ingest worker
+//! → `MemoryRiskStore`, keyed by client IP.
+//!
+//! Deliberately runs on the default `current_thread` test runtime — the submit
+//! side must be runtime-flavor agnostic (no `block_in_place`).
+
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use waf_engine::checks::ddos::{ActionExecutor, DetectorVerdict, RiskBumpAction};
+use waf_engine::device_fp::aggregator::RiskAggregator;
+use waf_engine::device_fp::types::{FingerprintValue, FpKey};
+use waf_engine::risk::key::RiskKey;
+use waf_engine::risk::state::ContributorKind;
+use waf_engine::risk::store::{MemoryRiskStore, RiskStore};
+use waf_engine::risk::{ScoringAggregator, SignalWeights};
+
+fn start_pipeline() -> (Arc<dyn RiskStore>, Arc<ScoringAggregator>, tokio::task::JoinHandle<()>) {
+    let store: Arc<dyn RiskStore> = Arc::new(MemoryRiskStore::new());
+    let (agg, handle) = ScoringAggregator::start(Arc::clone(&store), SignalWeights::default());
+    (store, Arc::new(agg), handle)
+}
+
+/// Poll the ingest metrics until `n` jobs were processed, bounded by a timeout.
+async fn await_processed(agg: &ScoringAggregator, n: u64) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    while agg.metrics().processed_total() < n {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "worker did not process {n} job(s) in time"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
+async fn hard_burst_raises_scored_actor_state() {
+    let (store, agg, _handle) = start_pipeline();
+    let action = RiskBumpAction::new(agg.clone() as Arc<dyn RiskAggregator>);
+    let ip: IpAddr = "198.51.100.77".parse().unwrap();
+
+    let verdict = DetectorVerdict::HardBurst {
+        reason: "burst",
+        detector: "per_ip",
+        rps: 500,
+    };
+    // Plain sync call — no runtime bridge involved.
+    let result = action.execute(ip, &verdict, 1000);
+    assert_eq!(result.risk_delta, 100);
+
+    await_processed(&agg, 1).await;
+
+    // Same key shape the request-path scorer builds for this client.
+    let state = store
+        .read(&RiskKey::from_ip(ip))
+        .await
+        .unwrap()
+        .expect("risk state must exist under the client IP actor");
+    assert!(state.clamped_score > 0);
+    let contributor = state
+        .contributors
+        .iter()
+        .find(|c| matches!(&c.kind, ContributorKind::Signal(name) if name == "ddos_burst"))
+        .expect("ddos_burst contributor must be recorded");
+    assert_eq!(contributor.delta, 100);
+}
+
+#[tokio::test]
+async fn soft_anomaly_preserves_severity() {
+    let (store, agg, _handle) = start_pipeline();
+    let action = RiskBumpAction::new(agg.clone() as Arc<dyn RiskAggregator>);
+    let ip: IpAddr = "198.51.100.78".parse().unwrap();
+
+    let result = action.execute(ip, &DetectorVerdict::SoftAnomaly(37), 1000);
+    assert_eq!(result.risk_delta, 37);
+
+    await_processed(&agg, 1).await;
+
+    let state = store.read(&RiskKey::from_ip(ip)).await.unwrap().unwrap();
+    let contributor = state
+        .contributors
+        .iter()
+        .find(|c| matches!(&c.kind, ContributorKind::Signal(name) if name == "ddos_burst"))
+        .expect("ddos_burst contributor must be recorded");
+    assert_eq!(contributor.delta, 37, "detector severity must survive end-to-end");
+}
+
+#[tokio::test]
+async fn phantom_actor_regression() {
+    let (store, agg, _handle) = start_pipeline();
+    let action = RiskBumpAction::new(agg.clone() as Arc<dyn RiskAggregator>);
+    let ip: IpAddr = "198.51.100.79".parse().unwrap();
+
+    let verdict = DetectorVerdict::HardBurst {
+        reason: "burst",
+        detector: "per_ip",
+        rps: 500,
+    };
+    action.execute(ip, &verdict, 1000);
+
+    await_processed(&agg, 1).await;
+
+    // The old implementation smuggled the IP inside a synthetic fingerprint
+    // key; nothing may land under that phantom actor anymore.
+    let smuggled = FpKey {
+        ja3: Some(FingerprintValue::new(format!("ddos:{ip}"))),
+        ja4: None,
+        h2_akamai: None,
+    };
+    let phantom_key = RiskKey {
+        ip: None,
+        fp_hash: RiskKey::hash_fp_key(&smuggled),
+        session: None,
+    };
+    assert!(
+        store.read(&phantom_key).await.unwrap().is_none(),
+        "no state may exist under the smuggled fingerprint actor"
+    );
+    // ...while the real IP actor does have state.
+    assert!(store.read(&RiskKey::from_ip(ip)).await.unwrap().is_some());
+}

--- a/crates/waf-engine/tests/geo_rules_enforcement.rs
+++ b/crates/waf-engine/tests/geo_rules_enforcement.rs
@@ -99,3 +99,52 @@ async fn allow_rows_union_into_single_allow_only_rule() {
         "country outside the allow list must be blocked"
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn allow_only_fail_mode_honored_when_geo_unavailable() {
+    let fx = start_engine().await;
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let path = dir.path().join("geo-rules.yaml");
+
+    // fail_closed on an allow row: a request with no determinable country is
+    // blocked instead of silently passing the allowlist.
+    write_file(
+        &path,
+        r#"rules:
+  - { id: 1, iso_code: "US", action: "allow", scope: "global", enabled: true, fail_closed: true }
+"#,
+    );
+    fx.engine.load_geo_rules(&path);
+
+    let mut empty_geo = geo_ctx("", "");
+    assert!(
+        fx.engine.geo_check().check(&mut empty_geo).is_some(),
+        "fail-closed allowlist must block a request with empty geo info"
+    );
+    let mut no_geo = geo_ctx("", "");
+    no_geo.geo = None;
+    assert!(
+        fx.engine.geo_check().check(&mut no_geo).is_some(),
+        "fail-closed allowlist must block a request with no geo info"
+    );
+    let mut us = geo_ctx("US", "United States");
+    assert!(
+        fx.engine.geo_check().check(&mut us).is_none(),
+        "listed country still passes under fail-closed"
+    );
+
+    // Same rule without fail_closed: default fail-open behavior is unchanged.
+    write_file(
+        &path,
+        r#"rules:
+  - { id: 1, iso_code: "US", action: "allow", scope: "global", enabled: true }
+"#,
+    );
+    fx.engine.load_geo_rules(&path);
+
+    let mut empty_geo = geo_ctx("", "");
+    assert!(
+        fx.engine.geo_check().check(&mut empty_geo).is_none(),
+        "fail-open allowlist must pass a request with empty geo info"
+    );
+}

--- a/crates/waf-engine/tests/risk_scorer_extended.rs
+++ b/crates/waf-engine/tests/risk_scorer_extended.rs
@@ -145,7 +145,7 @@ async fn header_name_and_emit_header_accessors() {
 }
 
 #[tokio::test]
-async fn with_seed_constructor_and_set_seed() {
+async fn set_seed_then_score_allows() {
     let cfg = RiskConfig {
         enabled: true,
         ..Default::default()
@@ -153,27 +153,12 @@ async fn with_seed_constructor_and_set_seed() {
     let store = Arc::new(MemoryRiskStore::new());
     let swap = Arc::new(ArcSwap::from(Arc::new(cfg)));
     let seed = Arc::new(SeedLayer::empty());
-    let mut scorer = Scorer::with_seed(Arc::clone(&store), swap, Arc::clone(&seed));
+    let mut scorer = Scorer::new(Arc::clone(&store), swap);
     scorer.set_seed(seed);
     // Sanity: can score without panic
     let ctx = ctx_with(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), HashMap::new());
     let r = scorer.score(&ctx, None, &[], None, 1000).await.unwrap();
     assert!(matches!(r.action, WafAction::Allow));
-}
-
-#[tokio::test]
-async fn with_velocity_threshold_constructor() {
-    let cfg = RiskConfig {
-        enabled: true,
-        ..Default::default()
-    };
-    let store = Arc::new(MemoryRiskStore::new());
-    let swap = Arc::new(ArcSwap::from(Arc::new(cfg)));
-    let scorer = Scorer::with_velocity_threshold(store, swap, 1);
-    let ctx = ctx_with(IpAddr::V4(Ipv4Addr::new(7, 7, 7, 7)), HashMap::new());
-    // Run a few requests; expect velocity breach contribution to bump score eventually
-    let r = scorer.score(&ctx, None, &[], None, 1000).await.unwrap();
-    let _ = r;
 }
 
 #[tokio::test]

--- a/docs/journals/2026-07-05-gh-202-riskbump-actor-keyed-submit-implementation.md
+++ b/docs/journals/2026-07-05-gh-202-riskbump-actor-keyed-submit-implementation.md
@@ -1,0 +1,48 @@
+# 2026-07-05 — GH-202: RiskBump actor-keyed sync submit
+
+## What
+
+Three latent `RiskBumpAction` defects fixed on branch
+`fix/gh-202-riskbump-actor-keyed-submit` (stacked on
+`fix/gh-204-risk-delta-cap-decay-config`). All were latent because the engine
+wires ban-only actions today; they would fire the moment `ban_and_risk` is
+enabled:
+
+1. **`block_in_place` panic** on `current_thread` runtimes (prx-waf main uses
+   `new_current_thread`). Replaced by a sync `RiskAggregator::submit_ip(ip,
+   signals)` trait method — `try_send` is already sync, so no bridge is needed.
+   `ScoringAggregator` shares one private `enqueue` between both seams.
+2. **Phantom actor.** The IP was smuggled as `FpKey { ja3: "ddos:{ip}" }` and
+   hashed to an fp axis the request-path scorer (`RiskKey::from_ip`) never
+   joins. Ingest `Job` now carries `fp_key: Option<FpKey>` + `actor_ip:
+   Option<IpAddr>` (`Job::for_fp` / `Job::for_ip`); the worker builds
+   `RiskKey { ip, fp_hash, session: None }` and drops with the unresolved-key
+   metric only when both axes are None.
+3. **Severity flattening.** The 0-100 detector delta went through
+   `Signal::BurstInterval { count }` and the weight table (flat 20/30). New
+   `Signal::DdosBurst { risk_delta: u8 }` maps passthrough to the contributor
+   delta — deliberately not weight-table routed.
+
+Non-goals kept: `ban_and_risk` stays unwired in `engine.rs`; no SoftAnomaly
+action-policy change; no redis store changes.
+
+## Verified
+
+- New acceptance suite `tests/ddos_risk_bump_acceptance.rs`, deliberately on
+  the default current_thread test runtime: HardBurst → state readable at
+  `RiskKey::from_ip` with `ddos_burst` delta 100; SoftAnomaly(37) → delta 37
+  end-to-end; phantom-key regression (no state under the smuggled shape).
+- `risk.rs` action unit tests converted from `#[tokio::test(multi_thread)]`
+  to plain `#[test]` — itself the unit-level panic-regression proof.
+- waf-engine lib (redis-store): 1453 passed + the known 6 docker-gated
+  `engine::tests` failures (environmental). Workspace tests, clippy (both
+  feature sets), fmt clean.
+
+## Gotchas
+
+- `LoggingAggregator::submit_ip` records `key: FpKey::default()` +
+  `actor_ip: Some(ip)` — assertions should check `actor_ip`, not the key.
+- `DdosBurst` bypasses `SignalWeights` overrides by design; severity is
+  operator-controlled at the DDoS detector config instead.
+- The worker's drop-on-unresolvable branch is now "both axes None"; an empty
+  `FpKey` alone no longer drops if an IP is present.

--- a/docs/journals/2026-07-05-gh-203-geo-allowonly-fail-policy-implementation.md
+++ b/docs/journals/2026-07-05-gh-203-geo-allowonly-fail-policy-implementation.md
@@ -1,0 +1,51 @@
+# 2026-07-05 — GH-203: geo AllowOnly fail policy + reload guard
+
+## What
+
+Two fail-open geo defects fixed on branch `fix/gh-203-geo-allowonly-fail-policy`
+(stacked on `fix/gh-202-riskbump-actor-keyed-submit`):
+
+1. **Reload could swap a working searcher for `None`.**
+   `GeoIpService::reload` now decides per address family via a
+   `FamilyReload<T>` seam: new load succeeds → swap; fails with a working
+   searcher present → keep the old one and return `Err` naming the family;
+   fails with an empty slot → stay empty, no error (first-time/degraded
+   unchanged). The only production caller (`geoip_updater.rs`) already
+   surfaces `Err` via `warn!` — no caller change.
+
+2. **AllowOnly failed open whenever geo data was unavailable.**
+   `GeoRule` gained `fail_closed: bool` (default `false` — behavior
+   unchanged unless opted in). `GeoCheck::check` routes absent/empty geo to
+   `eval_fail_closed`, which blocks only when a fail-closed AllowOnly rule
+   applies (host-then-global, same precedence as `eval_rules`). Block rules
+   never fail closed. The knob rides the API row (`fail_closed` on
+   `action:"allow"` rows, persisted by create/patch handlers) and is OR-ed
+   into the host's single unioned AllowOnly rule by `parse_geo_rules`
+   (most-restrictive wins).
+
+## Verified
+
+- `geoip.rs`: `family_reload` decision matrix unit tests + service-level
+  degraded-reload tests (`Ok(false)`, no error, still unavailable).
+- `geo.rs`: fail-closed blocks on `None` and empty geo; fail-open regression
+  guard; data-present matching unchanged; block-mode never fails closed.
+- `geo_config.rs`: OR aggregation, default-false, block-row `fail_closed`
+  ignored.
+- Acceptance appended to `tests/geo_rules_enforcement.rs` (CI, docker-gated
+  locally): allow row `fail_closed:true` → empty/absent geo blocked, listed
+  country passes; without the flag → fail-open unchanged.
+- API round-trip appended to `waf-api/tests/handler_geo_rules.rs` (CI):
+  create with `fail_closed:true` → GET/loader show it; PATCH toggles it.
+- waf-engine lib: 1438 passed + known 6 docker-gated `engine::tests`
+  failures. Workspace clippy (and waf-engine with `redis-store`) clean; fmt
+  clean.
+
+## Gotchas
+
+- No valid xdb fixture exists in the repo, so the preserve-working-searcher
+  path cannot be exercised end-to-end locally; the `FamilyReload` seam
+  covers the decision matrix instead (the plan's documented fallback).
+- With GeoIP fully disabled (`ctx.geo = None`), a fail-closed AllowOnly rule
+  blocks matching hosts — intentional, opt-in; internal ranges are exempted
+  upstream by the FR-008 IP allowlist which short-circuits before geo.
+- `fail_closed` is stored on every API row but only read for allow rows.

--- a/docs/journals/2026-07-05-gh-205-geoip-updater-hardened-fetch-implementation.md
+++ b/docs/journals/2026-07-05-gh-205-geoip-updater-hardened-fetch-implementation.md
@@ -1,0 +1,54 @@
+# 2026-07-05 — GH-205: geoip updater hardened fetch
+
+## What
+
+Routed the ip2region xdb updater through the same SSRF-hardened fetch posture
+as the remote rules loader, on branch `fix/gh-205-geoip-updater-hardened-fetch`
+(stacked on `fix/gh-203-geo-allowonly-fail-policy`):
+
+1. **New shared module `waf-engine/src/validated_fetch.rs`.**
+   `build_validated_client(url, connect_timeout, total_timeout, user_agent)`
+   validates the URL against private/reserved/loopback/IMDS ranges, pins the
+   client to the IPs resolved at validation time (DNS-rebinding TOCTOU),
+   disables redirects, and sets timeouts + a stable `mini-waf/<ver>` UA.
+   `rules/manager.rs::fetch_remote_content` was refactored onto it — DRY is
+   the fix; the drift between the two fetch paths was the root cause.
+
+2. **`geoip_updater.rs` hardened.** `check_update` (HEAD) and `download`
+   (GET) build one validated client per cycle from `source_url`; the old
+   bare `build_client` (no validation, no redirect policy, no connect
+   timeout) is removed. `download_one` no longer buffers the body with
+   `resp.bytes()`: it fast-rejects an advertised `Content-Length` over
+   `MAX_XDB_RESPONSE_SIZE` (64 MiB) and streams to `<file>.tmp` with a
+   running cap via `relay::intel::atomic_swap::stream_to_tmp` (promoted to
+   `pub(crate)`). Searcher-validate-then-rename atomicity unchanged.
+   Missing-local-file check moved before client construction so the
+   "files absent → download needed" answer needs no network and no URL
+   validation.
+
+## Verified
+
+- `validated_fetch`: private/loopback/IMDS/file-scheme URLs → `Err`; public
+  IP-literal → `Ok`.
+- `geoip_updater`: private + IMDS `source_url` rejected in both
+  `check_update` (files present) and `download`; oversized response → `Err`,
+  no final xdb, no tmp left; 302 → `Err("HTTP 302 …")`, redirect target
+  never fetched (wiremock `expect(0)`); invalid xdb body → Searcher
+  validation failure, tmp cleaned. Existing duration/xdb-info/constructor
+  tests unchanged.
+- `rules::manager` 11 tests green after the refactor; waf-engine lib 1448
+  passed (only the known 6 docker-gated `engine::tests` failures). Clippy
+  (default + `redis-store`, all targets) and fmt clean.
+
+## Gotchas
+
+- SSRF validation rejects loopback by design, so `download()` cannot be
+  pointed at a local test server. Tests build the client through
+  `build_validated_client` against a public IP-literal placeholder (never
+  contacted — same redirect policy/timeouts/UA) and drive `download_one`
+  directly; the full-path wiring is covered by the private-host `Err` tests.
+- The oversized test relies on the `Content-Length` fast-reject (wiremock
+  sets CL from the 64 MiB + 1 body), so no body bytes stream in CI; the
+  mid-stream cap loop itself is covered by `atomic_swap`'s own tests.
+- `check_update`'s HEAD warn-and-continue on non-success status is
+  unchanged; only client construction and ordering moved.

--- a/docs/journals/2026-07-05-gh-207-waf-api-config-helpers-dedupe-implementation.md
+++ b/docs/journals/2026-07-05-gh-207-waf-api-config-helpers-dedupe-implementation.md
@@ -1,0 +1,76 @@
+# GH-207 — waf-api config helpers dedupe + unified risk clock (implementation)
+
+Date: 2026-07-05
+Branch: `fix/gh-207-waf-api-config-helpers-dedupe` (stacked on `fix/gh-205-geoip-updater-hardened-fetch`)
+Plan: `plans/260705-0958-gh-207-waf-api-config-helpers-dedupe/`
+
+## What shipped
+
+Pure dedupe, behavior-preserving. Three items from the issue:
+
+1. **Shared config-file helpers (`crates/waf-api/src/config_files.rs`, new).**
+   `resolve_path` (walk `main_config_file` up two parents, join relative),
+   `read_yaml_opt` (silent-default Value reader), `write_yaml_str` (atomic
+   `create_dir_all` + `.yaml.tmp` write + rename), and `write_yaml` (serialize
+   Value then `write_yaml_str`). Migrated 9 modules: risk_api,
+   tier_policies_api, access_lists_api, device_fp_api (all three helpers);
+   challenge_api (resolve_path + write_yaml — kept its local `read_yaml`
+   because a malformed file must surface as `BadRequest`, not default);
+   relay_api, ddos_api, tx_velocity_api (resolve_path + `write_yaml_str`,
+   keeping their typed-document serialization and error text); geo_api
+   (deleted `rules_path`, inlined `resolve_path(&state, "configs/geo-rules.yaml")`
+   at the 4 handler sites; `read_rules`/`write_rules` now thin wrappers over
+   the shared helpers). `tls.rs` untouched — sync PEM writer with chmod 600 is
+   a different contract, documented out of scope in the plan.
+
+2. **Unified clock (`crates/waf-engine/src/time.rs`, new).** `Clock` trait,
+   `SystemClock`, and `test_utils::MockClock` moved verbatim from
+   `checks/ddos/detector/clock.rs`, which is now a re-export shim so all
+   existing `checks::ddos::detector::clock::*` paths (per_tier.rs, detector
+   re-exports, integration suites) keep resolving. Injection:
+   - `ScoringAggregator` gains `clock: Arc<dyn Clock>`; new
+     `start_with_clock` ctor; `start`/`start_with_capacity` signatures
+     unchanged (default `SystemClock`). `submit`/`submit_ip` stamp
+     `Job.submitted_ms` from the clock; private `unix_now_ms()` deleted.
+   - `spawn_worker` → `supervised_worker_loop` → `process_job` take the same
+     clock; `chrono::Utc::now().timestamp_millis()` removed from the lag
+     measurement, so submit-vs-process lag is deterministic under one
+     `MockClock`. New test `lag_is_deterministic_under_mock_clock`: stamp at
+     T, `advance_ms(250)`, assert `avg_lag_ms() == 250`.
+   - `MemoryRiskStore::start_purge_loop` takes `Arc<dyn Clock>`; chrono
+     removed. Sole production caller (`engine.rs` risk store builder — landed
+     with the GH-196 wiring after the plan was authored, plan said zero
+     callers) updated to pass `SystemClock`.
+   Remaining `chrono` in risk/ddos are `timestamp_nanos` unique-id seeds in
+   redis test files — out of scope per plan.
+
+3. **RiskConfig serde mapping — verification only.** `yaml_to_fe` /
+   `fe_to_yaml` / `default_risk_fe` already absent from `risk_api.rs` (grep
+   empty): the GH-196 serde round-trip landed earlier in this stack. Nothing
+   to defer.
+
+## Gates
+
+- `cargo test -p waf-api --lib`: 118 passed (Phase 1).
+- `cargo test -p waf-engine --lib risk::` 255 passed; `checks::ddos::` 99
+  passed (Phase 2, includes new mock-clock lag test and moved `time::` tests).
+- `cargo clippy --workspace --all-targets` and
+  `cargo clippy -p waf-engine --all-targets --features redis-store`: clean
+  (only the pre-existing unused-pingora-patch note).
+- `cargo fmt --all --check`: clean.
+- Grep gates: `fn resolve_path|fn rules_path` only in `config_files.rs`;
+  `unix_now_ms` gone; ingest/memory pipeline chrono gone.
+- Full `cargo test --workspace --no-fail-fast`: green except the known
+  docker-gated suites (no docker socket on this host — testcontainer
+  integration suites and 6 docker-dependent engine lib tests), unchanged from
+  before this change.
+
+## Friction / notes
+
+- Plan staleness: `start_purge_loop` "zero production callers" was true when
+  the plan was authored but GH-196 (earlier in this stack) added the
+  `engine.rs` caller — caught by grep before changing the signature.
+- clippy `too_long_first_doc_paragraph` (nursery) fired on the shim's module
+  doc; fixed by splitting the first paragraph rather than allowing the lint.
+- clippy `redundant_pub_crate` on `pub(crate)` items in the private
+  `config_files` module — items are `pub` inside the private module instead.

--- a/docs/journals/2026-07-05-gh-208-risk-dead-code-cleanup-implementation.md
+++ b/docs/journals/2026-07-05-gh-208-risk-dead-code-cleanup-implementation.md
@@ -1,0 +1,23 @@
+# 2026-07-05 — GH-208 risk dead-code cleanup implementation
+
+Plan: `plans/260705-0958-gh-208-risk-dead-code-cleanup/` · Branch: `fix/gh-208-risk-dead-code-cleanup` (stacked on `fix/gh-207-waf-api-config-helpers-dedupe`).
+
+## What shipped
+
+Behavior-preserving cleanup of the risk module, four phases:
+
+1. **RiskKeyBuilder deleted** from `risk/store/store_trait.rs` — zero call sites outside its own two tests; both tests deleted, imports trimmed (`IpAddr` moved into the test module, `SessionId` dropped). Grep confirms zero references workspace-wide.
+2. **Test-only Scorer ctors deleted** — `Scorer::with_seed` and `Scorer::with_velocity_threshold` removed from `risk/scorer.rs`. In `tests/risk_scorer_extended.rs` the seed test migrated to `Scorer::new` + `set_seed` (renamed `set_seed_then_score_allows`); the velocity-ctor test deleted outright — velocity behavior is covered by `tests/tx_velocity_integration.rs`, and no production path sets a custom threshold (YAGNI: no setter added).
+3. **`force_max` unified on `reclamp()`** in `risk/store/memory.rs` — `raw_score = 100; state.reclamp();` replaces the hand-set `clamped_score = 100`, so clamping now flows through the single invariant everywhere. Redis Lua script untouched (already consistent). Covered by store conformance suite.
+4. **Comment sweep** — 87 plan/phase/FR-ID process tokens across 51 files in `risk/**` and `checks/ddos/**` rewritten to describe the actual behavior or invariant (e.g. "§3.3 of the plan" → the stated best-effort drop semantics; stale "GAP" notes in `per_fp.rs` restated truthfully against current code). Comment-only: no code lines changed. Acceptance grep returns zero hits.
+
+## Validation
+
+- `cargo test -p waf-engine --lib risk::` 253 passed (was 255; −2 deleted builder tests); conformance 5 passed; `risk_scorer_extended` 14 passed.
+- `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
+- Full `cargo test --workspace --no-fail-fast` compared against the known docker-gated baseline (no docker socket on this host).
+
+## Decisions / notes
+
+- Dropped the plan's original claim that `UpdateResult.ipv4_updated/ipv6_updated` were dead — they have 7 live read sites; ownership of any change there stays with the geoip updater work.
+- `reclamp()` verified semantically identical for raw=100 (clamp bounds are 0..=100; pin logic reads `pinned_until_ms`, set separately).

--- a/plans/260705-0739-gh-202-riskbump-actor-keyed-submit/phase-01-actor-keyed-sync-submit-seam.md
+++ b/plans/260705-0739-gh-202-riskbump-actor-keyed-submit/phase-01-actor-keyed-sync-submit-seam.md
@@ -1,7 +1,7 @@
 ---
 phase: 1
 title: "Actor-Keyed Sync Submit Seam"
-status: pending
+status: completed
 priority: P2
 dependencies: []
 ---

--- a/plans/260705-0739-gh-202-riskbump-actor-keyed-submit/phase-02-ddosburst-signal-riskbumpaction-rewrite.md
+++ b/plans/260705-0739-gh-202-riskbump-actor-keyed-submit/phase-02-ddosburst-signal-riskbumpaction-rewrite.md
@@ -1,7 +1,7 @@
 ---
 phase: 2
 title: "DdosBurst Signal + RiskBumpAction Rewrite"
-status: pending
+status: completed
 priority: P2
 dependencies: [1]
 ---

--- a/plans/260705-0739-gh-202-riskbump-actor-keyed-submit/phase-03-integration-tests-verification.md
+++ b/plans/260705-0739-gh-202-riskbump-actor-keyed-submit/phase-03-integration-tests-verification.md
@@ -1,7 +1,7 @@
 ---
 phase: 3
 title: "Integration Tests & Verification"
-status: pending
+status: completed
 priority: P2
 dependencies: [1, 2]
 ---

--- a/plans/260705-0739-gh-202-riskbump-actor-keyed-submit/plan.md
+++ b/plans/260705-0739-gh-202-riskbump-actor-keyed-submit/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "GH-202: RiskBumpAction actor-keyed non-blocking risk submit"
 description: "Fix three latent defects in RiskBumpAction: block_in_place panic on current_thread runtime, phantom-actor FpKey smuggling, severity flattened through BurstInterval weights"
-status: pending
+status: completed
 priority: P2
 branch: "main-harness"
 tags: [bug, ddos, risk-scoring, waf-engine]

--- a/plans/260705-0958-gh-203-geo-allowonly-fail-policy-reload-guard/phase-01-keep-old-on-failure-reload-guard.md
+++ b/plans/260705-0958-gh-203-geo-allowonly-fail-policy-reload-guard/phase-01-keep-old-on-failure-reload-guard.md
@@ -1,7 +1,7 @@
 ---
 phase: 1
 title: "Keep-old-on-failure reload guard"
-status: pending
+status: completed
 dependencies: []
 effort: "1.5h"
 ---

--- a/plans/260705-0958-gh-203-geo-allowonly-fail-policy-reload-guard/phase-02-allowonly-fail-closed-policy-in-engine.md
+++ b/plans/260705-0958-gh-203-geo-allowonly-fail-policy-reload-guard/phase-02-allowonly-fail-closed-policy-in-engine.md
@@ -1,7 +1,7 @@
 ---
 phase: 2
 title: "AllowOnly fail-closed policy in engine"
-status: pending
+status: completed
 dependencies: [1]
 effort: "2h"
 ---

--- a/plans/260705-0958-gh-203-geo-allowonly-fail-policy-reload-guard/phase-03-api-knob-gh-197-loader-wiring-acceptance.md
+++ b/plans/260705-0958-gh-203-geo-allowonly-fail-policy-reload-guard/phase-03-api-knob-gh-197-loader-wiring-acceptance.md
@@ -1,7 +1,7 @@
 ---
 phase: 3
 title: "API knob + GH-197 loader wiring + acceptance"
-status: pending
+status: completed
 dependencies: [1, 2]
 effort: "1.5h"
 ---

--- a/plans/260705-0958-gh-203-geo-allowonly-fail-policy-reload-guard/plan.md
+++ b/plans/260705-0958-gh-203-geo-allowonly-fail-policy-reload-guard/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "GH-203 geo: AllowOnly fail policy + keep-old-searcher reload guard"
 description: "AllowOnly fails open on missing/empty geo data and reload can swap a working xdb for None; add a keep-old-on-failure reload guard and an opt-in fail-closed policy for AllowOnly."
-status: pending
+status: completed
 priority: P2
 effort: 5h
 branch: "main-harness"
@@ -64,9 +64,9 @@ would be a user-decision violation.
 
 | Phase | Name | Status |
 |-------|------|--------|
-| 1 | [Keep-old-on-failure reload guard](./phase-01-keep-old-on-failure-reload-guard.md) | Pending |
-| 2 | [AllowOnly fail-closed policy in engine](./phase-02-allowonly-fail-closed-policy-in-engine.md) | Pending |
-| 3 | [API knob + GH-197 loader wiring + acceptance](./phase-03-api-knob-gh-197-loader-wiring-acceptance.md) | Pending |
+| 1 | [Keep-old-on-failure reload guard](./phase-01-keep-old-on-failure-reload-guard.md) | Completed |
+| 2 | [AllowOnly fail-closed policy in engine](./phase-02-allowonly-fail-closed-policy-in-engine.md) | Completed |
+| 3 | [API knob + GH-197 loader wiring + acceptance](./phase-03-api-knob-gh-197-loader-wiring-acceptance.md) | Completed |
 
 ## Key Decisions
 

--- a/plans/260705-0958-gh-205-geoip-updater-hardened-fetch/phase-01-shared-validated-fetch-helper-extract-from-rules-manager.md
+++ b/plans/260705-0958-gh-205-geoip-updater-hardened-fetch/phase-01-shared-validated-fetch-helper-extract-from-rules-manager.md
@@ -1,7 +1,7 @@
 ---
 phase: 1
 title: "Shared validated-fetch helper (extract from rules manager)"
-status: pending
+status: completed
 effort: "1.5h"
 ---
 

--- a/plans/260705-0958-gh-205-geoip-updater-hardened-fetch/phase-02-wire-geoip-updater-to-hardened-fetch.md
+++ b/plans/260705-0958-gh-205-geoip-updater-hardened-fetch/phase-02-wire-geoip-updater-to-hardened-fetch.md
@@ -1,7 +1,7 @@
 ---
 phase: 2
 title: "Wire geoip updater to hardened fetch"
-status: pending
+status: completed
 effort: "1.5h"
 ---
 

--- a/plans/260705-0958-gh-205-geoip-updater-hardened-fetch/phase-03-acceptance-tests-and-quality-gates.md
+++ b/plans/260705-0958-gh-205-geoip-updater-hardened-fetch/phase-03-acceptance-tests-and-quality-gates.md
@@ -1,7 +1,7 @@
 ---
 phase: 3
 title: "Acceptance tests and quality gates"
-status: pending
+status: completed
 effort: "1.5h"
 ---
 

--- a/plans/260705-0958-gh-205-geoip-updater-hardened-fetch/plan.md
+++ b/plans/260705-0958-gh-205-geoip-updater-hardened-fetch/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "GH-205 geoip updater: hardened fetch (SSRF validation, size cap, bounded redirects)"
 description: "Route the ip2region xdb downloader through a shared SSRF-validated, IP-pinned, redirect-disabled, size-capped fetch path instead of a plain reqwest client"
-status: pending
+status: completed
 priority: P2
 branch: "main-harness"
 tags: [bug, area:engine, geoip, security, gh-205]
@@ -59,9 +59,9 @@ stays proportional: no new config surface, cap is a compile-time const parameter
 
 | Phase | Name | Status |
 |-------|------|--------|
-| 1 | [Shared validated-fetch helper (extract from rules manager)](./phase-01-shared-validated-fetch-helper-extract-from-rules-manager.md) | Pending |
-| 2 | [Wire geoip updater to hardened fetch](./phase-02-wire-geoip-updater-to-hardened-fetch.md) | Pending |
-| 3 | [Acceptance tests and quality gates](./phase-03-acceptance-tests-and-quality-gates.md) | Pending |
+| 1 | [Shared validated-fetch helper (extract from rules manager)](./phase-01-shared-validated-fetch-helper-extract-from-rules-manager.md) | Completed |
+| 2 | [Wire geoip updater to hardened fetch](./phase-02-wire-geoip-updater-to-hardened-fetch.md) | Completed |
+| 3 | [Acceptance tests and quality gates](./phase-03-acceptance-tests-and-quality-gates.md) | Completed |
 
 ## Key Decisions
 

--- a/plans/260705-0958-gh-207-waf-api-config-helpers-dedupe/phase-01-shared-config-files-module-and-migrate-9-waf-api-modules.md
+++ b/plans/260705-0958-gh-207-waf-api-config-helpers-dedupe/phase-01-shared-config-files-module-and-migrate-9-waf-api-modules.md
@@ -1,7 +1,7 @@
 ---
 phase: 1
 title: "Shared config_files module and migrate 9 waf-api modules"
-status: pending
+status: completed
 effort: "3h"
 ---
 

--- a/plans/260705-0958-gh-207-waf-api-config-helpers-dedupe/phase-02-unified-clock-injected-into-risk-ingest-and-purge-loop.md
+++ b/plans/260705-0958-gh-207-waf-api-config-helpers-dedupe/phase-02-unified-clock-injected-into-risk-ingest-and-purge-loop.md
@@ -1,7 +1,7 @@
 ---
 phase: 2
 title: "Unified Clock injected into risk ingest and purge loop"
-status: pending
+status: completed
 effort: "2h"
 ---
 

--- a/plans/260705-0958-gh-207-waf-api-config-helpers-dedupe/phase-03-riskconfig-serde-verify-and-acceptance-quality-gates.md
+++ b/plans/260705-0958-gh-207-waf-api-config-helpers-dedupe/phase-03-riskconfig-serde-verify-and-acceptance-quality-gates.md
@@ -1,7 +1,7 @@
 ---
 phase: 3
 title: "RiskConfig serde verify and acceptance quality gates"
-status: pending
+status: completed
 effort: "1h"
 ---
 

--- a/plans/260705-0958-gh-207-waf-api-config-helpers-dedupe/plan.md
+++ b/plans/260705-0958-gh-207-waf-api-config-helpers-dedupe/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "GH-207 waf-api/risk dedupe: shared config-file helpers, RiskConfig serde mapping, unified Clock"
 description: "Collapse resolve_path + atomic tmp-write-rename copied across 9 waf-api modules into one config_files.rs, unify the risk-pipeline clock on the existing Clock trait, and verify RiskConfig serde mapping lands via GH-196. Behavior-preserving."
-status: pending
+status: completed
 priority: P3
 issue: https://github.com/future-and-go/mini-waf/issues/207
 branch: "main-harness"
@@ -57,9 +57,9 @@ is low-risk. `resolve_path`/writer migration is internal (private module fns).
 
 | Phase | Name | Status |
 |-------|------|--------|
-| 1 | [Shared config_files module and migrate 9 waf-api modules](./phase-01-shared-config-files-module-and-migrate-9-waf-api-modules.md) | Pending |
-| 2 | [Unified Clock injected into risk ingest and purge loop](./phase-02-unified-clock-injected-into-risk-ingest-and-purge-loop.md) | Pending |
-| 3 | [RiskConfig serde verify and acceptance quality gates](./phase-03-riskconfig-serde-verify-and-acceptance-quality-gates.md) | Pending |
+| 1 | [Shared config_files module and migrate 9 waf-api modules](./phase-01-shared-config-files-module-and-migrate-9-waf-api-modules.md) | Completed |
+| 2 | [Unified Clock injected into risk ingest and purge loop](./phase-02-unified-clock-injected-into-risk-ingest-and-purge-loop.md) | Completed |
+| 3 | [RiskConfig serde verify and acceptance quality gates](./phase-03-riskconfig-serde-verify-and-acceptance-quality-gates.md) | Completed |
 
 ## Key Decisions
 

--- a/plans/260705-0958-gh-208-risk-dead-code-cleanup/phase-01-remove-dead-code-riskkeybuilder.md
+++ b/plans/260705-0958-gh-208-risk-dead-code-cleanup/phase-01-remove-dead-code-riskkeybuilder.md
@@ -1,7 +1,7 @@
 ---
 phase: 1
 title: "Remove dead RiskKeyBuilder + its tests"
-status: pending
+status: completed
 effort: "20m"
 ---
 

--- a/plans/260705-0958-gh-208-risk-dead-code-cleanup/phase-02-unused-scorer-ctors.md
+++ b/plans/260705-0958-gh-208-risk-dead-code-cleanup/phase-02-unused-scorer-ctors.md
@@ -1,7 +1,7 @@
 ---
 phase: 2
 title: "Remove unused Scorer ctors + migrate tests"
-status: pending
+status: completed
 effort: "20m"
 ---
 

--- a/plans/260705-0958-gh-208-risk-dead-code-cleanup/phase-03-force-max-via-reclamp-unification.md
+++ b/plans/260705-0958-gh-208-risk-dead-code-cleanup/phase-03-force-max-via-reclamp-unification.md
@@ -1,7 +1,7 @@
 ---
 phase: 3
 title: "force_max via reclamp() unification"
-status: pending
+status: completed
 effort: "15m"
 ---
 

--- a/plans/260705-0958-gh-208-risk-dead-code-cleanup/phase-04-comment-and-test-name-sweep-strip-plan-phase-fr-ids.md
+++ b/plans/260705-0958-gh-208-risk-dead-code-cleanup/phase-04-comment-and-test-name-sweep-strip-plan-phase-fr-ids.md
@@ -1,7 +1,7 @@
 ---
 phase: 4
 title: "Comment + test-name sweep (strip plan/phase/FR IDs)"
-status: pending
+status: completed
 effort: "45m"
 ---
 

--- a/plans/260705-0958-gh-208-risk-dead-code-cleanup/plan.md
+++ b/plans/260705-0958-gh-208-risk-dead-code-cleanup/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "GH-208 risk pipeline dead-code cleanup"
 description: "Remove verified dead code (RiskKeyBuilder, unused Scorer ctors), unify force_max via reclamp(), and strip plan/phase/FR IDs from risk + ddos comments. Behavior-preserving."
-status: pending
+status: completed
 priority: P3
 issue: https://github.com/future-and-go/mini-waf/issues/208
 branch: "main-harness"

--- a/plans/reports/code-review-260705-1436-gh-208-risk-dead-code-cleanup-report.md
+++ b/plans/reports/code-review-260705-1436-gh-208-risk-dead-code-cleanup-report.md
@@ -1,0 +1,59 @@
+# Code Review — GH-208 risk dead-code cleanup (uncommitted, fix/gh-208-risk-dead-code-cleanup)
+
+## Scope
+- 52 files, +122/−232, per plan `plans/260705-0958-gh-208-risk-dead-code-cleanup/`
+- Code changes confined to: `risk/store/store_trait.rs`, `risk/scorer.rs`, `risk/store/memory.rs`, `tests/risk_scorer_extended.rs`; remaining ~48 files comment-only
+- Review by reading only (controller holds target-dir lock); test evidence supplied by controller: lib risk:: 253 pass, conformance 5 pass, risk_scorer_extended 14 pass, fmt + clippy `-D warnings` clean
+
+## Verification Results
+
+### (a) No dangling references to deleted items — PASS
+- `grep -rn RiskKeyBuilder\|with_velocity_threshold` across repo: zero hits.
+- `with_seed` hits are unrelated symbols only (`XxHash64::with_seed` in gateway filters, `RandomState::with_seeds` in vendored tinyufo).
+- `RiskKeyBuilder` was never re-exported from `risk/store/mod.rs` or `risk/mod.rs` (only `RiskStore`), so the deleted surface is exactly the direct path with no callers.
+
+### (b) force_max semantic equivalence — PASS
+- `state.rs:130-135` `reclamp()` is `clamped_score = raw_score.clamp(0, 100) as u8`. No configurable max bound, no pin interaction, no other clamp rule. `raw_score = 100` → `clamped_score = 100` unconditionally.
+- Ordering in `memory.rs:197-203` is safe: `reclamp()` runs before `pinned_until_ms` is set, but `reclamp` does not read pin state, so ordering is irrelevant.
+- Redis `FORCE_MAX_SCRIPT` untouched as planned; conformance (memory 5 pass) asserts clamped==100.
+
+### (c) Phase-4 sweep genuinely comment-only — PASS
+- Strict diff scan (`-U0`, all `+/-` lines, excluding the four phase-1..3 files): every changed line in the sweep files starts with `//`, `//!`, `///`, or block-comment continuation. Only non-comment changes outside crates/ are the plan-file `status: pending → completed` flips.
+- All 10 changed attribute lines (`#[must_use]` ×7, `#[test]` ×2, `#[tokio::test]` ×1) trace to the phase-1/2 deletions.
+
+### (d) Rewritten comments accurate — PASS (10+ files spot-checked)
+- `check.rs`: "before rate-limit (`Phase::RateLimit`)" — verified `Phase::RateLimit = 11` exists in `waf-common/src/types.rs:428`; rewrite preserves the old "Phase 11" meaning in durable form.
+- `per_fp.rs`: rewrite *improves* accuracy — old comment claimed "`RequestCtx` does not yet carry a `device_fp` field" (stale; the field exists and is used by tx_velocity session fallback). New text correctly narrows the gap to "`Detector::evaluate` does not yet read the device fingerprint".
+- `aggregator_impl.rs`: "(65536 per plan)" / "per §3.3 of the plan" → behavior-descriptive; constant unchanged.
+- `memory.rs`, `conformance.rs`, `state.rs`, `config.rs`, `canary.rs`, `decay.rs`, `seed/mod.rs`, `degrade.rs`, `worker.rs`, `sequence.rs`, `store/mod.rs`, `risk/mod.rs`: all rewrites describe current behavior correctly; no meaning lost, no new false claims.
+- Plan AC grep (`Phase |phase-|FR-0|§`) over `risk/**` + `checks/ddos/**`: zero hits (each pattern run individually, all exit 1).
+
+### (e) Public contract changes limited to intended deletions — PASS
+- Deleted pub items: `RiskKeyBuilder` (+Default impl), `Scorer::with_seed`, `Scorer::with_velocity_threshold`. No workspace consumer outside the deleted tests (grep-verified across all crates incl. waf-api, gateway, prx-waf).
+- No re-export list edits; `pub use` surfaces in `risk/mod.rs` / `store/mod.rs` unchanged.
+- Import cleanup in `store_trait.rs` correct: `IpAddr`/`SessionId` removed from module scope, `IpAddr` re-imported inside `#[cfg(test)]` where still used. Clippy `-D warnings` clean confirms no orphans.
+
+### (f) Test migration preserves coverage intent — PASS
+- Seed test: `Scorer::new` + `set_seed(seed)` + live `score()` + `Allow` assertion retained; rename to `set_seed_then_score_allows` drops the removed-API name as planned.
+- Deleted `with_velocity_threshold_constructor` was a phantom test: it ended `let _ = r;` with **zero assertions** — deleting it loses nothing. Actual `VelocityLayer` breach behavior is directly unit-tested in `risk/velocity/mod.rs:105-151` (thresholds 0/2/100/1000 incl. breach), plus pipeline-level `tx_velocity_integration.rs`.
+
+## Findings
+
+### Critical / High
+None.
+
+### Low (informational, no action required)
+1. **Plan citation imprecision**: the plan justifies the velocity-test deletion via `tx_velocity_integration.rs:242` (the `checks/tx_velocity` subsystem), but the direct `VelocityLayer` breach coverage actually lives in `risk/velocity/mod.rs` unit tests. Conclusion (coverage preserved) holds either way; the deleted test asserted nothing.
+2. **Out-of-scope residue (correctly left alone)**: `waf-common/src/types.rs:443` still carries an `FR-005` comment on `Phase::Ddos`; waf-engine crate-level CLAUDE.md also uses FR labels. Both are outside the plan's stated sweep scope (`risk/**` + `checks/ddos/**`) — noting for completeness, not requesting change (surgical-change rule).
+
+## Acceptance Criteria
+- [x] Dead items removed with dedicated tests (P1, P2); `UpdateResult` bools deliberately untouched per dropped claim
+- [x] `force_max` derives via `reclamp()` (P3); semantically identical, conformance green
+- [x] AC grep returns zero hits in scoped dirs (P4)
+- [x] fmt/clippy/test gates green (controller-verified)
+
+## Verdict
+Behavior-preserving as claimed. No blocking or high-priority issues. Ready to land (rebase ordering vs GH-196/GH-202 per plan's soft-ordering notes remains the controller's call).
+
+Status: DONE
+Summary: All six checks pass. Deletions are clean with no dangling refs or contract leaks; force_max reclamp is provably equivalent (raw.clamp(0,100), no other bounds); phase-4 sweep is strictly comment-only and rewrites are accurate (per_fp.rs even fixes a stale claim); deleted velocity test was assertion-free. Two Low informational notes only.

--- a/plans/reports/code-review-260705-gh-207-config-helpers-clock-dedupe-report.md
+++ b/plans/reports/code-review-260705-gh-207-config-helpers-clock-dedupe-report.md
@@ -1,0 +1,59 @@
+# Code Review — GH-207 config helpers + clock dedupe (working tree vs c9742e2)
+
+## Scope
+- Files: 16 source files (10 waf-api, 6 waf-engine) + 2 new modules (`crates/waf-api/src/config_files.rs`, `crates/waf-engine/src/time.rs`) + 4 plan-status docs
+- LOC: +113 / -440 (net -327)
+- Focus: behavior-preserving dedupe refactor; acceptance criteria (a)-(e)
+- Scout findings: all clock-path dependents and helper callers enumerated by grep; no orphaned callers found
+
+## Overall Assessment
+Clean, faithful dedupe. Extracted helpers are byte-for-byte semantically identical to the removed copies (same tmp-name scheme `with_extension("yaml.tmp")`, same mkdir→write→rename order, same serde paths, same JSON response shapes). Clock unification preserves epoch-ms semantics. No critical or high findings.
+
+## Critical Issues
+None.
+
+## High Priority
+None.
+
+## Medium Priority
+None.
+
+## Low Priority / Informational (pre-existing, not regressions)
+1. **No fsync before rename** in `write_yaml_str` (`config_files.rs:38-52`): rename is atomic for readers but not durable across a crash — a power loss just after rename can leave an empty/partial file on some filesystems. Pre-existing in all nine removed copies; out of scope for a behavior-preserving refactor, but now a single fix site. Candidate backlog item.
+2. **Concurrent-writer race**: two simultaneous PUTs to the same config file share one tmp filename; last rename wins and an interleaved write can rename a mixed tmp. Pre-existing; unchanged.
+3. **Time-source swap in `process_job`** (`worker.rs:96`): `chrono::Utc::now().timestamp_millis()` → `SystemClock` (`SystemTime`-based). Both are wall-clock UNIX epoch ms; drift is nil. Accepted as behavior-preserving.
+4. **Remaining clock duplicates elsewhere** (mention only, per surgical-change rule): `checks/mod.rs:79-98` (`test_clock`), `checks/rate_limit/check.rs:110` and `checks/rate_limit/store/memory.rs:135` (local epoch-ms helpers). Not in scope for GH-207; possible follow-up dedupe.
+
+## Acceptance Criteria Verification
+- **(a) Behavior-preserving in 9 migrated modules** — PASS. Diff-audited each module: only helper bodies removed; handler logic, response envelopes (`{success, data, total}`), config file names, and error *statuses* unchanged. `challenge_api.rs` keeps its local `read_yaml` (malformed file → `BadRequest`), now with an explanatory doc comment. `geo_api::read_rules` rewrite over `read_yaml_opt` is equivalent for all three failure modes (missing file, parse error, missing/non-array `rules` → `vec![]`). Internal 500 text drift (`"write tmp:"`→`"write:"`, `"yaml serialize:"`→bare) is within accepted scope.
+- **(b) No touchpoint regressions** — PASS.
+  - No remaining local `resolve_path`/`read_yaml_opt`/`write_yaml` duplicates in waf-api (grep-verified; only `config_files.rs` defines them).
+  - `per_tier.rs:31` (`super::clock::Clock`) and `per_tier.rs:154` (`super::super::clock::test_utils::MockClock`) resolve through the shim; `#[cfg(test)] pub use crate::time::test_utils;` preserves the old cfg-gating exactly.
+  - Integration tests (`tests/ddos_soak.rs:34`, `tests/ddos_scenarios/mod.rs:75,163`, `tests/ddos_integration.rs:122,225,311,406`) use only `Clock`/`SystemClock` via the shim (they define their own `MockClock`), and both are re-exported unconditionally. `detector/mod.rs:17` `pub use clock::{Clock, SystemClock}` still resolves.
+  - `ScoringAggregator::start` caller `tests/ddos_risk_bump_acceptance.rs:22` unaffected — `start`/`start_with_capacity` signatures unchanged; both now delegate to `start_with_clock(..., Arc::new(SystemClock))`.
+  - `unix_now_ms` fully deleted (grep: zero references); replacement `SystemClock::now_ms` is logic-identical (0 on pre-epoch, saturate to `i64::MAX`).
+- **(c) No public contract break** — PASS. `risk/ingest/mod.rs` declares `mod worker;` (private) and re-exports only `Job`, so the `spawn_worker`/`process_job` clock params are crate-internal. `start_purge_loop` is technically `pub` on the exported `MemoryRiskStore`, but grep confirms the single caller is `engine.rs:372` (workspace-internal crate, no external consumers) — accepted per stated scope.
+- **(d) Existing patterns** — PASS. `mod config_files;` (private) sits alphabetically in `waf-api/lib.rs` (cluster < config_files < crowdsec); `pub mod time;` alphabetical in `waf-engine/lib.rs` (rules < time < validated_fetch). Module-level and item doc comments present. Clippy pedantic/nursery are workspace `warn` (root `Cargo.toml:133-134`); new code carries no obvious pedantic triggers (`map_or_else` used, `#[must_use]` on constructors, `missing_errors_doc` does not fire on the non-exported `config_files` items). Not independently re-run (see Metrics).
+- **(e) No plan/issue IDs in comments or test names** — PASS. New test `lag_is_deterministic_under_mock_clock` and all new comments are ID-free. The `"65536 per plan"` comment in `aggregator_impl.rs` is pre-existing, untouched (correctly left per surgical-change rule).
+
+## Edge Cases Checked
+- Malformed-YAML handling divergence between `challenge_api` (BadRequest) and shared `read_yaml_opt` (silent default) is deliberate and now documented at the site.
+- New MockClock lag test is genuinely deterministic: single shared clock stamps submit time and worker measurement; asserts exact 250 ms via `avg_lag_ms()` (getter verified at `metrics.rs:107`, correct for 1 sample). Not a phantom test — it would fail if `process_job` reverted to wall-clock.
+- `ScoringAggregator` gains a `clock` field; struct had no `Debug` derive to break.
+
+## Positive Observations (risk calibration)
+- `checks/ddos/detector/clock.rs` shim keeps every legacy path compiling with zero call-site churn in 4 integration test files — the lowest-risk way to move the module.
+- Clock is injected at both submit (`aggregator_impl.rs`) and measure (`worker.rs`) ends, so lag is measured against one time source — this fixes a latent chrono-vs-SystemTime mixed-source inconsistency in the old code.
+
+## Recommended Actions
+1. None blocking. Optionally file a backlog item for fsync-on-write durability in `write_yaml_str` (single site now).
+
+## Metrics
+- Tests: implementer-reported green (waf-api --lib 118; waf-engine --lib 255 + risk:: 99). Not re-run here to avoid target-dir lock contention with the in-flight workspace test run; clippy-clean claim likewise implementer-reported.
+- Linting: no new suppressions, no `allow` attributes added; one pre-existing `#[allow(clippy::cast_possible_truncation)]` *removed* along with `unix_now_ms`.
+
+## Plan Status
+`plans/260705-0958-gh-207-waf-api-config-helpers-dedupe/plan.md` marks all 3 phases Completed; phases 1-2 verified against the diff. Phase 3 (RiskConfig serde verify) is a verification-only phase — its evidence is the journal + test runs, consistent with no `risk_api.rs` behavior change in this diff.
+
+## Unresolved Questions
+- None blocking. Full-workspace test result (running separately) should be confirmed green before merge.


### PR DESCRIPTION
## Summary

Fixes #202 — `RiskBumpAction` had three latent defects that would surface the moment `ban_and_risk` gets wired into the engine:

1. **Runtime panic**: `execute` bridged into async via `tokio::task::block_in_place`, which panics on a `current_thread` runtime — and `prx-waf`'s main uses `new_current_thread`.
2. **Phantom actor**: the client IP was smuggled inside a synthetic `FpKey { ja3: "ddos:{ip}" }`, so deltas landed under a fingerprint hash the request-path scorer (which reads `RiskKey::from_ip`) can never join.
3. **Severity flattened**: the detector's 0–100 delta was stuffed into `Signal::BurstInterval { count }` and weight-table mapped to a flat 20/30.

## Changes

- **`RiskAggregator` gains a sync `submit_ip(ip, signals)` seam** (queue fan-out, drop-with-warn, no runtime needed). Implemented on `ScoringAggregator` (shared private `enqueue` with the async path), `NoopAggregator`, and `LoggingAggregator` (`AggregatorSubmission` now records `actor_ip`).
- **Ingest `Job` carries an actor axis**: `fp_key: Option<FpKey>` + `actor_ip: Option<IpAddr>` with `Job::for_fp` / `Job::for_ip` constructors. The worker builds `RiskKey { ip, fp_hash, session: None }` and drops (with metric) only when both axes are unresolvable.
- **New `Signal::DdosBurst { risk_delta }`** — passthrough contributor delta by design (the detector already quantifies severity; a static weight is exactly the flattening bug).
- **`RiskBumpAction::execute` rewritten**: pure sync `submit_ip` call; `block_in_place`, the smuggled-`FpKey` helper, and all tokio imports deleted.

## Tests

- `tests/ddos_risk_bump_acceptance.rs` (new, runs on default current_thread runtime): `hard_burst_raises_scored_actor_state` (state readable at `RiskKey::from_ip`, contributor `ddos_burst` delta 100), `soft_anomaly_preserves_severity` (delta 37 end-to-end), `phantom_actor_regression` (no state under the old smuggled key).
- Unit: worker IP-axis job test, both-axes-unresolvable drop test, sync `submit_ip` enqueue test, `LoggingAggregator.actor_ip` test, `DdosBurst` passthrough mapping tests; `risk.rs` action tests converted from `multi_thread` tokio tests to plain `#[test]` (the panic-regression proof at unit level).
- Gates: waf-engine lib 1453 passed (+ the 6 known docker-gated `engine::tests` failures, environmental); workspace tests, `cargo clippy --workspace --all-targets` (also with `redis-store`), `cargo fmt --check` all clean.

## Stacking

Stacked on #216 (`fix/gh-204-risk-delta-cap-decay-config`). Merge order: #212 → #213 → #214 → #216 → this PR.

Non-goals (per plan): wiring `ban_and_risk` into `engine.rs`, SoftAnomaly action execution policy, redis store changes.
