### PR TITLE
fix(risk-api): flag store.backend changes as restart-required instead of silent success

### DIFF
--- a/crates/waf-api/src/risk_api.rs
+++ b/crates/waf-api/src/risk_api.rs
@@ -48,6 +48,16 @@ fn deep_merge(base: &mut Value, patch: Value) {
     }
 }
 
+/// The store backend is start-time only: the engine's hot-reload keeps the
+/// active store when `store.backend` changes. True when the saved config asks
+/// for a different backend than the one actually running (including a redis →
+/// memory startup fallback), i.e. the operator needs a gateway restart for the
+/// saved value to take effect. `active = None` (watcher not started, e.g. unit
+/// tests) cannot claim a mismatch.
+fn backend_restart_required(requested: &str, active: Option<&str>) -> bool {
+    active.is_some_and(|a| a != requested)
+}
+
 // ─── Handlers ─────────────────────────────────────────────────────────────────
 
 pub async fn get_risk_config(State(state): State<Arc<AppState>>) -> ApiResult<Json<Value>> {
@@ -58,7 +68,14 @@ pub async fn get_risk_config(State(state): State<Arc<AppState>>) -> ApiResult<Js
     let cfg: RiskConfig = serde_json::from_value(node)
         .map_err(|e| ApiError::Internal(anyhow::anyhow!("configs/risk.yaml does not parse as RiskConfig: {e}")))?;
     let data = serde_json::to_value(&cfg).map_err(|e| ApiError::Internal(anyhow::anyhow!("{e}")))?;
-    Ok(Json(json!({ "success": true, "data": data })))
+    // `active_store_backend` is the backend actually running, which can lag
+    // the file (backend edits are start-time only) or differ from it after a
+    // redis connect fallback — the operator's downgrade-detection surface.
+    Ok(Json(json!({
+        "success": true,
+        "data": data,
+        "active_store_backend": state.engine.risk_store_backend(),
+    })))
 }
 
 pub async fn put_risk_config(State(state): State<Arc<AppState>>, Json(body): Json<Value>) -> ApiResult<Json<Value>> {
@@ -72,7 +89,26 @@ pub async fn put_risk_config(State(state): State<Arc<AppState>>, Json(body): Jso
         serde_json::from_value(merged).map_err(|e| ApiError::BadRequest(format!("invalid risk config: {e}")))?;
     let data = serde_json::to_value(&cfg).map_err(|e| ApiError::Internal(anyhow::anyhow!("{e}")))?;
     write_yaml(&path, &json!({ "risk": data })).await?;
-    Ok(Json(json!({ "success": true, "data": data })))
+    let active = state.engine.risk_store_backend();
+    let restart_required = backend_restart_required(&cfg.store.backend, active);
+    let mut resp = json!({
+        "success": true,
+        "data": data,
+        "restart_required": restart_required,
+        "active_store_backend": active,
+    });
+    if restart_required && let Some(obj) = resp.as_object_mut() {
+        obj.insert(
+            "message".into(),
+            json!(format!(
+                "store.backend saved as \"{}\" but the gateway is running the \"{}\" store; \
+                 the change takes effect after a gateway restart",
+                cfg.store.backend,
+                active.unwrap_or("unknown"),
+            )),
+        );
+    }
+    Ok(Json(resp))
 }
 
 pub async fn get_risk_metrics(_: State<Arc<AppState>>) -> ApiResult<Json<Value>> {
@@ -200,6 +236,23 @@ mod tests {
         let mut node = serde_json::to_value(RiskConfig::default()).unwrap();
         deep_merge(&mut node, json!({ "ttl_secs": "not_a_number" }));
         assert!(serde_json::from_value::<RiskConfig>(node).is_err());
+    }
+
+    /// PUT changing `store.backend` away from the running store must be
+    /// flagged, never silently 200-OK'd; matching or unknown (watcher not
+    /// started) backends must not flag.
+    #[test]
+    fn backend_change_flags_restart_required() {
+        // memory → redis via PUT (engine keeps memory until restart); the
+        // same input covers the startup-fallback case where the file already
+        // said redis but the connect failed and memory is active.
+        assert!(backend_restart_required("redis", Some("memory")));
+        assert!(backend_restart_required("memory", Some("redis")));
+        // No change → no flag.
+        assert!(!backend_restart_required("memory", Some("memory")));
+        assert!(!backend_restart_required("redis", Some("redis")));
+        // Watcher never started (no active store to contradict).
+        assert!(!backend_restart_required("redis", None));
     }
 
     #[test]

--- a/crates/waf-engine/src/engine.rs
+++ b/crates/waf-engine/src/engine.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
 use arc_swap::ArcSwap;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use waf_common::{DetectionResult, InteropMode, RequestCtx, RuleAction, WafAction, WafDecision};
@@ -185,6 +185,12 @@ pub struct WafEngine {
     /// risk-config load (when enabled) and re-attached on every scorer
     /// rebuild. HMAC secret and nonce store are start-time only.
     risk_challenge_verifier: OnceLock<Arc<ChallengeVerifier>>,
+    /// Backend actually running behind the scorer (`"memory"` or `"redis"`),
+    /// set once by [`Self::start_risk_watcher`]. May differ from
+    /// `RiskConfig.store.backend` after a redis connect fallback. Surfaced to
+    /// the admin API so a PUT that changes the backend can report
+    /// "restart required" instead of a silent no-op.
+    risk_active_backend: OnceLock<String>,
     // ── FR-007/FR-042 relay-intel feed metadata (D3) ─────────────────────────
     /// Threat-intel feed metadata (Tor / ASN / datacenter), loaded from
     /// `configs/relay.yaml` at startup via [`Self::load_relay_feeds`]. Empty
@@ -327,6 +333,7 @@ impl WafEngine {
             risk_canary,
             risk_seed: OnceLock::new(),
             risk_challenge_verifier: OnceLock::new(),
+            risk_active_backend: OnceLock::new(),
             relay_feeds: ArcSwap::from_pointee(Vec::new()),
         }
     }
@@ -348,9 +355,11 @@ impl WafEngine {
 
     /// Build a risk store from `RiskConfig.store`. Fail-soft: any redis
     /// failure (feature absent, connect/ping error) falls back to the
-    /// in-memory store so the gateway never refuses to start.
+    /// in-memory store so the gateway never refuses to start. Returns the
+    /// store together with the backend name actually built (`"redis"` or
+    /// `"memory"`) so callers can detect a fallback downgrade.
     #[cfg_attr(not(feature = "redis-store"), allow(clippy::unused_async))]
-    async fn build_risk_store(cfg: &RiskConfig) -> Arc<dyn RiskStore> {
+    async fn build_risk_store(cfg: &RiskConfig) -> (Arc<dyn RiskStore>, &'static str) {
         if cfg.store.backend == "redis" {
             #[cfg(feature = "redis-store")]
             {
@@ -366,7 +375,7 @@ impl WafEngine {
                 match connect.await {
                     Ok(Ok(store)) => {
                         info!("risk: redis store connected");
-                        return Arc::new(store);
+                        return (Arc::new(store), "redis");
                     }
                     Ok(Err(e)) => {
                         warn!(error = %e, "risk: redis store connect failed; falling back to memory store");
@@ -384,7 +393,7 @@ impl WafEngine {
         // before the Arc is unsized to `Arc<dyn RiskStore>`.
         let ttl_ms = i64::try_from(cfg.ttl_secs.saturating_mul(1000)).unwrap_or(i64::MAX);
         store.start_purge_loop(ttl_ms, cfg.gc_interval_secs, Arc::new(crate::time::SystemClock));
-        store
+        (store, "memory")
     }
 
     /// Build a scorer over `store` sharing the engine's config snapshot and
@@ -455,10 +464,19 @@ impl WafEngine {
         let mut active_backend = "memory".to_string();
         match RiskConfig::from_path(path) {
             Ok(cfg) => {
-                let store = Self::build_risk_store(&cfg).await;
+                let (store, built_backend) = Self::build_risk_store(&cfg).await;
+                if cfg.store.backend != built_backend {
+                    // error-level on purpose: the operator asked for a shared
+                    // store and is silently running per-instance memory.
+                    error!(
+                        requested = %cfg.store.backend,
+                        active = %built_backend,
+                        "risk: requested store backend unavailable; running degraded on the memory store (restart to retry)"
+                    );
+                }
                 self.init_risk_layers(&cfg);
                 self.scorer.store(Arc::new(self.build_scorer(store)));
-                active_backend.clone_from(&cfg.store.backend);
+                active_backend = built_backend.to_string();
                 self.replace_risk_config((*cfg).clone());
                 info!(file = %path.display(), backend = %active_backend, "risk: initial config loaded");
             }
@@ -466,6 +484,7 @@ impl WafEngine {
                 warn!(file = %path.display(), error = %e, "risk: initial load failed; risk scoring stays disabled");
             }
         }
+        let _ = self.risk_active_backend.set(active_backend.clone());
         let canary = Arc::clone(&self.risk_canary);
         let risk_cfg = Arc::clone(&self.risk_cfg);
         let result = RiskReloader::start(path.to_path_buf(), RISK_DEBOUNCE_MS, move |cfg| {
@@ -492,6 +511,14 @@ impl WafEngine {
                 "risk: hot-reload watcher failed to start; running without hot-reload"
             ),
         }
+    }
+
+    /// Admin API: the risk-store backend actually running (`"memory"` or
+    /// `"redis"`). `None` until [`Self::start_risk_watcher`] has run. May
+    /// differ from the configured `store.backend` after a redis connect
+    /// fallback, so it doubles as the downgrade-detection surface.
+    pub fn risk_store_backend(&self) -> Option<&str> {
+        self.risk_active_backend.get().map(String::as_str)
     }
 
     /// Admin API: remove an actor's risk state (all axes reachable from the
@@ -1843,7 +1870,8 @@ mod tests {
             gc_interval_secs: 1,
             ..RiskConfig::default()
         };
-        let store = WafEngine::build_risk_store(&cfg).await;
+        let (store, built) = WafEngine::build_risk_store(&cfg).await;
+        assert_eq!(built, "memory");
 
         let key = RiskKey::from_ip("198.51.100.77".parse().expect("ip"));
         let stale_ms = chrono::Utc::now().timestamp_millis() - 10_000;
@@ -1876,7 +1904,8 @@ mod tests {
         cfg.store.backend = "redis".to_string();
         cfg.store.redis.url = "redis://127.0.0.1:1".to_string();
 
-        let store = WafEngine::build_risk_store(&cfg).await;
+        let (store, built) = WafEngine::build_risk_store(&cfg).await;
+        assert_eq!(built, "memory", "fallback must report the memory backend, not the requested one");
         assert!(store.is_empty().await, "fallback memory store must start empty");
     }
 
@@ -1895,7 +1924,8 @@ mod tests {
         cfg.store.redis.url = url;
         cfg.store.redis.key_prefix = format!("waf:risk:enginetest:{now_ms}:");
 
-        let store = WafEngine::build_risk_store(&cfg).await;
+        let (store, built) = WafEngine::build_risk_store(&cfg).await;
+        assert_eq!(built, "redis");
         let key = crate::risk::key::RiskKey::from_ip("10.98.98.98".parse().unwrap());
         let bump = crate::risk::state::Contributor::new(
             crate::risk::state::ContributorKind::Signal("engine_test".to_string()),
@@ -1919,8 +1949,17 @@ mod tests {
         let path = dir.path().join("risk.yaml");
         std::fs::write(&path, "risk:\n  enabled: false\n").expect("write initial");
 
+        assert!(
+            engine.risk_store_backend().is_none(),
+            "no active backend reported before the watcher starts"
+        );
         engine.start_risk_watcher(&path).await;
         assert!(!engine.risk_cfg.load().enabled, "initial config has enabled=false");
+        assert_eq!(
+            engine.risk_store_backend(),
+            Some("memory"),
+            "watcher must record the store backend actually built"
+        );
 
         std::fs::write(&path, "risk:\n  enabled: true\n  canary:\n    paths:\n      - /trap\n").expect("write update");
 


### PR DESCRIPTION
Closes #228

> **Stacked on #237** (`fix/gh-224-seed-challenge-scorer-wiring`) because both edit the `start_risk_watcher` Ok-branch and the engine struct fields — merging #237 first avoids a manual conflict resolution. GitHub retargets this PR to `main-harness` automatically once #237 merges and its branch is deleted. The diff below shows only this PR's delta.

## Root cause
Two silent paths hid the real store backend from the operator:
1. `put_risk_config` returned bare `success:true`; the engine's reload closure keeps the active store when `store.backend` changes (start-time-only by design), so a memory→redis switch got 200 OK while scores kept vanishing on restart (undercuts #198).
2. `build_risk_store` falls back redis→memory on a 5s connect timeout with one `warn!`, and `start_risk_watcher` then recorded the **requested** backend as active — so even the reload-closure "restart required" warning compared against the wrong value, and nothing downstream could detect the downgrade.

## Fix
**Engine** (`crates/waf-engine/src/engine.rs`)
- `build_risk_store` returns `(store, "redis" | "memory")` — the backend actually built.
- `start_risk_watcher` logs an **error-level** "requested store backend unavailable; running degraded on the memory store" line on fallback, records the actual backend in a new `risk_active_backend: OnceLock<String>`, and the reload closure now compares requested vs **actual**. So after a fallback, a hot-reload that still says `redis` correctly warns restart-required.
- New `WafEngine::risk_store_backend() -> Option<&str>` (None until the watcher starts).

**API** (`crates/waf-api/src/risk_api.rs`)
- `PUT /api/risk/config` response now carries `restart_required: bool` + `active_store_backend` and, when flagged, a `message` explaining the saved value takes effect after a gateway restart. The write still succeeds (config file is the restart-time source of truth) — it's flagged, not silently OK'd.
- `GET /api/risk/config` includes `active_store_backend`, giving operators a downgrade-detection surface (file says `redis`, active says `memory`).
- Extracted pure `backend_restart_required(requested, active)` for the decision logic. Additive envelope keys only — existing FE `data` handling untouched.

## Acceptance criteria
- [x] Backend change surfaces in the API response as restart-required
- [x] Startup redis fallback logged prominently (error-level) **and** detectable via GET `active_store_backend`
- [x] Test: PUT changing `store.backend` is flagged, not silently 200-OK'd (`backend_change_flags_restart_required` matrix incl. fallback + not-started cases)

## Verification
- `cargo test -p waf-api --lib risk_api`: 4 passed (includes the new matrix test).
- `cargo test -p waf-engine --lib build_risk_store_redis_unreachable_falls_back_to_memory`: passes locally (docker-free) — now also asserts the reported backend is `memory`.
- `risk_watcher_hot_reloads_config_and_canary` extended to assert the getter (None before / `Some("memory")` after start); runs in CI (needs the Postgres testcontainer; docker unavailable on this machine).
- `cargo clippy -p waf-engine -p waf-api --all-targets`: clean.

## Conflict notes (bug-fix PR stack)
- `risk_api.rs`: helper + handler edits sit between #235's (tests appended at end) and #236's (test at top) hunks; the new unit test is inserted mid-module. Expected clean 3-way merges with both.
- `engine.rs`: overlaps only with #237, handled by stacking (above). #226/#227 (upcoming) touch `inspect()` / the purge path — the `build_risk_store` signature change here is what #227 will build on.

https://claude.ai/code/session_018YtgAuSKSMHKBJEuJtVuzV