### PR TITLE
fix(risk-ui): send positive credit magnitudes so Add-credit stops 400ing

### DIFF
--- a/crates/waf-api/src/risk_api.rs
+++ b/crates/waf-api/src/risk_api.rs
@@ -115,18 +115,26 @@ pub struct CreditBody {
 
 const DEFAULT_CREDIT_AMOUNT: i16 = 25;
 
+/// Contract gate shared with the admin UI credit modal: credit is a positive
+/// magnitude (1..=100) that the engine subtracts from the score — "add
+/// credit" can never raise it, so negative and zero amounts are rejected.
+fn validate_credit_amount(amount: i16) -> Result<i16, ApiError> {
+    if (1..=100).contains(&amount) {
+        Ok(amount)
+    } else {
+        Err(ApiError::BadRequest(format!(
+            "amount must be between 1 and 100, got {amount}"
+        )))
+    }
+}
+
 pub async fn credit_risk_actor(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
     Json(body): Json<CreditBody>,
 ) -> ApiResult<Json<Value>> {
     let ip = parse_actor_ip(&id)?;
-    let amount = body.amount.unwrap_or(DEFAULT_CREDIT_AMOUNT);
-    if !(1..=100).contains(&amount) {
-        return Err(ApiError::BadRequest(format!(
-            "amount must be between 1 and 100, got {amount}"
-        )));
-    }
+    let amount = validate_credit_amount(body.amount.unwrap_or(DEFAULT_CREDIT_AMOUNT))?;
     let score = state.engine.risk_credit_actor(ip, amount).await?;
     Ok(Json(json!({ "success": true, "data": { "id": id, "score": score } })))
 }
@@ -143,6 +151,19 @@ pub async fn clear_risk_actor(State(state): State<Arc<AppState>>, Path(id): Path
 #[allow(clippy::indexing_slicing)]
 mod tests {
     use super::*;
+
+    /// The credit modal sends positive magnitudes; every UI button value and
+    /// the API default must pass the gate, while the pre-fix negative UI
+    /// values, zero, and out-of-range magnitudes are rejected.
+    #[test]
+    fn credit_amount_gate_matches_ui_contract() {
+        for ui_amount in [50, 25, 10, DEFAULT_CREDIT_AMOUNT] {
+            assert!(validate_credit_amount(ui_amount).is_ok(), "UI amount {ui_amount} must pass");
+        }
+        for bad in [-50, -25, -10, 0, 101] {
+            assert!(validate_credit_amount(bad).is_err(), "amount {bad} must be rejected");
+        }
+    }
 
     /// Non-default fields in every section must survive
     /// YAML → deep-merge → `RiskConfig` → YAML, including sections the admin

--- a/web/admin-panel/src/i18n/locales/en.json
+++ b/web/admin-panel/src/i18n/locales/en.json
@@ -919,7 +919,7 @@
     "configSaved": "Config saved",
     "scoreCleared": "Score cleared",
     "noActors": "No actors tracked yet",
-    "creditHint": "A positive amount decreases the risk score; negative increases it.",
+    "creditHint": "The credit amount is subtracted from the actor's risk score (allowed range 1\u2013100).",
     "creditApplied": "Credit applied",
     "actorDetail": "Actor Detail",
     "addCreditTitle": "Add Score Credit",

--- a/web/admin-panel/src/pages/risk-scoring/index.tsx
+++ b/web/admin-panel/src/pages/risk-scoring/index.tsx
@@ -677,13 +677,15 @@ export const RiskScoringPage: React.FC = () => {
         <Space direction="vertical" style={{ width: "100%" }}>
           <Typography.Text type="secondary">{t("risk.creditHint")}</Typography.Text>
           <Space>
-            {([-50, -25, -10] as const).map((amt) => (
+            {/* Positive magnitudes: the API accepts 1..=100 and the engine
+                subtracts the amount from the score (credit always lowers). */}
+            {([50, 25, 10] as const).map((amt) => (
               <Button
                 key={amt}
                 onClick={() => onCredit(amt)}
                 loading={creditMutation.isPending}
               >
-                {amt}
+                −{amt}
               </Button>
             ))}
           </Space>


### PR DESCRIPTION
Closes #225

## Problem
Every "Add credit" click returned HTTP 400: the modal sent `[-50,-25,-10]` while the API rejects anything outside `1..=100`. The sign convention conflicted across four layers (UI negative-to-reduce, i18n hint claiming negative increases, engine `-amount.abs()` always-decreases, API `1..=100`).

## Fix
Canonical contract: **credit is a positive magnitude the engine subtracts from the score**.
- UI buttons send `[50, 25, 10]` (rendered as −50/−25/−10 so the operator still reads "score goes down").
- `creditHint` in `en.json` corrected — the old text described a negative-increases path that cannot exist in the engine (vi/zh don't carry these keys).
- API gate extracted into `validate_credit_amount` + contract test covering every UI button value, the default (25), and rejection of the pre-fix negatives, 0, and 101.

## Verification
- `cargo test -p waf-api --lib risk_api`: 4/4 pass (incl. new `credit_amount_gate_matches_ui_contract`).
- `tsc --noEmit` clean on the admin panel.
- Manual-check AC (each button returns 200 and lowers the score) needs a running stack — covered by the contract test at the API boundary.

## Conflict note
Test added at the *top* of the `risk_api.rs` tests mod so it merges cleanly alongside PR #235, which appends tests at the bottom of the same file. No merge-order dependency.

https://claude.ai/code/session_018YtgAuSKSMHKBJEuJtVuzV