### PR TITLE
fix(risk): wire seed and challenge-credit layers into the production scorer

### DIFF
--- a/crates/waf-engine/src/engine.rs
+++ b/crates/waf-engine/src/engine.rs
@@ -44,9 +44,11 @@ use crate::rules::custom_file_loader::CustomRuleFileWatcher;
 use crate::rules::engine::{CustomRulesEngine, from_db_rule};
 
 use crate::risk::canary::{CanaryLayer, DEFAULT_CANARY_BAN_TTL_SECS};
+use crate::risk::challenge_credit::{ChallengeBuilder, ChallengeVerifier};
 use crate::risk::config::RiskConfig;
 use crate::risk::reload::{DEFAULT_DEBOUNCE_MS as RISK_DEBOUNCE_MS, RiskReloader};
 use crate::risk::scorer::{Scorer, ScorerResult};
+use crate::risk::seed::{SeedDeltas, SeedLayer};
 use crate::risk::store::{MemoryRiskStore, RiskStore};
 
 /// WAF engine configuration
@@ -173,6 +175,16 @@ pub struct WafEngine {
     /// subsequent requests. Paths and ban TTL follow `RiskConfig.canary`
     /// via [`Self::replace_risk_config`].
     risk_canary: Arc<CanaryLayer>,
+    /// L0 seed layer (Tor exits / ASN classes / whitelist) built from
+    /// `RiskConfig.seed` on initial risk-config load and re-attached on every
+    /// scorer rebuild. Table paths and deltas are start-time only; the
+    /// `seed.enabled` flag stays hot-reloadable because the scorer gates on
+    /// the live config snapshot per request.
+    risk_seed: OnceLock<Arc<SeedLayer>>,
+    /// Challenge-credit verifier built from `RiskConfig.challenge` on initial
+    /// risk-config load (when enabled) and re-attached on every scorer
+    /// rebuild. HMAC secret and nonce store are start-time only.
+    risk_challenge_verifier: OnceLock<Arc<ChallengeVerifier>>,
     // ── FR-007/FR-042 relay-intel feed metadata (D3) ─────────────────────────
     /// Threat-intel feed metadata (Tor / ASN / datacenter), loaded from
     /// `configs/relay.yaml` at startup via [`Self::load_relay_feeds`]. Empty
@@ -313,6 +325,8 @@ impl WafEngine {
             scorer,
             risk_reloader: OnceLock::new(),
             risk_canary,
+            risk_seed: OnceLock::new(),
+            risk_challenge_verifier: OnceLock::new(),
             relay_feeds: ArcSwap::from_pointee(Vec::new()),
         }
     }
@@ -375,11 +389,55 @@ impl WafEngine {
 
     /// Build a scorer over `store` sharing the engine's config snapshot and
     /// canary layer (the canary must be re-attached on every scorer rebuild
-    /// or honeypot hits stop pinning scores).
+    /// or honeypot hits stop pinning scores). The seed layer and challenge
+    /// verifier are likewise re-attached whenever they have been initialized
+    /// by [`Self::init_risk_layers`].
     fn build_scorer(&self, store: Arc<dyn RiskStore>) -> Scorer<dyn RiskStore> {
         let mut scorer = Scorer::new(store, Arc::clone(&self.risk_cfg));
         scorer.set_canary(Arc::clone(&self.risk_canary));
+        if let Some(seed) = self.risk_seed.get() {
+            scorer.set_seed(Arc::clone(seed));
+        }
+        if let Some(verifier) = self.risk_challenge_verifier.get() {
+            scorer.set_challenge_verifier(Arc::clone(verifier));
+        }
         scorer
+    }
+
+    /// Build the L0 seed layer and challenge-credit verifier from the initial
+    /// risk config so [`Self::build_scorer`] can attach them.
+    ///
+    /// The seed layer is always built: table paths pointing at missing files
+    /// load empty (fail-soft), and the per-request `seed.enabled` gate lives
+    /// in the scorer, so a hot-reload that flips the flag works without a
+    /// scorer rebuild. The challenge verifier is only built when
+    /// `challenge.enabled` because construction bootstraps the HMAC secret
+    /// file on disk; enabling it later requires a restart.
+    fn init_risk_layers(&self, cfg: &RiskConfig) {
+        let deltas = SeedDeltas {
+            tor_exit: cfg.seed.tor_delta,
+            datacenter: cfg.seed.datacenter_delta,
+            bad_asn: cfg.seed.bad_asn_delta,
+        };
+        let seed = SeedLayer::load_from_paths(
+            cfg.seed.tor_exits_path.as_deref().map(Path::new),
+            cfg.seed.asn_classes_path.as_deref().map(Path::new),
+            cfg.seed.whitelist_path.as_deref().map(Path::new),
+            deltas,
+        );
+        let _ = self.risk_seed.set(Arc::new(seed));
+
+        if cfg.challenge.enabled {
+            match ChallengeBuilder::from_config(&cfg.challenge) {
+                Ok((_issuer, verifier)) => {
+                    let _ = self.risk_challenge_verifier.set(Arc::new(verifier));
+                }
+                Err(e) => warn!(
+                    error = %e,
+                    "risk: challenge verifier init failed; challenge credit stays disabled"
+                ),
+            }
+        }
     }
 
     /// Load `configs/risk.yaml` once, build the configured store, and start
@@ -398,6 +456,7 @@ impl WafEngine {
         match RiskConfig::from_path(path) {
             Ok(cfg) => {
                 let store = Self::build_risk_store(&cfg).await;
+                self.init_risk_layers(&cfg);
                 self.scorer.store(Arc::new(self.build_scorer(store)));
                 active_backend.clone_from(&cfg.store.backend);
                 self.replace_risk_config((*cfg).clone());

--- a/crates/waf-engine/tests/risk_seed_challenge_engine_wiring.rs
+++ b/crates/waf-engine/tests/risk_seed_challenge_engine_wiring.rs
@@ -1,0 +1,99 @@
+//! Engine-level proof that `start_risk_watcher` wires the L0 seed layer and
+//! the challenge-credit verifier into the scorer `inspect()` actually uses —
+//! no hand-constructed `Scorer`. Regression coverage for the gap where
+//! `build_scorer` attached only the canary layer, so `seed.enabled: true`
+//! silently scored nothing.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use std::sync::Arc;
+
+use waf_engine::risk::challenge_credit::{ChallengeIssuer, HmacSecret};
+use waf_engine::risk::key::RiskKey;
+
+/// Write a risk config into `dir` and return its path.
+fn write_risk_yaml(dir: &std::path::Path, body: &str) -> std::path::PathBuf {
+    let path = dir.join("risk.yaml");
+    std::fs::write(&path, body).unwrap();
+    path
+}
+
+#[tokio::test]
+async fn tor_exit_ip_accrues_seed_delta_through_inspect() {
+    let fx = common::start_engine().await;
+    let dir = tempfile::tempdir().unwrap();
+
+    let tor_ip = "203.0.113.7";
+    let tor_path = dir.path().join("tor-exits.txt");
+    std::fs::write(&tor_path, format!("{tor_ip}\n")).unwrap();
+
+    let risk_yaml = write_risk_yaml(
+        dir.path(),
+        &format!(
+            "risk:\n  enabled: true\n  seed:\n    enabled: true\n    tor_exits_path: \"{}\"\n",
+            tor_path.display()
+        ),
+    );
+    fx.engine.start_risk_watcher(&risk_yaml).await;
+
+    let mut ctx = common::make_ctx("h1", "/", tor_ip);
+    let decision = fx.engine.inspect(&mut ctx).await;
+
+    // Default tor_delta is 30; default tier thresholds (challenge=70) keep
+    // the request allowed, so the seed contribution surfaces as the score.
+    assert!(decision.is_enforcement_allowed(), "score 30 must stay below thresholds");
+    assert_eq!(
+        decision.risk_score, 30,
+        "tor-exit seed delta must reach the request-path scorer"
+    );
+
+    // A non-listed IP on the same engine accrues nothing.
+    let mut clean_ctx = common::make_ctx("h1", "/", "198.51.100.10");
+    let clean = fx.engine.inspect(&mut clean_ctx).await;
+    assert_eq!(clean.risk_score, 0, "non-tor IP must not inherit seed deltas");
+}
+
+#[tokio::test]
+async fn challenge_credit_token_verifies_through_inspect() {
+    let fx = common::start_engine().await;
+    let dir = tempfile::tempdir().unwrap();
+
+    let secret_path = dir.path().join("hmac.key");
+    let risk_yaml = write_risk_yaml(
+        dir.path(),
+        &format!(
+            "risk:\n  enabled: true\n  challenge:\n    enabled: true\n    hmac_secret_path: \"{}\"\n    header_name: \"x-waf-cred\"\n",
+            secret_path.display()
+        ),
+    );
+    fx.engine.start_risk_watcher(&risk_yaml).await;
+
+    // The watcher's ChallengeBuilder bootstrapped the secret file; issue a
+    // token with the same secret, bound to the IP-axis owner id the scorer
+    // derives for this client.
+    let ip = "198.51.100.9";
+    let secret = HmacSecret::load_or_init(&secret_path).unwrap();
+    let issuer = ChallengeIssuer::new(Arc::new(secret), 300);
+    let owner = RiskKey::from_ip(ip.parse().unwrap()).owner_id();
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let token = issuer.issue(&owner, now_ms);
+
+    // First presentation: Valid outcome, credit delta (-25) clamps to 0.
+    let mut ctx = common::make_ctx("h1", "/", ip);
+    ctx.headers.insert("x-waf-cred".into(), token.clone());
+    let first = fx.engine.inspect(&mut ctx).await;
+    assert_eq!(first.risk_score, 0, "valid credit must not add risk");
+
+    // Replay of the same token: the verifier consumed the nonce on the first
+    // pass, so the second pass must score the replay delta (+30). This only
+    // happens when the verifier inspect() uses is the one the watcher built.
+    let mut replay_ctx = common::make_ctx("h1", "/", ip);
+    replay_ctx.headers.insert("x-waf-cred".into(), token);
+    let replay = fx.engine.inspect(&mut replay_ctx).await;
+    assert_eq!(
+        replay.risk_score, 30,
+        "replayed token must apply replay_delta through the wired verifier"
+    );
+}


### PR DESCRIPTION
Closes #224

## Root cause
`WafEngine::build_scorer` attached only the canary layer. `SeedLayer` and `ChallengeVerifier` were never constructed outside tests, so `Scorer::score` always saw `seed = None` / `challenge_verifier = None` and the L0 reputation layer plus challenge-credit verification were silently inert — despite `configs/risk.yaml` shipping `seed.enabled: true`.

## Fix
- `start_risk_watcher` calls a new `init_risk_layers(&cfg)` before the scorer swap:
  - **Seed layer**: always built from `cfg.seed` paths + deltas. Missing/unset table paths load empty (fail-soft), and the per-request `seed.enabled` gate in `Scorer::score` stays hot-reloadable. Table paths/deltas are start-time only (documented on the field).
  - **Challenge verifier**: built via `ChallengeBuilder::from_config` only when `challenge.enabled`, because construction bootstraps the HMAC secret file on disk. Init failure warns and degrades (matches engine fail-soft style).
- `build_scorer` re-attaches both on every scorer rebuild, same contract as the canary layer.

## configs/risk.yaml seed default (AC reconciliation)
`seed.enabled: true` is now accurate — the layer is wired and active; with all table paths commented out it loads empty and contributes nothing until an operator points it at data. No config change needed.

## Tests (engine-level, per AC — no hand-constructed Scorer)
`crates/waf-engine/tests/risk_seed_challenge_engine_wiring.rs`:
- Tor-exit IP listed in a temp `tor-exits.txt` accrues `tor_delta` (+30) through `WafEngine::inspect()`; a non-listed IP scores 0.
- Challenge token issued against the watcher-bootstrapped HMAC secret verifies end-to-end through `inspect()`: first presentation → Valid (score clamps to 0), replay of the same token → `replay_delta` (+30), which can only happen if the wired verifier consumed the nonce on the first pass.

## Verification
- `cargo test -p waf-engine --lib`: 1446 passed. 7 failures are pre-existing and environmental on this machine: 6 engine unit tests need the docker socket (testcontainers; user not in docker group) and 1 is the user's local uncommitted `configs/device-fp.yaml` edit. Verified identical failure set at baseline (`origin/main-harness` with my change stashed).
- `cargo test -p waf-engine --test risk_seed_layer_e2e --test risk_challenge_credit_outcomes`: 17/17 pass.
- New integration test compiles (`--no-run`); it requires docker (same as every `tests/common` fixture test) and will run in CI.
- `cargo clippy -p waf-engine --all-targets`: clean.

## Conflict notes (parallel bug-fix PR stack, all based on origin/main-harness)
- Touches `engine.rs` imports/struct fields/`build_scorer`/`start_risk_watcher` Ok-branch only. Upcoming #226 (score call args), #227 (velocity purge loop), #228 (backend-change warning) touch different functions/lines of the same file; hunks are positioned to merge cleanly in any order.
- New test file is standalone — no shared-file conflicts.

https://claude.ai/code/session_018YtgAuSKSMHKBJEuJtVuzV