### PR TITLE
fix(geo-api): reject geo rule actions the engine does not implement

### DIFF
--- a/crates/waf-api/src/geo_api.rs
+++ b/crates/waf-api/src/geo_api.rs
@@ -39,6 +39,25 @@ fn next_id(rules: &[Value]) -> i64 {
         + 1
 }
 
+/// Actions the engine's geo loader implements. `parse_geo_rules` groups rows
+/// into allow / block sets and treats every non-"allow" action as Block, so
+/// accepting anything else (challenge, log, …) would echo the value back as
+/// honored while the engine hard-blocks the country.
+const SUPPORTED_GEO_ACTIONS: [&str; 2] = ["allow", "block"];
+
+fn validate_geo_action(value: &Value) -> Result<&str, ApiError> {
+    let action = value
+        .as_str()
+        .ok_or_else(|| ApiError::BadRequest("geo rule action must be a string".to_string()))?;
+    if SUPPORTED_GEO_ACTIONS.contains(&action) {
+        Ok(action)
+    } else {
+        Err(ApiError::BadRequest(format!(
+            "unsupported geo rule action {action:?}: the engine implements only \"allow\" and \"block\""
+        )))
+    }
+}
+
 // ─── Handlers ─────────────────────────────────────────────────────────────────
 
 pub async fn list_geo_rules(State(state): State<Arc<AppState>>) -> ApiResult<Json<Value>> {
@@ -57,12 +76,16 @@ pub async fn create_geo_rule(State(state): State<Arc<AppState>>, Json(body): Jso
         .and_then(|v| v.as_str())
         .unwrap_or("XX")
         .to_uppercase();
+    let action = match body.get("action") {
+        Some(v) => validate_geo_action(v)?,
+        None => "block",
+    };
 
     let new_rule = json!({
         "id":           next_id(&rules),
         "iso_code":     iso,
         "country_name": body.get("country_name"),
-        "action":       body.get("action").and_then(|v| v.as_str()).unwrap_or("block"),
+        "action":       action,
         "scope":        body.get("scope").and_then(|v| v.as_str()).unwrap_or("global"),
         "enabled":      true,
         "fail_closed":  body.get("fail_closed").and_then(Value::as_bool).unwrap_or(false),
@@ -87,6 +110,9 @@ pub async fn patch_geo_rule(
         .position(|r| r.get("id").and_then(Value::as_i64) == Some(id))
         .ok_or_else(|| ApiError::NotFound(format!("geo rule {id} not found")))?;
 
+    if let Some(v) = body.get("action") {
+        validate_geo_action(v)?;
+    }
     if let Some(obj) = rules.get_mut(idx).and_then(Value::as_object_mut) {
         for field in &["enabled", "action", "scope", "fail_closed"] {
             if let Some(v) = body.get(*field) {
@@ -140,5 +166,27 @@ pub async fn lookup_ip(State(state): State<Arc<AppState>>, Json(body): Json<Valu
                 "isp":          null
             }
         }))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Only actions the engine geo loader implements pass; anything else
+    /// (including the UI's former "challenge"/"log" options, which the engine
+    /// would silently coerce to Block) is a 400, as is a non-string action.
+    #[test]
+    fn action_validation_matches_engine_supported_set() {
+        assert_eq!(validate_geo_action(&json!("allow")).unwrap(), "allow");
+        assert_eq!(validate_geo_action(&json!("block")).unwrap(), "block");
+        for bad in ["challenge", "log", "Block", "deny", ""] {
+            assert!(
+                matches!(validate_geo_action(&json!(bad)), Err(ApiError::BadRequest(_))),
+                "action {bad:?} must be rejected"
+            );
+        }
+        assert!(matches!(validate_geo_action(&json!(5)), Err(ApiError::BadRequest(_))));
+        assert!(matches!(validate_geo_action(&Value::Null), Err(ApiError::BadRequest(_))));
     }
 }

--- a/crates/waf-api/tests/handler_geo_rules.rs
+++ b/crates/waf-api/tests/handler_geo_rules.rs
@@ -186,3 +186,58 @@ async fn fail_closed_round_trips_through_create_and_patch() {
     let rules = map.get("*").expect("global host rules");
     assert!(!rules[0].fail_closed);
 }
+
+/// Actions the engine has no geo implementation for ("challenge", "log")
+/// must be rejected with 400 by create and patch — never persisted and
+/// echoed back as honored while `parse_geo_rules` coerces them to Block.
+#[tokio::test(flavor = "multi_thread")]
+async fn unsupported_action_is_rejected_not_silently_coerced_to_block() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let main_cfg = dir.path().join("config/waf.yaml");
+    let s = start_test_server_with_main_config(main_cfg.to_str().unwrap()).await;
+
+    for bad in ["challenge", "log"] {
+        let resp = client()
+            .post(url_for(s.addr, "/api/geoip/rules"))
+            .bearer_auth(&s.admin_token)
+            .json(&json!({ "iso_code": "US", "action": bad }))
+            .send()
+            .await
+            .expect("create send");
+        assert_eq!(resp.status(), 400, "create with action {bad:?} must be rejected");
+    }
+
+    // Nothing was persisted by the rejected creates.
+    let rules_file = dir.path().join("configs/geo-rules.yaml");
+    assert!(
+        parse_geo_rules(&rules_file).map_or(true, |m| m.is_empty()),
+        "rejected creates must not write rules"
+    );
+
+    // A valid rule can be created, but cannot be patched to an unsupported action.
+    let created: serde_json::Value = client()
+        .post(url_for(s.addr, "/api/geoip/rules"))
+        .bearer_auth(&s.admin_token)
+        .json(&json!({ "iso_code": "US", "action": "allow" }))
+        .send()
+        .await
+        .expect("create send")
+        .json()
+        .await
+        .expect("create json");
+    let id = created["data"]["id"].as_i64().expect("rule id");
+
+    let resp = client()
+        .patch(url_for(s.addr, &format!("/api/geoip/rules/{id}")))
+        .bearer_auth(&s.admin_token)
+        .json(&json!({ "action": "challenge" }))
+        .send()
+        .await
+        .expect("patch send");
+    assert_eq!(resp.status(), 400, "patch to an unsupported action must be rejected");
+
+    // The stored rule still parses as the allow rule the engine enforces.
+    let map = parse_geo_rules(&rules_file).expect("engine loader parses API file");
+    let rules = map.get("*").expect("global host rules");
+    assert_eq!(rules[0].mode, GeoRuleMode::AllowOnly);
+}

--- a/web/admin-panel/src/pages/geo-restriction/geo-shared.ts
+++ b/web/admin-panel/src/pages/geo-restriction/geo-shared.ts
@@ -1,10 +1,15 @@
 import type { TopEntry } from "../../types/api";
 
+// The engine's geo loader implements exactly two actions: "allow" and
+// "block" (waf-engine parse_geo_rules). The API rejects anything else with
+// 400, so the UI must not offer unsupported values like challenge/log.
+export type GeoAction = "block" | "allow";
+
 export interface GeoRule {
   id: number;
   iso_code: string;
   country_name?: string;
-  action: "block" | "challenge" | "log" | "allow";
+  action: GeoAction;
   scope: "global" | string;
   enabled: boolean;
   created_at?: string;
@@ -24,7 +29,7 @@ export interface GeoStat {
 
 export interface AddForm {
   iso_code: string;
-  action: "block" | "challenge" | "log" | "allow";
+  action: GeoAction;
   scope: string;
 }
 
@@ -83,7 +88,5 @@ export const countryLabel = (iso: string, name?: string) => {
 
 export const ACTION_OPTIONS = [
   { value: "block", label: "block" },
-  { value: "challenge", label: "challenge" },
-  { value: "log", label: "log" },
   { value: "allow", label: "allow" },
 ];

--- a/web/admin-panel/src/pages/geo-restriction/index.tsx
+++ b/web/admin-panel/src/pages/geo-restriction/index.tsx
@@ -13,7 +13,7 @@ export const GeoRestrictionPage: React.FC = () => {
           {t("geo.title", { defaultValue: "Geo Restriction (FR-041)" })}
         </Typography.Title>
         <Typography.Text type="secondary">
-          {t("geo.subtitle", { defaultValue: "Block or challenge requests by country via GeoIP" })}
+          {t("geo.subtitle", { defaultValue: "Block or allow requests by country via GeoIP" })}
         </Typography.Text>
       </div>
 

--- a/web/admin-panel/src/pages/geo-restriction/rules-tab.tsx
+++ b/web/admin-panel/src/pages/geo-restriction/rules-tab.tsx
@@ -221,12 +221,7 @@ export const RulesTab: React.FC = () => {
           allowClear
           value={actionFilter}
           onChange={setActionFilter}
-          options={[
-            { value: "block", label: "block" },
-            { value: "challenge", label: "challenge" },
-            { value: "log", label: "log" },
-            { value: "allow", label: "allow" },
-          ]}
+          options={ACTION_OPTIONS}
         />
         <Button type="primary" icon={<PlusOutlined />} onClick={() => { addForm.resetFields(); setDrawerOpen(true); }}>
           {t("geo.addCountry", { defaultValue: "Add country" })}


### PR DESCRIPTION
Closes #229

## Root cause
`create_geo_rule` accepted an arbitrary `action` string (`crates/waf-api/src/geo_api.rs`) and `patch_geo_rule` inserted any JSON value verbatim, while the engine's `parse_geo_rules` (`crates/waf-engine/src/checks/geo_config.rs`) groups rows into allow/block sets and treats **everything except `"allow"` as Block**. The admin panel offered `challenge` and `log` in `ACTION_OPTIONS` — picking "challenge" silently hard-blocked the country while the API echoed the bogus action back as honored.

## Fix (per AC option 1: reject with 400 + align UI)
**API**
- New `validate_geo_action`: only `"allow"` / `"block"` pass. Applied in `create_geo_rule` (missing action still defaults to `"block"`, unchanged) and `patch_geo_rule` (which also now rejects non-string `action` values it previously stored verbatim).
- Unsupported values → `400 BadRequest` with a message naming the supported set. Nothing is persisted.

**Admin panel**
- `geo-shared.ts`: `GeoAction = "block" | "allow"` union replaces the 4-value union in `GeoRule`/`AddForm`; `ACTION_OPTIONS` trimmed to block/allow with a comment pointing at the engine contract.
- `rules-tab.tsx`: the action filter now reuses `ACTION_OPTIONS` instead of its own 4-value list.
- `index.tsx`: subtitle default no longer claims challenge support ("Block or allow requests by country via GeoIP").

Existing persisted rules with `action: challenge|log` keep their current effective behavior (engine blocks them); the UI will show the raw value and any edit must move them to a supported action.

## Tests
- Unit (`geo_api::tests::action_validation_matches_engine_supported_set`): allow/block pass; challenge, log, `"Block"` (case), deny, empty string, number, and null are rejected — **passes locally**.
- Integration (`handler_geo_rules::unsupported_action_is_rejected_not_silently_coerced_to_block`): POST with challenge/log → 400 and nothing persisted; PATCH of a valid allow rule to challenge → 400; stored file still parses to the engine's `AllowOnly` mode. Compiles locally; runs in CI (testcontainer harness, docker unavailable on this machine).
- `npx tsc --noEmit` clean; `cargo clippy -p waf-api --all-targets` clean.

## Conflict notes (bug-fix PR stack)
Touches `geo_api.rs`, `handler_geo_rules.rs`, and the geo-restriction pages — no other PR in the stack (#235–#239, upcoming #226/#227/#230–#232) modifies these files. Independent of the #237→#239 stack; merges cleanly in any order.

https://claude.ai/code/session_018YtgAuSKSMHKBJEuJtVuzV