### PR TITLE
fix(admin): expose clearable upstream IP pin in the host dialog (US-1806)

### DIFF
--- a/crates/waf-storage/tests/repo_hosts.rs
+++ b/crates/waf-storage/tests/repo_hosts.rs
@@ -115,6 +115,74 @@ async fn update_partial_fields_persists() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn update_remote_ip_empty_string_clears_pin_and_null_preserves_it() {
+    let fx = fresh().await;
+    let mut create = sample_host();
+    create.remote_ip = Some("10.0.0.9".into());
+    let host = fx.db.create_host(create).await.unwrap();
+    assert_eq!(host.remote_ip.as_deref(), Some("10.0.0.9"));
+
+    let clear = UpdateHost {
+        host: None,
+        port: None,
+        ssl: None,
+        guard_status: None,
+        remote_host: None,
+        remote_port: None,
+        remote_ip: Some(String::new()),
+        cert_file: None,
+        key_file: None,
+        remarks: None,
+        start_status: None,
+        log_only_mode: None,
+        upstream_alpn: None,
+        upstream_skip_ssl_verify: None,
+        defense_json: None,
+        http_redirect: None,
+        preserve_host: None,
+    };
+    // COALESCE('', remote_ip) stores the empty string — the proxy filters
+    // empty pins, so this is the effective "clear" the admin panel sends.
+    let cleared = fx.db.update_host(host.id, clear).await.unwrap().unwrap();
+    assert_eq!(cleared.remote_ip.as_deref(), Some(""));
+
+    // Re-pin, then send NULL: COALESCE keeps the existing value. This is why
+    // the frontend must send "" (not omit the field) to clear the pin.
+    let repin = UpdateHost {
+        remote_ip: Some("10.0.0.7".into()),
+        ..clear_update_template()
+    };
+    let repinned = fx.db.update_host(host.id, repin).await.unwrap().unwrap();
+    assert_eq!(repinned.remote_ip.as_deref(), Some("10.0.0.7"));
+
+    let omit = clear_update_template();
+    let unchanged = fx.db.update_host(host.id, omit).await.unwrap().unwrap();
+    assert_eq!(unchanged.remote_ip.as_deref(), Some("10.0.0.7"));
+}
+
+fn clear_update_template() -> UpdateHost {
+    UpdateHost {
+        host: None,
+        port: None,
+        ssl: None,
+        guard_status: None,
+        remote_host: None,
+        remote_port: None,
+        remote_ip: None,
+        cert_file: None,
+        key_file: None,
+        remarks: None,
+        start_status: None,
+        log_only_mode: None,
+        upstream_alpn: None,
+        upstream_skip_ssl_verify: None,
+        defense_json: None,
+        http_redirect: None,
+        preserve_host: None,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn update_missing_returns_none() {
     let fx = fresh().await;
     let upd = UpdateHost {

--- a/web/admin-panel/src/i18n/locales/en.json
+++ b/web/admin-panel/src/i18n/locales/en.json
@@ -184,6 +184,8 @@
     "http": "HTTP",
     "editHost": "Edit Host",
     "upstreamPort": "Upstream port",
+    "remoteIpPin": "Upstream IP (pin)",
+    "remoteIpPinTooltip": "Pins the upstream to this IP, bypassing DNS resolution of the Upstream hostname. Leave empty to route to the hostname. A set pin overrides the Upstream field.",
     "logOnly": "Log only",
     "upstreamAlpn": "Upstream ALPN",
     "upstreamAlpnTooltip": "ALPN only applies to TLS upstreams (SSL on)",

--- a/web/admin-panel/src/i18n/locales/vi.json
+++ b/web/admin-panel/src/i18n/locales/vi.json
@@ -184,6 +184,8 @@
     "http": "HTTP",
     "editHost": "Sửa Host",
     "upstreamPort": "Upstream port",
+    "remoteIpPin": "IP upstream (ghim)",
+    "remoteIpPinTooltip": "Ghim upstream vào IP này, bỏ qua phân giải DNS của hostname Upstream. Để trống để định tuyến theo hostname. IP đã ghim sẽ ghi đè trường Upstream.",
     "logOnly": "Chỉ ghi log",
     "upstreamAlpn": "ALPN upstream",
     "upstreamAlpnTooltip": "ALPN chỉ áp dụng khi bật SSL",

--- a/web/admin-panel/src/i18n/locales/zh.json
+++ b/web/admin-panel/src/i18n/locales/zh.json
@@ -141,6 +141,8 @@
     "http": "HTTP",
     "editHost": "编辑主机",
     "upstreamPort": "上游端口",
+    "remoteIpPin": "上游 IP（固定）",
+    "remoteIpPinTooltip": "将上游固定到此 IP，绕过上游主机名的 DNS 解析。留空则路由到主机名。已设置的固定 IP 会覆盖上游字段。",
     "logOnly": "仅记录日志",
     "upstreamAlpn": "上游 ALPN",
     "upstreamAlpnTooltip": "ALPN 仅适用于 TLS 上游（SSL 开启时）",

--- a/web/admin-panel/src/pages/hosts/index.tsx
+++ b/web/admin-panel/src/pages/hosts/index.tsx
@@ -31,6 +31,7 @@ interface HostFormShape {
   guard_status: boolean;
   remote_host: string;
   remote_port: number;
+  remote_ip: string;
   start_status: boolean;
   log_only_mode: boolean;
   upstream_alpn: UpstreamAlpn;
@@ -65,6 +66,7 @@ const DEFAULT_FORM: HostFormShape = {
   guard_status: true,
   remote_host: "",
   remote_port: 8080,
+  remote_ip: "",
   start_status: true,
   log_only_mode: false,
   upstream_alpn: "h2h1",
@@ -125,6 +127,7 @@ export const HostsPage: React.FC = () => {
       guard_status: host.guard_status,
       remote_host: host.remote_host,
       remote_port: host.remote_port,
+      remote_ip: host.remote_ip ?? "",
       start_status: host.start_status,
       log_only_mode: host.log_only_mode ?? false,
       upstream_alpn: host.upstream_alpn ?? "h2h1",
@@ -255,6 +258,19 @@ export const HostsPage: React.FC = () => {
           <InputNumber min={1} max={65535} style={{ width: "100%" }} />
         </Form.Item>
       </Space.Compact>
+      <Form.Item
+        name="remote_ip"
+        label={
+          <span>
+            {t("hosts.remoteIpPin")}&nbsp;
+            <Tooltip title={t("hosts.remoteIpPinTooltip")}>
+              <InfoCircleOutlined style={{ color: "#8c8c8c" }} />
+            </Tooltip>
+          </span>
+        }
+      >
+        <Input placeholder="203.0.113.10" allowClear />
+      </Form.Item>
       <Form.Item name="remarks" label={t("hosts.remarks")}>
         <Input />
       </Form.Item>

--- a/web/admin-panel/src/types/api.ts
+++ b/web/admin-panel/src/types/api.ts
@@ -50,6 +50,9 @@ export interface Host {
   guard_status: boolean;
   remote_host: string;
   remote_port: number;
+  /** Upstream IP pin. When non-empty, the proxy dials this IP instead of
+   *  resolving remote_host (bypasses container DNS). Empty = use remote_host. */
+  remote_ip?: string;
   start_status: boolean;
   log_only_mode?: boolean;
   remarks?: string;


### PR DESCRIPTION
Closes #194
Closes #171

## Root cause (frontend-only, per the #194 analysis)
The `Host` TS type and the Add/Edit Host dialog had no `remote_ip` field. The submit handlers send `{ ...DEFAULT_FORM, ...values }`, so `remote_ip` was **omitted** from the request body → backend `remote_ip = COALESCE($8, remote_ip)` kept the stale pin → the proxy kept dialing the pinned IP no matter what the operator set as Upstream.

## Fix (Phase 1 of the committed plan `plans/260702-1407-us-1806-clearable-remote-ip-upstream-pin/`)
- `types/api.ts`: `Host.remote_ip?: string` (doc comment explains pin semantics).
- `pages/hosts/index.tsx`: `HostFormShape.remote_ip`, `DEFAULT_FORM` default `""` (guarantees a string is always sent), `onOpenEdit` pre-fills the active pin (visible-pin AC), optional "Upstream IP (pin)" `Form.Item` with tooltip + `allowClear` after the Upstream row.
- i18n: `hosts.remoteIpPin` / `hosts.remoteIpPinTooltip` in en/vi/zh (+2 lines each).

Clear semantics: cleared/untouched field sends `""` → `COALESCE('', remote_ip)` stores `''` → `proxy.rs` filters empty pins → routes to `remote_host` on the next request. No restart, no SQL. COALESCE intentionally kept (partial-update contract for other callers).

## Backend proof (Phase 2 — zero production `.rs` changes)
New test in `crates/waf-storage/tests/repo_hosts.rs`:
- create with pin `10.0.0.9` → update `remote_ip: Some("")` → stored `Some("")` (effective clear),
- re-pin → update with `remote_ip: None` → value preserved (documents why the FE must send `""`, not omit).

## Verification
- `npx tsc --noEmit`: clean (admin panel has no test runner).
- `cargo test -p waf-storage --test repo_hosts --no-run`: compiles. The suite needs the Postgres testcontainer harness; docker is unavailable on this machine (user not in docker group), so it runs in CI — recorded honestly per the plan's risk note.
- `cargo clippy -p waf-storage --all-targets`: clean.

## Known deviation from story
Proxy fallback selection (`proxy.rs:470-474`) is inline in `upstream_peer` and not unit-testable without a pingora session; fallback behavior is covered by the repo contract test + the proxy's existing non-empty filter, as the plan's phase-02 risk note prescribes.

## Conflict notes (parallel bug-fix PR stack)
Touches the hosts page, `types/api.ts`, locale files, and `repo_hosts.rs` — none of which any other PR in the stack (#235, #236, #237, upcoming #226-#232) modifies. Expected to merge cleanly in any order.

https://claude.ai/code/session_018YtgAuSKSMHKBJEuJtVuzV