### PR TITLE
refactor(engine): remove dead risk code and rewrite process-artifact comments

### DIFF
--- a/crates/waf-engine/src/checks/ddos/action/ban.rs
+++ b/crates/waf-engine/src/checks/ddos/action/ban.rs
@@ -1,4 +1,4 @@
-//! FR-005 phase-05 — Ban action with TTL escalation.
+//! Ban action with TTL escalation.
 //!
 //! [`BanAction`] tracks offenses per IP and applies escalating bans:
 //! - 1st offense: 60s ban, +30 risk
@@ -335,7 +335,7 @@ impl ActionExecutor for BanAction {
             },
         );
 
-        // Structured logging per brainstorm §9
+        // Structured audit log for ban events
         warn!(
             action = "ban",
             ip = %ip,

--- a/crates/waf-engine/src/checks/ddos/action/mod.rs
+++ b/crates/waf-engine/src/checks/ddos/action/mod.rs
@@ -1,6 +1,6 @@
-//! FR-005 phase-05 — `DDoS` action executors (Command pattern).
+//! `DDoS` action executors (Command pattern).
 //!
-//! Decouples detection (phases 2-4) from side-effects (bans, risk bumps).
+//! Decouples detection from side-effects (bans, risk bumps).
 //! Each action implements [`ActionExecutor`] and produces an [`ActionResult`].
 
 use std::net::IpAddr;

--- a/crates/waf-engine/src/checks/ddos/action/risk.rs
+++ b/crates/waf-engine/src/checks/ddos/action/risk.rs
@@ -1,6 +1,6 @@
-//! FR-005 phase-05 — Risk bump action for `DDoS` verdicts.
+//! Risk bump action for `DDoS` verdicts.
 //!
-//! Submits risk signals to FR-010's [`RiskAggregator`] when `DDoS` violations
+//! Submits risk signals to the [`RiskAggregator`] when `DDoS` violations
 //! are detected. Fire-and-forget via the sync `submit_ip` seam — the actor is
 //! the client IP on the `RiskKey` IP axis, so the request-path scorer joins
 //! the same state it reads for that IP. No blocking, no runtime required.

--- a/crates/waf-engine/src/checks/ddos/check.rs
+++ b/crates/waf-engine/src/checks/ddos/check.rs
@@ -1,7 +1,7 @@
-//! FR-005 Phase 7 — `DdosCheck` pipeline integration.
+//! `DdosCheck` pipeline integration.
 //!
 //! Wires detectors (per-IP, per-FP, per-tier) into the WAF engine pipeline.
-//! Runs after allowlist phases (1-4) and before rate-limit (Phase 11).
+//! Runs after the allowlist checks and before rate-limit (`Phase::RateLimit`).
 //!
 //! ## Pipeline Behavior
 //! - Runs detectors in cheap-first order: `per_ip` → `per_fp` → `per_tier`
@@ -170,7 +170,7 @@ impl Check for DdosCheck {
                         self.metrics.inc_ban();
                     }
 
-                    // Structured audit log per FR-032
+                    // Structured audit log
                     warn!(
                         target: "ddos::audit",
                         request_id = %ctx.req_id,

--- a/crates/waf-engine/src/checks/ddos/config.rs
+++ b/crates/waf-engine/src/checks/ddos/config.rs
@@ -1,4 +1,4 @@
-//! FR-005 phase-01 — YAML schema + parser for `configs/ddos.yaml`.
+//! YAML schema + parser for `configs/ddos.yaml`.
 //!
 //! Pure data + validation, returns an `Arc<DdosConfig>` runtime snapshot.
 //! `deny_unknown_fields` everywhere — typos in operator YAML are loud, not
@@ -49,7 +49,7 @@ pub struct DdosFileConfig {
     #[serde(default = "default_max_keys")]
     pub max_keys: usize,
     /// Optional Redis backend. Absence ⇒ memory-only standalone mode.
-    /// Parsed but unused until phase 4.
+    /// Parsed and validated but not yet wired to a runtime store.
     #[serde(default)]
     pub redis: Option<RedisCfg>,
 }
@@ -109,7 +109,7 @@ pub struct TierThresholdCfg {
     pub per_tier_window_s: u32,
 }
 
-/// Optional Redis backend block (parsed but unused until phase 4).
+/// Optional Redis backend block (parsed and validated but not yet wired).
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RedisCfg {

--- a/crates/waf-engine/src/checks/ddos/degrade.rs
+++ b/crates/waf-engine/src/checks/ddos/degrade.rs
@@ -1,4 +1,4 @@
-//! FR-005 Phase 6 — Degrade & Circuit Breaker.
+//! Degrade & Circuit Breaker.
 //!
 //! `resolve` maps (`Tier`, `FailMode`, `ErrorKind`) → `DegradeAction` per the fail-mode
 //! matrix. `OverloadGuard` monitors runtime load via an in-flight call counter
@@ -39,7 +39,7 @@ pub enum DegradeAction {
 
 /// Resolve the degradation action based on tier, `fail_mode`, and error kind.
 ///
-/// ## Matrix (FR-036/037/038)
+/// ## Fail-mode matrix
 ///
 /// | Tier       | `StoreUnavailable` | `BackendOverload` | `ConfigStale` |
 /// |------------|------------------|-----------------|-------------|

--- a/crates/waf-engine/src/checks/ddos/detector/mod.rs
+++ b/crates/waf-engine/src/checks/ddos/detector/mod.rs
@@ -37,7 +37,7 @@ pub enum DetectorVerdict {
         detector: &'static str,
         /// Rate (requests per detection window) associated with the burst.
         /// For `per_fp`/`per_tier` this is the **observed** count in the
-        /// window; for `per_ip` (backed by the FR-004 rate-limit store, which
+        /// window; for `per_ip` (backed by the shared rate-limit store, which
         /// only returns an allow/deny `Decision`) it is the configured
         /// **threshold** that was exceeded. Surfaced to the admin ban table as
         /// `last_rps`.

--- a/crates/waf-engine/src/checks/ddos/detector/per_fp.rs
+++ b/crates/waf-engine/src/checks/ddos/detector/per_fp.rs
@@ -16,15 +16,14 @@
 //!   which adds memory overhead proportional to (keys × `window_duration` / granularity).
 //!   For 100k fingerprints × 60s window, this is significant.
 //!
-//! For FR-005 v1, the fixed-window approximation is sufficient. Upgrade to
+//! For now, the fixed-window approximation is sufficient. Upgrade to
 //! precise sliding if edge-case exploitation becomes a real attack vector.
 //!
 //! # Current Limitation
 //!
-//! **GAP**: `RequestCtx` does not yet carry a `device_fp` field. Until phase 7
-//! wires device fingerprinting into the request pipeline, this detector will
-//! always return `Allow` for live traffic. The core logic is complete and
-//! tested via `evaluate_with_fp()`.
+//! **GAP**: `Detector::evaluate` does not yet read the device fingerprint
+//! from the request, so this detector always returns `Allow` for live
+//! traffic. The core logic is complete and tested via `evaluate_with_fp()`.
 
 use std::sync::Arc;
 
@@ -48,7 +47,7 @@ impl PerFpDetector {
     /// Create a new per-fingerprint detector backed by the given counter store.
     ///
     /// The store is typically `MemoryCounterStore` for standalone deployments
-    /// or a Redis-backed store for clustered deployments (phase 4).
+    /// or a Redis-backed store for clustered deployments.
     #[must_use]
     pub fn new(store: Arc<dyn CounterStore>) -> Self {
         Self { store }
@@ -64,8 +63,8 @@ impl PerFpDetector {
     /// Core evaluation logic with explicit fingerprint input.
     ///
     /// This method contains the actual detection logic. It's exposed separately
-    /// from `Detector::evaluate` because `RequestCtx` doesn't yet carry device
-    /// fingerprint data (that wiring happens in phase 7).
+    /// from `Detector::evaluate`, which does not yet read device fingerprint
+    /// data from the request.
     ///
     /// # Arguments
     /// - `fp_hash`: Device fingerprint hash. `None` or empty string → `Allow` (no signal).
@@ -80,8 +79,8 @@ impl PerFpDetector {
         now_ms: i64,
     ) -> DetectorVerdict {
         // Skip when fingerprint is absent or empty — no signal available.
-        // This happens when FR-010 device fingerprinting didn't run (e.g.,
-        // plain HTTP/1 without TLS extensions, or FR-010 disabled).
+        // This happens when device fingerprinting didn't run (e.g., plain
+        // HTTP/1 without TLS extensions, or fingerprinting disabled).
         let Some(fp) = fp_hash.filter(|s| !s.is_empty()) else {
             return DetectorVerdict::Allow;
         };
@@ -97,7 +96,7 @@ impl PerFpDetector {
             },
             Ok(_) => DetectorVerdict::Allow,
             Err(e) => {
-                // Degrade decision owned by phase 6 — here we warn and allow.
+                // Degrade decision owned by the degrade module — here we warn and allow.
                 warn!(
                     detector = "per_fp",
                     fp = %fp,
@@ -120,15 +119,14 @@ impl Detector for PerFpDetector {
     ///
     /// # Current Behavior
     ///
-    /// **Always returns `Allow`** because `RequestCtx` doesn't yet carry
-    /// `device_fp`. This is a documented gap — phase 7 wires device
-    /// fingerprinting into the request pipeline.
+    /// **Always returns `Allow`** — the device fingerprint is not yet read
+    /// from the request here; this is a documented gap.
     ///
-    /// Once phase 7 is complete, this will extract `ctx.device_fp.hash` and
+    /// Once the wiring lands, this will extract `ctx.device_fp.hash` and
     /// delegate to `evaluate_with_fp()`.
     fn evaluate(&self, _ctx: &RequestCtx, _cfg: &DdosTierCfg, _now_ms: i64) -> DetectorVerdict {
-        // GAP: RequestCtx.device_fp does not exist yet.
-        // Phase 7 will add it; then this becomes:
+        // GAP: the device fingerprint is not read from the request here yet.
+        // Once wired, this becomes:
         //   let fp = ctx.device_fp.as_ref().and_then(|f| f.hash.as_ref());
         //   self.evaluate_with_fp(fp.map(String::as_str), ctx, cfg, now_ms)
         DetectorVerdict::Allow
@@ -426,8 +424,8 @@ mod tests {
 
     #[test]
     fn detector_evaluate_returns_allow_gap_documented() {
-        // This tests the current behavior where RequestCtx.device_fp doesn't exist.
-        // The Detector::evaluate method always returns Allow until phase 7 wires it up.
+        // This tests the current behavior where the fingerprint is not wired up:
+        // the Detector::evaluate method always returns Allow.
         let store = TestCounterStore::new();
         let detector = PerFpDetector::new(store);
         let ctx = test_ctx(Tier::Medium);

--- a/crates/waf-engine/src/checks/ddos/detector/per_ip.rs
+++ b/crates/waf-engine/src/checks/ddos/detector/per_ip.rs
@@ -1,6 +1,6 @@
 //! Per-IP `DDoS` detector.
 //!
-//! Thin wrapper around `RateLimitStore` — delegates rate limiting math to FR-004,
+//! Thin wrapper around `RateLimitStore` — delegates the rate limiting math to it,
 //! only translates `Decision` → `DetectorVerdict`. No new counters or algorithms.
 
 use std::sync::Arc;
@@ -14,9 +14,9 @@ use super::{DdosTierCfg, Detector, DetectorVerdict, tier_str};
 
 /// Per-IP rate detector using the existing `RateLimitStore`.
 ///
-/// Reuses FR-004's token bucket + sliding window implementation to detect
+/// Reuses the rate limiter's token bucket + sliding window implementation to detect
 /// per-IP burst violations. Key format: `ddos:ip:{tier}:{ip}` to avoid
-/// collision with FR-004's `ip:{host}:{ip}` namespace.
+/// collision with the rate limiter's `ip:{host}:{ip}` namespace.
 pub struct PerIpDetector {
     store: Arc<dyn RateLimitStore>,
 }
@@ -30,7 +30,7 @@ impl PerIpDetector {
 
     /// Build the rate limit key for this IP + tier combination.
     ///
-    /// Format: `ddos:ip:{tier}:{ip}` — distinct from FR-004's `ip:{host}:{ip}`.
+    /// Format: `ddos:ip:{tier}:{ip}` — distinct from the rate limiter's `ip:{host}:{ip}`.
     fn build_key(ctx: &RequestCtx) -> String {
         format!("ddos:ip:{}:{}", tier_str(ctx.tier), ctx.client_ip)
     }
@@ -82,7 +82,7 @@ impl Detector for PerIpDetector {
                 rps: cfg.per_fp_threshold,
             },
             Err(e) => {
-                // Degrade decision owned by phase 6 — here we just warn and allow
+                // Degrade decision owned by the degrade module — here we just warn and allow
                 warn!(
                     detector = "per_ip",
                     ip = %ctx.client_ip,
@@ -247,7 +247,7 @@ mod tests {
         let ctx = test_ctx(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), Tier::CatchAll);
         let cfg = test_cfg();
 
-        // Error should degrade to Allow (fail-open for now, phase 6 owns degrade)
+        // Error should degrade to Allow (fail-open; the degrade module owns degrade)
         let verdict = detector.evaluate(&ctx, &cfg, 1000);
         assert_eq!(verdict, DetectorVerdict::Allow);
     }

--- a/crates/waf-engine/src/checks/ddos/metrics.rs
+++ b/crates/waf-engine/src/checks/ddos/metrics.rs
@@ -1,4 +1,4 @@
-//! FR-005 Phase 7 — `DDoS` observability metrics.
+//! `DDoS` observability metrics.
 //!
 //! Provides atomic counters for `DDoS` detection events. Uses `AtomicU64` for
 //! lock-free updates on the hot path. Counters are exposed via accessor methods

--- a/crates/waf-engine/src/checks/ddos/mod.rs
+++ b/crates/waf-engine/src/checks/ddos/mod.rs
@@ -1,14 +1,14 @@
-//! FR-005 `DDoS` protection module.
+//! `DDoS` protection module.
 //!
 //! Composed of:
 //! - [`store`]    — async `CounterStore` trait + in-memory backend
 //! - [`config`]   — YAML schema + parsing for `configs/ddos.yaml`
 //! - [`reload`]   — hot-reload watcher with `ArcSwap` snapshot
-//! - [`detector`] — `Detector` trait + per-IP detector (phase 2)
-//! - [`action`]   — action executors for bans and risk bumps (phase 5)
-//! - [`degrade`]  — circuit breaker & fail-mode resolution (phase 6)
-//! - [`check`]    — `DdosCheck` pipeline integration (phase 7)
-//! - [`metrics`]  — atomic counters for observability (phase 7)
+//! - [`detector`] — `Detector` trait + per-IP detector
+//! - [`action`]   — action executors for bans and risk bumps
+//! - [`degrade`]  — circuit breaker & fail-mode resolution
+//! - [`check`]    — `DdosCheck` pipeline integration
+//! - [`metrics`]  — atomic counters for observability
 
 use std::collections::HashMap;
 

--- a/crates/waf-engine/src/checks/ddos/reload.rs
+++ b/crates/waf-engine/src/checks/ddos/reload.rs
@@ -1,4 +1,4 @@
-//! FR-005 phase-01 — hot-reload watcher for `configs/ddos.yaml`.
+//! Hot-reload watcher for `configs/ddos.yaml`.
 //!
 //! Mirrors `rate_limit::reload`: parent-dir `notify` watcher on a sync
 //! `std::thread`, debounced, fail-soft on parse error (previous snapshot

--- a/crates/waf-engine/src/checks/ddos/store/redis.rs
+++ b/crates/waf-engine/src/checks/ddos/store/redis.rs
@@ -17,7 +17,7 @@
 //!
 //! Tracks consecutive failures via `AtomicU32`. Once `breaker_threshold` is reached,
 //! `breaker_open()` returns true. A single success resets the counter.
-//! The wrapping layer (phase 6) can route to memory fallback when breaker is open.
+//! The wrapping degrade layer can route to memory fallback when breaker is open.
 
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
@@ -107,7 +107,7 @@ impl RedisCounterStore {
 
     /// True once `breaker_threshold` consecutive failures have occurred.
     ///
-    /// The wrapping layer (phase 6) can read this to route to memory fallback.
+    /// The wrapping degrade layer can read this to route to memory fallback.
     #[must_use]
     pub fn breaker_open(&self) -> bool {
         self.consecutive_fails.load(Ordering::Relaxed) >= self.cfg.breaker_threshold

--- a/crates/waf-engine/src/risk/anomaly/mod.rs
+++ b/crates/waf-engine/src/risk/anomaly/mod.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 5: Anomaly detection layer (L2).
+//! Anomaly detection layer (L2).
 //!
 //! Inline synchronous anomaly detectors for per-request evaluation.
 //! Each detector emits risk deltas based on request characteristics.

--- a/crates/waf-engine/src/risk/canary.rs
+++ b/crates/waf-engine/src/risk/canary.rs
@@ -1,9 +1,9 @@
-//! FR-028 Canary Honeypot layer.
+//! Canary Honeypot layer.
 //!
 //! Configured canary paths (e.g., `/admin-test`, `/api-debug`) that no legitimate
 //! user should hit. When triggered:
 //! 1. `store.force_max()` — pins score to 100 with `pinned_until_ms`
-//! 2. Adds IP to dynamic ban table (FR-005 `DynamicBanTable`)
+//! 2. Adds IP to the dynamic ban table (`DynamicBanTable`)
 //! 3. Returns `Block` immediately, bypassing threshold gate
 //!
 //! Hot-reloadable via `ArcSwap<HashSet<String>>` for path list updates.

--- a/crates/waf-engine/src/risk/challenge_credit/mod.rs
+++ b/crates/waf-engine/src/risk/challenge_credit/mod.rs
@@ -1,4 +1,4 @@
-//! FR-006/FR-025 Phase 8: Challenge Credit Token System.
+//! Challenge Credit Token System.
 //!
 //! Issues HMAC-signed credit tokens on successful challenge completion (e.g., JS-PoW).
 //! Tokens are single-use and bound to the actor identity to prevent replay and sharing.
@@ -63,7 +63,7 @@ impl std::fmt::Display for InvalidReason {
 
 /// Issues challenge credit tokens.
 ///
-/// Called by the challenge page (FR-006) on successful `PoW` completion.
+/// Called by the challenge page on successful `PoW` completion.
 pub struct ChallengeIssuer {
     secret: Arc<HmacSecret>,
     ttl_secs: u32,

--- a/crates/waf-engine/src/risk/challenge_credit/secret.rs
+++ b/crates/waf-engine/src/risk/challenge_credit/secret.rs
@@ -1,7 +1,7 @@
 //! HMAC secret bootstrap for challenge credit tokens.
 //!
 //! Loads secret from disk; generates 32 random bytes on first boot if absent.
-//! Never auto-rotates (Iron Rule §11) — secret persists across restarts.
+//! Never auto-rotates — secret persists across restarts.
 
 use std::fs;
 use std::io::Write;

--- a/crates/waf-engine/src/risk/config.rs
+++ b/crates/waf-engine/src/risk/config.rs
@@ -1,4 +1,4 @@
-//! FR-025 risk scoring configuration.
+//! Risk scoring configuration.
 //!
 //! YAML schema for `configs/risk.yaml`. Hot-reload via `ArcSwap` + `notify`.
 
@@ -58,15 +58,15 @@ pub struct RiskConfig {
     #[serde(default)]
     pub seed: SeedConfig,
 
-    /// Async ingest pipeline configuration (Phase 4).
+    /// Async ingest pipeline configuration.
     #[serde(default)]
     pub ingest: IngestConfig,
 
-    /// FR-028 canary honeypot configuration (Phase 6).
+    /// Canary honeypot configuration.
     #[serde(default)]
     pub canary: CanaryConfig,
 
-    /// FR-006/FR-025 Phase 8 challenge credit configuration.
+    /// Challenge credit configuration.
     #[serde(default)]
     pub challenge: ChallengeConfig,
 }
@@ -92,7 +92,7 @@ impl Default for StoreConfig {
     }
 }
 
-/// Redis store configuration (Phase 7).
+/// Redis store configuration.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RedisStoreConfig {
     /// Redis URL, e.g. `redis://127.0.0.1:6379`.
@@ -242,7 +242,7 @@ impl SeedConfig {
     }
 }
 
-/// Async ingest pipeline configuration (Phase 4).
+/// Async ingest pipeline configuration.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct IngestConfig {
     /// Whether async ingest is enabled.
@@ -259,7 +259,7 @@ pub struct IngestConfig {
     pub signal_weights: HashMap<String, i16>,
 }
 
-/// FR-028 Canary honeypot configuration (Phase 6).
+/// Canary honeypot configuration.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CanaryConfig {
     /// Whether canary detection is enabled.
@@ -276,7 +276,7 @@ pub struct CanaryConfig {
     pub ban_ttl_secs: u32,
 }
 
-/// FR-006/FR-025 Phase 8 Challenge credit configuration.
+/// Challenge credit configuration.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ChallengeConfig {
     /// Whether challenge credit verification is enabled.

--- a/crates/waf-engine/src/risk/decay.rs
+++ b/crates/waf-engine/src/risk/decay.rs
@@ -1,4 +1,4 @@
-//! FR-025 pure decay function.
+//! Pure decay function.
 //!
 //! Applies time-based decay to risk scores. Clean requests (no risk events)
 //! accumulate a streak; after enough clean requests, the score decays.

--- a/crates/waf-engine/src/risk/ingest/aggregator_impl.rs
+++ b/crates/waf-engine/src/risk/ingest/aggregator_impl.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 4 — `ScoringAggregator` implementation.
+//! `ScoringAggregator` implementation.
 //!
 //! Implements `RiskAggregator` by forwarding signals to a bounded MPSC channel.
 //! Fire-and-forget semantics: `submit` never blocks, drops with warning on overflow.
@@ -19,13 +19,13 @@ use crate::risk::ingest::worker::{Job, spawn_worker};
 use crate::risk::store::RiskStore;
 use crate::time::{Clock, SystemClock};
 
-/// Default channel capacity (65536 per plan).
+/// Default channel capacity.
 pub const DEFAULT_CHANNEL_CAPACITY: usize = 65536;
 
 /// Async risk aggregator that forwards signals to the ingest worker.
 ///
 /// Bounded channel prevents unbounded memory growth under load. Overflow
-/// triggers drop-with-warn (best-effort semantics per §3.3 of the plan).
+/// triggers drop-with-warn (best-effort semantics).
 pub struct ScoringAggregator {
     tx: mpsc::Sender<Job>,
     metrics: Arc<IngestMetrics>,

--- a/crates/waf-engine/src/risk/ingest/metrics.rs
+++ b/crates/waf-engine/src/risk/ingest/metrics.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 4 — Async ingest pipeline metrics.
+//! Async ingest pipeline metrics.
 //!
 //! Atomic counters for ingest queue health and processing. Uses `AtomicU64`
 //! for lock-free updates. Counters exposed via accessor methods for external

--- a/crates/waf-engine/src/risk/ingest/mod.rs
+++ b/crates/waf-engine/src/risk/ingest/mod.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 4 — Async ingest pipeline.
+//! Async ingest pipeline.
 //!
 //! Replaces `NoopAggregator` with `ScoringAggregator` — bounded MPSC channel +
 //! worker that translates `Signal` → `Contributor`, builds `RiskKey` from

--- a/crates/waf-engine/src/risk/ingest/signal_to_contributor.rs
+++ b/crates/waf-engine/src/risk/ingest/signal_to_contributor.rs
@@ -12,7 +12,7 @@ use crate::risk::state::{Contributor, ContributorKind};
 
 /// Configurable weights for signal → delta mapping.
 ///
-/// Default values match the plan table. Operators can override via
+/// Operators can override the default values via
 /// `risk.signal_weights` in the config YAML.
 #[derive(Clone, Debug)]
 pub struct SignalWeights {

--- a/crates/waf-engine/src/risk/ingest/worker.rs
+++ b/crates/waf-engine/src/risk/ingest/worker.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 4 — Async ingest worker loop.
+//! Async ingest worker loop.
 //!
 //! Single tokio task that drains the job queue, maps signals to contributors,
 //! and applies them to the risk store. Best-effort: job errors are logged but

--- a/crates/waf-engine/src/risk/key.rs
+++ b/crates/waf-engine/src/risk/key.rs
@@ -1,4 +1,4 @@
-//! FR-025 risk identity key types.
+//! Risk identity key types.
 //!
 //! `RiskKey` bundles the three identity axes (IP, fingerprint hash, session)
 //! used to look up / update risk state. Not all axes are always present —

--- a/crates/waf-engine/src/risk/mod.rs
+++ b/crates/waf-engine/src/risk/mod.rs
@@ -1,8 +1,8 @@
-//! FR-025 cumulative risk scoring subsystem.
+//! Cumulative risk scoring subsystem.
 //!
 //! Tracks per-actor (IP, fingerprint, session) risk state and applies a
 //! threshold gate to emit Allow / Challenge / Block decisions. Mirrors the
-//! FR-010 device-fingerprinting architecture: `ArcSwap<RiskConfig>` snapshot,
+//! device-fingerprinting architecture: `ArcSwap<RiskConfig>` snapshot,
 //! hot-reload via `notify`, and a store trait with in-memory + Redis backends.
 //!
 //! Module structure:

--- a/crates/waf-engine/src/risk/reload.rs
+++ b/crates/waf-engine/src/risk/reload.rs
@@ -1,4 +1,4 @@
-//! FR-025 hot-reload watcher for `configs/risk.yaml`.
+//! Hot-reload watcher for `configs/risk.yaml`.
 //!
 //! Mirrors `device_fp::reload` pattern: per-path sync thread + mpsc, parent-dir
 //! watch, debounced reload, fail-soft on parse error.

--- a/crates/waf-engine/src/risk/score.rs
+++ b/crates/waf-engine/src/risk/score.rs
@@ -1,4 +1,4 @@
-//! FR-025 pure score-fold function.
+//! Pure score-fold function.
 //!
 //! Takes a `RiskState` and a list of deltas, returns the updated state.
 //! No I/O, no side effects — pure transformation.
@@ -34,7 +34,7 @@ pub fn sum_deltas(deltas: &[Contributor]) -> i32 {
     deltas.iter().map(|c| i32::from(c.delta)).sum()
 }
 
-/// FR-025: Maximum per-request raw delta sum.
+/// Maximum per-request raw delta sum.
 pub const MAX_PER_REQUEST_DELTA: i32 = 100;
 
 /// Convert rule engine `RiskDelta` to a `Contributor` for the risk store.

--- a/crates/waf-engine/src/risk/scorer.rs
+++ b/crates/waf-engine/src/risk/scorer.rs
@@ -1,11 +1,11 @@
-//! FR-025 Scorer orchestrator.
+//! Scorer orchestrator.
 //!
 //! Builds `RiskKey` from request context, calls store, applies threshold gate,
 //! sets `X-WAF-Risk-Score` header, returns `WafAction`.
 //!
-//! Phase 5 adds L2 detectors (anomaly + velocity) evaluated inline.
-//! Phase 6 adds canary honeypot layer (FR-028) for scanner detection.
-//! Phase 8 adds challenge credit verification (FR-006 wiring).
+//! L2 detectors (anomaly + velocity) are evaluated inline, along with the
+//! canary honeypot layer (scanner detection) and challenge credit
+//! verification.
 
 use std::sync::Arc;
 
@@ -41,16 +41,15 @@ pub struct ScorerResult {
 /// Scorer orchestrator for the risk scoring pipeline.
 ///
 /// Owns a reference to the store and config snapshot. Thread-safe via `Arc`.
-/// Phase 5 adds L2 detectors: anomaly layer and velocity layer.
-/// Phase 6 adds canary honeypot layer (FR-028).
-/// Phase 8 adds challenge credit verifier (FR-006).
+/// Also owns the L2 detectors (anomaly + velocity layers), the canary
+/// honeypot layer, and the challenge credit verifier.
 pub struct Scorer<S: RiskStore + ?Sized> {
     store: Arc<S>,
     cfg: Arc<ArcSwap<RiskConfig>>,
     seed: Option<Arc<SeedLayer>>,
-    /// FR-028 canary honeypot layer for scanner detection.
+    /// Canary honeypot layer for scanner detection.
     pub canary: Option<Arc<CanaryLayer>>,
-    /// FR-006 challenge credit verifier.
+    /// Challenge credit verifier.
     challenge_verifier: Option<Arc<ChallengeVerifier>>,
     /// L2 anomaly detection layer (JA4↔UA mismatch, XFF, header sanity).
     anomaly: AnomalyLayer,
@@ -70,34 +69,6 @@ impl<S: RiskStore + ?Sized> Scorer<S> {
             challenge_verifier: None,
             anomaly: AnomalyLayer::new(),
             velocity: VelocityLayer::with_defaults(),
-        }
-    }
-
-    /// Create a scorer with seed layer.
-    #[must_use]
-    pub fn with_seed(store: Arc<S>, cfg: Arc<ArcSwap<RiskConfig>>, seed: Arc<SeedLayer>) -> Self {
-        Self {
-            store,
-            cfg,
-            seed: Some(seed),
-            canary: None,
-            challenge_verifier: None,
-            anomaly: AnomalyLayer::new(),
-            velocity: VelocityLayer::with_defaults(),
-        }
-    }
-
-    /// Create a scorer with custom velocity threshold.
-    #[must_use]
-    pub fn with_velocity_threshold(store: Arc<S>, cfg: Arc<ArcSwap<RiskConfig>>, threshold: u32) -> Self {
-        Self {
-            store,
-            cfg,
-            seed: None,
-            canary: None,
-            challenge_verifier: None,
-            anomaly: AnomalyLayer::new(),
-            velocity: VelocityLayer::new(threshold),
         }
     }
 
@@ -250,7 +221,7 @@ impl<S: RiskStore + ?Sized> Scorer<S> {
         let velocity_deltas = self.velocity.evaluate(&key, tx_endpoint, now_ms);
         all_deltas.extend(velocity_deltas);
 
-        // FR-006 Challenge credit verification
+        // Challenge credit verification
         if let Some(credit_delta) = self.evaluate_challenge_credit(ctx, &key, now_ms, cfg).await {
             all_deltas.push(credit_delta);
         }

--- a/crates/waf-engine/src/risk/seed/asn.rs
+++ b/crates/waf-engine/src/risk/seed/asn.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 2: ASN classification loader.
+//! ASN classification loader.
 //!
 //! Loads ASN classification data from a CSV file into a radix trie for
 //! longest-prefix matching. Format: `cidr,asn,classification`.

--- a/crates/waf-engine/src/risk/seed/mod.rs
+++ b/crates/waf-engine/src/risk/seed/mod.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 2: L0 Reputation Seed Layer.
+//! L0 Reputation Seed Layer.
 //!
 //! Classifies IPs via whitelist (short-circuit), Tor exit list, and ASN
 //! classification before any expensive detection layers run. Uses `ArcSwap`

--- a/crates/waf-engine/src/risk/seed/reload.rs
+++ b/crates/waf-engine/src/risk/seed/reload.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 2: Hot-reload watcher for seed data files.
+//! Hot-reload watcher for seed data files.
 //!
 //! Watches tor-exits.txt, asn-classes.csv, and risk-whitelist.txt for changes.
 //! On any change, reloads all files and swaps `SeedTables` atomically.

--- a/crates/waf-engine/src/risk/seed/tables.rs
+++ b/crates/waf-engine/src/risk/seed/tables.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 2: Seed data tables for L0 reputation layer.
+//! Seed data tables for the L0 reputation layer.
 //!
 //! Bundles Tor exit set, ASN classification trie, and whitelist CIDR trie
 //! into a single `SeedTables` struct for atomic hot-reload via `ArcSwap`.

--- a/crates/waf-engine/src/risk/seed/tor.rs
+++ b/crates/waf-engine/src/risk/seed/tor.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 2: Tor exit list loader.
+//! Tor exit list loader.
 //!
 //! Loads Tor exit node IPs from a newline-delimited file into a `HashSet`
 //! for O(1) lookup. Malformed lines are logged and skipped.

--- a/crates/waf-engine/src/risk/seed/whitelist.rs
+++ b/crates/waf-engine/src/risk/seed/whitelist.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 2: Whitelist CIDR loader.
+//! Whitelist CIDR loader.
 //!
 //! Loads whitelist CIDRs from a newline-delimited file. Malformed lines are
 //! logged and skipped — never panics.

--- a/crates/waf-engine/src/risk/state.rs
+++ b/crates/waf-engine/src/risk/state.rs
@@ -1,4 +1,4 @@
-//! FR-025 risk state types.
+//! Risk state types.
 //!
 //! `RiskState` holds the accumulated risk for a single actor identity.
 //! `Contributor` records individual risk events (rule hits, anomalies, signals)
@@ -20,7 +20,7 @@ pub enum SeedKind {
     BadASN,
 }
 
-/// Outcome of challenge credit verification (FR-006).
+/// Outcome of challenge credit verification.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CreditOutcome {
     /// Valid challenge token — grant credit.
@@ -38,7 +38,7 @@ pub enum CreditOutcome {
 pub enum ContributorKind {
     /// A WAF rule matched (`rule_id` stored).
     Rule(String),
-    /// Behavioral anomaly detected (FR-011).
+    /// Behavioral anomaly detected.
     Anomaly,
     /// L0 seed layer classification (Tor exit, datacenter ASN, bad ASN).
     Seed(SeedKind),
@@ -48,7 +48,7 @@ pub enum ContributorKind {
     Override,
     /// Decay credit applied.
     Decay,
-    /// FR-006 challenge credit verification result.
+    /// Challenge credit verification result.
     ChallengeCredit(CreditOutcome),
     /// Admin API credit — operator-issued score reduction.
     AdminCredit,
@@ -88,7 +88,7 @@ pub struct RiskState {
     pub contributors: SmallVec<[Contributor; 8]>,
     /// Consecutive "clean" requests (no risk events) — used for decay.
     pub clean_streak: u32,
-    /// FR-028 honeypot: floor the score until this timestamp (ms).
+    /// Canary honeypot: floor the score until this timestamp (ms).
     pub pinned_until_ms: Option<i64>,
 }
 

--- a/crates/waf-engine/src/risk/store/conformance.rs
+++ b/crates/waf-engine/src/risk/store/conformance.rs
@@ -1,7 +1,7 @@
-//! FR-025 store conformance suite.
+//! Store conformance suite.
 //!
 //! Shared test cases that any `RiskStore` implementation must pass.
-//! Memory backend tests call this; Redis backend (P7) will reuse.
+//! Memory backend tests call this; the Redis backend reuses it.
 
 use std::net::{IpAddr, Ipv4Addr};
 

--- a/crates/waf-engine/src/risk/store/memory.rs
+++ b/crates/waf-engine/src/risk/store/memory.rs
@@ -1,4 +1,4 @@
-//! FR-025 in-memory risk store with triple-index pattern.
+//! In-memory risk store with triple-index pattern.
 //!
 //! Three `DashMap` indices keyed independently (IP, `fp_hash`, session) share
 //! `Arc<RwLock<RiskState>>`. On collision (different Arcs for same actor),
@@ -159,7 +159,7 @@ impl RiskStore for MemoryRiskStore {
         // Apply decay then fold deltas under write lock (atomic)
         {
             let mut state = state_ref.write();
-            // Decay BEFORE fold (FR-025 §4): read state → decay → fold new deltas
+            // Decay BEFORE fold: read state → decay → fold new deltas
             if !is_new {
                 apply_decay(&mut state, now_ms, &self.decay);
             }
@@ -197,7 +197,7 @@ impl RiskStore for MemoryRiskStore {
         {
             let mut state = state_ref.write();
             state.raw_score = 100;
-            state.clamped_score = 100;
+            state.reclamp();
             state.pinned_until_ms = Some(until_ms);
             state.last_updated_ms = now_ms;
         }

--- a/crates/waf-engine/src/risk/store/mod.rs
+++ b/crates/waf-engine/src/risk/store/mod.rs
@@ -1,7 +1,7 @@
-//! FR-025 risk store backends.
+//! Risk store backends.
 //!
-//! Phase 1 ships the [`RiskStore`] trait + in-memory backend. Phase 7 adds
-//! Redis backend behind `redis-store` feature flag for cluster-wide state.
+//! The [`RiskStore`] trait has an in-memory backend, plus a Redis backend
+//! behind the `redis-store` feature flag for cluster-wide state.
 
 pub mod memory;
 pub mod store_trait;

--- a/crates/waf-engine/src/risk/store/redis.rs
+++ b/crates/waf-engine/src/risk/store/redis.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 7: Redis-backed `RiskStore` for cluster-wide risk state.
+//! Redis-backed `RiskStore` for cluster-wide risk state.
 //!
 //! Key layout:
 //! - `waf:risk:state:{owner_id}` → JSON-encoded `RiskState` (TTL: `ttl_secs`)

--- a/crates/waf-engine/src/risk/store/redis_lua.rs
+++ b/crates/waf-engine/src/risk/store/redis_lua.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 7: Embedded Lua scripts for Redis risk store.
+//! Embedded Lua scripts for the Redis risk store.
 //!
 //! All scripts are atomic single-RTT operations: owner resolution (mint or
 //! max-score convergence across index keys) and state mutation happen inside

--- a/crates/waf-engine/src/risk/store/store_trait.rs
+++ b/crates/waf-engine/src/risk/store/store_trait.rs
@@ -1,13 +1,11 @@
-//! FR-025 risk store trait.
+//! Risk store trait.
 //!
 //! Defines the async interface for risk state persistence. Implementations
 //! must be `Send + Sync` for use in the async pipeline.
 
-use std::net::IpAddr;
-
 use async_trait::async_trait;
 
-use crate::risk::key::{RiskKey, SessionId};
+use crate::risk::key::RiskKey;
 use crate::risk::state::{Contributor, RiskState};
 
 /// Result of an `apply` operation — the post-update state.
@@ -52,7 +50,7 @@ pub trait RiskStore: Send + Sync {
 
     /// Force the state to max score (100) until `until_ms`.
     ///
-    /// Used for honeypot traps (FR-028). Sets `pinned_until_ms` and floors
+    /// Used for honeypot traps. Sets `pinned_until_ms` and floors
     /// the score at 100 regardless of decay.
     async fn force_max(&self, key: &RiskKey, until_ms: i64, now_ms: i64) -> anyhow::Result<()>;
 
@@ -84,55 +82,12 @@ pub trait RiskStore: Send + Sync {
     }
 }
 
-/// Builder for `RiskKey` from request context.
-pub struct RiskKeyBuilder {
-    key: RiskKey,
-}
-
-impl RiskKeyBuilder {
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            key: RiskKey::default(),
-        }
-    }
-
-    #[must_use]
-    pub const fn with_ip(mut self, ip: IpAddr) -> Self {
-        self.key.ip = Some(ip);
-        self
-    }
-
-    #[must_use]
-    pub const fn with_fp_hash(mut self, hash: u64) -> Self {
-        self.key.fp_hash = Some(hash);
-        self
-    }
-
-    #[must_use]
-    pub fn with_session(mut self, session: SessionId) -> Self {
-        self.key.session = Some(session);
-        self
-    }
-
-    #[must_use]
-    pub fn build(self) -> RiskKey {
-        self.key
-    }
-}
-
-impl Default for RiskKeyBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[cfg(test)]
 #[allow(clippy::redundant_clone, clippy::uninlined_format_args)]
 mod tests {
     use super::*;
     use crate::risk::state::RiskState;
-    use std::net::Ipv4Addr;
+    use std::net::{IpAddr, Ipv4Addr};
 
     /// Minimal `RiskStore` impl that only implements required methods —
     /// drives default `is_empty` impl through the trait.
@@ -210,26 +165,6 @@ mod tests {
         assert_eq!(s.purge_expired(0, 0).await.unwrap(), 0);
         assert_eq!(s.len().await, 0);
         assert!(s.is_empty().await);
-    }
-
-    #[test]
-    fn key_builder_with_each_axis() {
-        use crate::risk::key::SessionId;
-        let key = RiskKeyBuilder::new()
-            .with_ip(IpAddr::V4(Ipv4Addr::LOCALHOST))
-            .with_fp_hash(0xDEAD_BEEF)
-            .with_session(SessionId::new(b"abc".to_vec()))
-            .build();
-        assert_eq!(key.axis_count(), 3);
-        assert!(key.ip.is_some());
-        assert!(key.fp_hash.is_some());
-        assert!(key.session.is_some());
-    }
-
-    #[test]
-    fn key_builder_default_is_empty() {
-        let key = RiskKeyBuilder::default().build();
-        assert!(key.is_empty());
     }
 
     #[test]

--- a/crates/waf-engine/src/risk/tests/anomaly_combos.rs
+++ b/crates/waf-engine/src/risk/tests/anomaly_combos.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 5: Anomaly detector combination tests.
+//! Anomaly detector combination tests.
 //!
 //! Verifies each detector emits correct deltas and that combinations
 //! accumulate properly without exceeding individual caps.

--- a/crates/waf-engine/src/risk/tests/canary.rs
+++ b/crates/waf-engine/src/risk/tests/canary.rs
@@ -1,4 +1,4 @@
-//! FR-028 Canary Honeypot integration tests.
+//! Canary Honeypot integration tests.
 //!
 //! Tests verify:
 //! - Canary path triggers score=100 and Block decision

--- a/crates/waf-engine/src/risk/tests/conformance_redis.rs
+++ b/crates/waf-engine/src/risk/tests/conformance_redis.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 7: Redis store conformance tests.
+//! Redis store conformance tests.
 //!
 //! Runs the shared conformance suite against `RedisRiskStore`. Only executes
 //! when `REDIS_TEST_URL` is set (e.g. `redis://127.0.0.1:6379`).

--- a/crates/waf-engine/src/risk/tests/lifecycle.rs
+++ b/crates/waf-engine/src/risk/tests/lifecycle.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 5: Risk lifecycle tests.
+//! Risk lifecycle tests.
 //!
 //! Verifies the rise → decay → floor behavior end-to-end:
 //! - Attack signals raise score

--- a/crates/waf-engine/src/risk/tests/mod.rs
+++ b/crates/waf-engine/src/risk/tests/mod.rs
@@ -1,4 +1,4 @@
-//! FR-025 Integration tests for risk scoring lifecycle.
+//! Integration tests for the risk scoring lifecycle.
 
 mod anomaly_combos;
 mod canary;

--- a/crates/waf-engine/src/risk/tests/redis_failover.rs
+++ b/crates/waf-engine/src/risk/tests/redis_failover.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 7: Redis failover and circuit breaker tests.
+//! Redis failover and circuit breaker tests.
 //!
 //! Tests fail-open behavior when Redis is unavailable or times out.
 //! Uses cache fallback to maintain continuity during outages.

--- a/crates/waf-engine/src/risk/threshold.rs
+++ b/crates/waf-engine/src/risk/threshold.rs
@@ -1,4 +1,4 @@
-//! FR-025 pure threshold gate.
+//! Pure threshold gate.
 //!
 //! Maps a clamped risk score (0..=100) to a `WafAction` based on configured
 //! thresholds. Uses the tier's `RiskThresholds` (allow, challenge, block).

--- a/crates/waf-engine/src/risk/velocity/mod.rs
+++ b/crates/waf-engine/src/risk/velocity/mod.rs
@@ -1,4 +1,4 @@
-//! FR-025 Phase 5: Velocity detection layer (L2).
+//! Velocity detection layer (L2).
 //!
 //! Tracks request velocity and transaction sequences per actor.
 //!

--- a/crates/waf-engine/src/risk/velocity/sequence.rs
+++ b/crates/waf-engine/src/risk/velocity/sequence.rs
@@ -5,7 +5,8 @@
 //! - Impossible-fast transitions (e.g., Login→OTP in <1.5s)
 //!
 //! Emits +30 delta on violation. Sync-side only — fires when sequence
-//! completes in a single request chain (FR-012 async handles cross-request).
+//! completes in a single request chain (the async transaction-velocity
+//! signals handle cross-request sequences).
 
 use dashmap::DashMap;
 

--- a/crates/waf-engine/tests/risk_scorer_extended.rs
+++ b/crates/waf-engine/tests/risk_scorer_extended.rs
@@ -145,7 +145,7 @@ async fn header_name_and_emit_header_accessors() {
 }
 
 #[tokio::test]
-async fn with_seed_constructor_and_set_seed() {
+async fn set_seed_then_score_allows() {
     let cfg = RiskConfig {
         enabled: true,
         ..Default::default()
@@ -153,27 +153,12 @@ async fn with_seed_constructor_and_set_seed() {
     let store = Arc::new(MemoryRiskStore::new());
     let swap = Arc::new(ArcSwap::from(Arc::new(cfg)));
     let seed = Arc::new(SeedLayer::empty());
-    let mut scorer = Scorer::with_seed(Arc::clone(&store), swap, Arc::clone(&seed));
+    let mut scorer = Scorer::new(Arc::clone(&store), swap);
     scorer.set_seed(seed);
     // Sanity: can score without panic
     let ctx = ctx_with(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), HashMap::new());
     let r = scorer.score(&ctx, None, &[], None, 1000).await.unwrap();
     assert!(matches!(r.action, WafAction::Allow));
-}
-
-#[tokio::test]
-async fn with_velocity_threshold_constructor() {
-    let cfg = RiskConfig {
-        enabled: true,
-        ..Default::default()
-    };
-    let store = Arc::new(MemoryRiskStore::new());
-    let swap = Arc::new(ArcSwap::from(Arc::new(cfg)));
-    let scorer = Scorer::with_velocity_threshold(store, swap, 1);
-    let ctx = ctx_with(IpAddr::V4(Ipv4Addr::new(7, 7, 7, 7)), HashMap::new());
-    // Run a few requests; expect velocity breach contribution to bump score eventually
-    let r = scorer.score(&ctx, None, &[], None, 1000).await.unwrap();
-    let _ = r;
 }
 
 #[tokio::test]

--- a/docs/journals/2026-07-05-gh-208-risk-dead-code-cleanup-implementation.md
+++ b/docs/journals/2026-07-05-gh-208-risk-dead-code-cleanup-implementation.md
@@ -1,0 +1,23 @@
+# 2026-07-05 — GH-208 risk dead-code cleanup implementation
+
+Plan: `plans/260705-0958-gh-208-risk-dead-code-cleanup/` · Branch: `fix/gh-208-risk-dead-code-cleanup` (stacked on `fix/gh-207-waf-api-config-helpers-dedupe`).
+
+## What shipped
+
+Behavior-preserving cleanup of the risk module, four phases:
+
+1. **RiskKeyBuilder deleted** from `risk/store/store_trait.rs` — zero call sites outside its own two tests; both tests deleted, imports trimmed (`IpAddr` moved into the test module, `SessionId` dropped). Grep confirms zero references workspace-wide.
+2. **Test-only Scorer ctors deleted** — `Scorer::with_seed` and `Scorer::with_velocity_threshold` removed from `risk/scorer.rs`. In `tests/risk_scorer_extended.rs` the seed test migrated to `Scorer::new` + `set_seed` (renamed `set_seed_then_score_allows`); the velocity-ctor test deleted outright — velocity behavior is covered by `tests/tx_velocity_integration.rs`, and no production path sets a custom threshold (YAGNI: no setter added).
+3. **`force_max` unified on `reclamp()`** in `risk/store/memory.rs` — `raw_score = 100; state.reclamp();` replaces the hand-set `clamped_score = 100`, so clamping now flows through the single invariant everywhere. Redis Lua script untouched (already consistent). Covered by store conformance suite.
+4. **Comment sweep** — 87 plan/phase/FR-ID process tokens across 51 files in `risk/**` and `checks/ddos/**` rewritten to describe the actual behavior or invariant (e.g. "§3.3 of the plan" → the stated best-effort drop semantics; stale "GAP" notes in `per_fp.rs` restated truthfully against current code). Comment-only: no code lines changed. Acceptance grep returns zero hits.
+
+## Validation
+
+- `cargo test -p waf-engine --lib risk::` 253 passed (was 255; −2 deleted builder tests); conformance 5 passed; `risk_scorer_extended` 14 passed.
+- `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
+- Full `cargo test --workspace --no-fail-fast` compared against the known docker-gated baseline (no docker socket on this host).
+
+## Decisions / notes
+
+- Dropped the plan's original claim that `UpdateResult.ipv4_updated/ipv6_updated` were dead — they have 7 live read sites; ownership of any change there stays with the geoip updater work.
+- `reclamp()` verified semantically identical for raw=100 (clamp bounds are 0..=100; pin logic reads `pinned_until_ms`, set separately).

--- a/plans/260705-0958-gh-208-risk-dead-code-cleanup/phase-01-remove-dead-code-riskkeybuilder.md
+++ b/plans/260705-0958-gh-208-risk-dead-code-cleanup/phase-01-remove-dead-code-riskkeybuilder.md
@@ -1,7 +1,7 @@
 ---
 phase: 1
 title: "Remove dead RiskKeyBuilder + its tests"
-status: pending
+status: completed
 effort: "20m"
 ---
 

--- a/plans/260705-0958-gh-208-risk-dead-code-cleanup/phase-02-unused-scorer-ctors.md
+++ b/plans/260705-0958-gh-208-risk-dead-code-cleanup/phase-02-unused-scorer-ctors.md
@@ -1,7 +1,7 @@
 ---
 phase: 2
 title: "Remove unused Scorer ctors + migrate tests"
-status: pending
+status: completed
 effort: "20m"
 ---
 

--- a/plans/260705-0958-gh-208-risk-dead-code-cleanup/phase-03-force-max-via-reclamp-unification.md
+++ b/plans/260705-0958-gh-208-risk-dead-code-cleanup/phase-03-force-max-via-reclamp-unification.md
@@ -1,7 +1,7 @@
 ---
 phase: 3
 title: "force_max via reclamp() unification"
-status: pending
+status: completed
 effort: "15m"
 ---
 

--- a/plans/260705-0958-gh-208-risk-dead-code-cleanup/phase-04-comment-and-test-name-sweep-strip-plan-phase-fr-ids.md
+++ b/plans/260705-0958-gh-208-risk-dead-code-cleanup/phase-04-comment-and-test-name-sweep-strip-plan-phase-fr-ids.md
@@ -1,7 +1,7 @@
 ---
 phase: 4
 title: "Comment + test-name sweep (strip plan/phase/FR IDs)"
-status: pending
+status: completed
 effort: "45m"
 ---
 

--- a/plans/260705-0958-gh-208-risk-dead-code-cleanup/plan.md
+++ b/plans/260705-0958-gh-208-risk-dead-code-cleanup/plan.md
@@ -1,7 +1,7 @@
 ---
 title: "GH-208 risk pipeline dead-code cleanup"
 description: "Remove verified dead code (RiskKeyBuilder, unused Scorer ctors), unify force_max via reclamp(), and strip plan/phase/FR IDs from risk + ddos comments. Behavior-preserving."
-status: pending
+status: completed
 priority: P3
 issue: https://github.com/future-and-go/mini-waf/issues/208
 branch: "main-harness"

--- a/plans/reports/code-review-260705-1436-gh-208-risk-dead-code-cleanup-report.md
+++ b/plans/reports/code-review-260705-1436-gh-208-risk-dead-code-cleanup-report.md
@@ -1,0 +1,59 @@
+# Code Review — GH-208 risk dead-code cleanup (uncommitted, fix/gh-208-risk-dead-code-cleanup)
+
+## Scope
+- 52 files, +122/−232, per plan `plans/260705-0958-gh-208-risk-dead-code-cleanup/`
+- Code changes confined to: `risk/store/store_trait.rs`, `risk/scorer.rs`, `risk/store/memory.rs`, `tests/risk_scorer_extended.rs`; remaining ~48 files comment-only
+- Review by reading only (controller holds target-dir lock); test evidence supplied by controller: lib risk:: 253 pass, conformance 5 pass, risk_scorer_extended 14 pass, fmt + clippy `-D warnings` clean
+
+## Verification Results
+
+### (a) No dangling references to deleted items — PASS
+- `grep -rn RiskKeyBuilder\|with_velocity_threshold` across repo: zero hits.
+- `with_seed` hits are unrelated symbols only (`XxHash64::with_seed` in gateway filters, `RandomState::with_seeds` in vendored tinyufo).
+- `RiskKeyBuilder` was never re-exported from `risk/store/mod.rs` or `risk/mod.rs` (only `RiskStore`), so the deleted surface is exactly the direct path with no callers.
+
+### (b) force_max semantic equivalence — PASS
+- `state.rs:130-135` `reclamp()` is `clamped_score = raw_score.clamp(0, 100) as u8`. No configurable max bound, no pin interaction, no other clamp rule. `raw_score = 100` → `clamped_score = 100` unconditionally.
+- Ordering in `memory.rs:197-203` is safe: `reclamp()` runs before `pinned_until_ms` is set, but `reclamp` does not read pin state, so ordering is irrelevant.
+- Redis `FORCE_MAX_SCRIPT` untouched as planned; conformance (memory 5 pass) asserts clamped==100.
+
+### (c) Phase-4 sweep genuinely comment-only — PASS
+- Strict diff scan (`-U0`, all `+/-` lines, excluding the four phase-1..3 files): every changed line in the sweep files starts with `//`, `//!`, `///`, or block-comment continuation. Only non-comment changes outside crates/ are the plan-file `status: pending → completed` flips.
+- All 10 changed attribute lines (`#[must_use]` ×7, `#[test]` ×2, `#[tokio::test]` ×1) trace to the phase-1/2 deletions.
+
+### (d) Rewritten comments accurate — PASS (10+ files spot-checked)
+- `check.rs`: "before rate-limit (`Phase::RateLimit`)" — verified `Phase::RateLimit = 11` exists in `waf-common/src/types.rs:428`; rewrite preserves the old "Phase 11" meaning in durable form.
+- `per_fp.rs`: rewrite *improves* accuracy — old comment claimed "`RequestCtx` does not yet carry a `device_fp` field" (stale; the field exists and is used by tx_velocity session fallback). New text correctly narrows the gap to "`Detector::evaluate` does not yet read the device fingerprint".
+- `aggregator_impl.rs`: "(65536 per plan)" / "per §3.3 of the plan" → behavior-descriptive; constant unchanged.
+- `memory.rs`, `conformance.rs`, `state.rs`, `config.rs`, `canary.rs`, `decay.rs`, `seed/mod.rs`, `degrade.rs`, `worker.rs`, `sequence.rs`, `store/mod.rs`, `risk/mod.rs`: all rewrites describe current behavior correctly; no meaning lost, no new false claims.
+- Plan AC grep (`Phase |phase-|FR-0|§`) over `risk/**` + `checks/ddos/**`: zero hits (each pattern run individually, all exit 1).
+
+### (e) Public contract changes limited to intended deletions — PASS
+- Deleted pub items: `RiskKeyBuilder` (+Default impl), `Scorer::with_seed`, `Scorer::with_velocity_threshold`. No workspace consumer outside the deleted tests (grep-verified across all crates incl. waf-api, gateway, prx-waf).
+- No re-export list edits; `pub use` surfaces in `risk/mod.rs` / `store/mod.rs` unchanged.
+- Import cleanup in `store_trait.rs` correct: `IpAddr`/`SessionId` removed from module scope, `IpAddr` re-imported inside `#[cfg(test)]` where still used. Clippy `-D warnings` clean confirms no orphans.
+
+### (f) Test migration preserves coverage intent — PASS
+- Seed test: `Scorer::new` + `set_seed(seed)` + live `score()` + `Allow` assertion retained; rename to `set_seed_then_score_allows` drops the removed-API name as planned.
+- Deleted `with_velocity_threshold_constructor` was a phantom test: it ended `let _ = r;` with **zero assertions** — deleting it loses nothing. Actual `VelocityLayer` breach behavior is directly unit-tested in `risk/velocity/mod.rs:105-151` (thresholds 0/2/100/1000 incl. breach), plus pipeline-level `tx_velocity_integration.rs`.
+
+## Findings
+
+### Critical / High
+None.
+
+### Low (informational, no action required)
+1. **Plan citation imprecision**: the plan justifies the velocity-test deletion via `tx_velocity_integration.rs:242` (the `checks/tx_velocity` subsystem), but the direct `VelocityLayer` breach coverage actually lives in `risk/velocity/mod.rs` unit tests. Conclusion (coverage preserved) holds either way; the deleted test asserted nothing.
+2. **Out-of-scope residue (correctly left alone)**: `waf-common/src/types.rs:443` still carries an `FR-005` comment on `Phase::Ddos`; waf-engine crate-level CLAUDE.md also uses FR labels. Both are outside the plan's stated sweep scope (`risk/**` + `checks/ddos/**`) — noting for completeness, not requesting change (surgical-change rule).
+
+## Acceptance Criteria
+- [x] Dead items removed with dedicated tests (P1, P2); `UpdateResult` bools deliberately untouched per dropped claim
+- [x] `force_max` derives via `reclamp()` (P3); semantically identical, conformance green
+- [x] AC grep returns zero hits in scoped dirs (P4)
+- [x] fmt/clippy/test gates green (controller-verified)
+
+## Verdict
+Behavior-preserving as claimed. No blocking or high-priority issues. Ready to land (rebase ordering vs GH-196/GH-202 per plan's soft-ordering notes remains the controller's call).
+
+Status: DONE
+Summary: All six checks pass. Deletions are clean with no dangling refs or contract leaks; force_max reclamp is provably equivalent (raw.clamp(0,100), no other bounds); phase-4 sweep is strictly comment-only and rewrites are accurate (per_fp.rs even fixes a stale claim); deleted velocity test was assertion-free. Two Low informational notes only.


### PR DESCRIPTION
Closes #208. Stacked on #220 (`fix/gh-207-waf-api-config-helpers-dedupe`) — merge that first.

Behavior-preserving dead-code and comment cleanup in `waf-engine` risk + ddos modules. No public contract changes beyond deleting two test-only constructors and one unused builder.

## What

**1. `RiskKeyBuilder` deleted** (`risk/store/store_trait.rs`)

Zero call sites outside its own two tests (production key construction goes through `RiskKey::from_ip` / scorer `build_key`). Struct, impls, and both builder tests removed; imports trimmed. Workspace grep: zero references.

**2. Test-only `Scorer` ctors deleted** (`risk/scorer.rs`)

`Scorer::with_seed` and `Scorer::with_velocity_threshold` were never called from production. The seed test in `tests/risk_scorer_extended.rs` now uses the production path (`Scorer::new` + `set_seed`, renamed `set_seed_then_score_allows`); the velocity-ctor test is deleted — velocity behavior is covered by `tests/tx_velocity_integration.rs`. No threshold setter added (nothing needs one).

**3. `force_max` clamps via `reclamp()`** (`risk/store/memory.rs`)

`state.raw_score = 100; state.reclamp();` replaces the hand-set `clamped_score = 100` so score clamping flows through the single invariant. Semantically identical (bounds 0..=100; pinning is set separately); covered by the store conformance suite. Redis Lua path untouched.

**4. Comment sweep** (`risk/**`, `checks/ddos/**`)

87 plan/phase/FR-ID process tokens across 51 files rewritten to state the actual behavior or invariant instead of pointing at planning docs. Comment lines only — the diff contains no code changes outside items 1–3. Stale "GAP" comments in `detector/per_fp.rs` restated truthfully against current code. Acceptance grep over both trees: zero hits.

## Validation

- `cargo test -p waf-engine --lib risk::`: 253 passed (−2 = the deleted builder tests); store conformance 5 passed; `risk_scorer_extended` 14 passed
- Full workspace `cargo test --no-fail-fast`: green except known docker-gated suites (no docker socket on this host), unchanged from base
- `cargo clippy --workspace --all-targets -- -D warnings` + `--features redis-store`: clean; `cargo fmt --check`: clean

Plan: `plans/260705-0958-gh-208-risk-dead-code-cleanup/` · Journal: `docs/journals/2026-07-05-gh-208-risk-dead-code-cleanup-implementation.md`
