### PR TITLE
fix(risk): feed device fingerprint and rule-match deltas into enforcement scoring

### DIFF
--- a/crates/waf-engine/src/engine.rs
+++ b/crates/waf-engine/src/engine.rs
@@ -874,11 +874,20 @@ impl WafEngine {
         let inspect_time = chrono::Utc::now();
         let now_ms = inspect_time.timestamp_millis();
 
-        let (mut decision, fast_path) = self.inspect_pipeline(ctx).await;
+        let mut rule_deltas: Vec<crate::risk::state::Contributor> = Vec::new();
+        let (mut decision, fast_path) = self.inspect_pipeline(ctx, &mut rule_deltas).await;
         // Fast-path exits (guard off, IP/URL allow/block lists) skip risk
         // scoring entirely: no store write, risk_score stays 0.
+        //
+        // The scorer receives the request's device fingerprint (so risk
+        // accrued on the fp axis — e.g. by the ingest worker — is read at
+        // enforcement) and the risk deltas from every matched custom rule.
         if matches!(fast_path, FastPath::Miss)
-            && let Ok(scorer_result) = self.scorer.load_full().score(ctx, None, &[], None, now_ms).await
+            && let Ok(scorer_result) = self
+                .scorer
+                .load_full()
+                .score(ctx, ctx.device_fp.as_deref(), &rule_deltas, None, now_ms)
+                .await
         {
             let risk_score = scorer_result.score.min(100);
             decision.risk_score = risk_score;
@@ -936,7 +945,14 @@ impl WafEngine {
     /// outer wrapper can attach the risk score to every decision without
     /// rewriting each early-return branch. The `FastPath` tag tells the
     /// wrapper whether the decision came from a pre-scoring fast-path exit.
-    async fn inspect_pipeline(&self, ctx: &mut RequestCtx) -> (WafDecision, FastPath) {
+    ///
+    /// `rule_deltas` is an out-parameter: risk deltas from matched custom
+    /// rules accumulate here so the wrapper can feed them to the scorer.
+    async fn inspect_pipeline(
+        &self,
+        ctx: &mut RequestCtx,
+        rule_deltas: &mut Vec<crate::risk::state::Contributor>,
+    ) -> (WafDecision, FastPath) {
         // Skip WAF if guard is disabled for this host
         if !ctx.host_config.guard_status {
             return (WafDecision::allow(), FastPath::Hit);
@@ -1089,7 +1105,15 @@ impl WafEngine {
         }
 
         // ── Phase 12: Custom rules engine ─────────────────────────────────────
-        if let Some(result) = self.custom_rules.check(ctx) {
+        let rule_verdict = self.custom_rules.check_with_verdict(ctx);
+        if !rule_verdict.risk_deltas.is_empty() {
+            let ts_ms = chrono::Utc::now().timestamp_millis();
+            rule_deltas.extend(crate::risk::score::rule_deltas_to_contributors(
+                &rule_verdict.risk_deltas,
+                ts_ms,
+            ));
+        }
+        if let Some(result) = rule_verdict.result {
             let rule_name = result.rule_name.clone();
             // Custom rules carry their own action intent/status overrides, so this
             // branch builds the action directly instead of using make_block_decision.
@@ -1886,5 +1910,121 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(400)).await;
         assert!(engine.risk_cfg.load().enabled, "bad YAML must keep previous snapshot");
         assert!(engine.risk_canary.check("/trap"), "bad YAML must keep canary paths");
+    }
+
+    /// A non-blocking custom rule that adds `risk_delta` when `path` contains
+    /// `path_fragment`. Log action so the pipeline decision stays a plain
+    /// Allow and only the risk deltas drive the outcome.
+    fn risk_delta_rule(id: &str, path_fragment: &str, delta: i16) -> crate::rules::engine::CustomRule {
+        use crate::rules::engine::{Condition, ConditionField, ConditionOp, ConditionValue, CustomRule, Operator};
+
+        CustomRule {
+            id: id.into(),
+            host_code: "*".into(),
+            name: id.into(),
+            priority: 1,
+            enabled: true,
+            condition_op: ConditionOp::And,
+            conditions: vec![Condition {
+                field: ConditionField::Path,
+                operator: Operator::Contains,
+                value: ConditionValue::Str(path_fragment.into()),
+            }],
+            action: RuleAction::Log,
+            action_status: 200,
+            action_msg: None,
+            script: None,
+            match_tree: None,
+            risk_delta: Some(delta),
+            risk_action: None,
+            pattern: None,
+            pattern_field: "all".into(),
+            category: None,
+            severity: None,
+            paranoia: None,
+            tags: Vec::new(),
+            metadata: HashMap::new(),
+            reference: None,
+        }
+    }
+
+    fn device_fp(tag: &str) -> Arc<waf_common::FpKey> {
+        Arc::new(waf_common::FpKey {
+            ja3: Some(waf_common::FingerprintValue::new(tag)),
+            ..waf_common::FpKey::default()
+        })
+    }
+
+    /// Risk deltas from matched custom rules must reach the scorer: a +80
+    /// delta lands the actor in the challenge band (default thresholds
+    /// allow=30 / block=90) on the very request that matched.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rule_match_risk_deltas_raise_cumulative_score() {
+        let (engine, _container) = spawn_engine().await;
+        engine.replace_risk_config(enabled_risk_config());
+        engine.custom_rules.add_file_rule(risk_delta_rule("gh226-bump", "/attack", 80));
+
+        let mut ctx = make_ctx("risk-test", "/attack/probe", "203.0.113.60");
+        let decision = engine.inspect(&mut ctx).await;
+        assert_eq!(
+            decision.risk_score, 80,
+            "rule risk_delta must contribute to the cumulative score"
+        );
+        assert!(
+            matches!(decision.action, WafAction::Challenge),
+            "score 80 must land in the challenge band, got {:?}",
+            decision.action
+        );
+        let result = decision.result.as_ref().expect("risk challenge must carry a result");
+        assert_eq!(result.rule_name, "cumulative_risk");
+
+        // A path the rule does not match stays clean for a fresh actor.
+        let mut ctx = make_ctx("risk-test", "/clean", "203.0.113.61");
+        let decision = engine.inspect(&mut ctx).await;
+        assert_eq!(decision.risk_score, 0);
+        assert!(matches!(decision.action, WafAction::Allow));
+    }
+
+    /// Risk accrued on the fingerprint axis must be read back at enforcement:
+    /// an actor that earned risk under one IP is still challenged from a
+    /// different IP when the request carries the same device fingerprint.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn fp_axis_risk_enforces_across_ips() {
+        let (engine, _container) = spawn_engine().await;
+        engine.replace_risk_config(enabled_risk_config());
+        engine.custom_rules.add_file_rule(risk_delta_rule("gh226-fp", "/attack", 80));
+
+        // Accrue risk under IP A with fingerprint X.
+        let mut ctx = make_ctx("risk-test", "/attack/probe", "203.0.113.70");
+        ctx.device_fp = Some(device_fp("gh226-ja3"));
+        let decision = engine.inspect(&mut ctx).await;
+        assert!(
+            matches!(decision.action, WafAction::Challenge),
+            "delta request must challenge, got {:?}",
+            decision.action
+        );
+
+        // Same fingerprint from a different IP on a benign path: the fp-axis
+        // state must surface (fp_key=None would score this as a fresh actor).
+        let mut ctx = make_ctx("risk-test", "/clean", "198.51.100.70");
+        ctx.device_fp = Some(device_fp("gh226-ja3"));
+        let decision = engine.inspect(&mut ctx).await;
+        assert!(
+            decision.risk_score >= 70,
+            "fp-axis risk must be read at enforcement, got score {}",
+            decision.risk_score
+        );
+        assert!(
+            matches!(decision.action, WafAction::Challenge),
+            "same-fp request from a new IP must challenge, got {:?}",
+            decision.action
+        );
+
+        // Control: a different fingerprint from another fresh IP stays clean.
+        let mut ctx = make_ctx("risk-test", "/clean", "198.51.100.71");
+        ctx.device_fp = Some(device_fp("gh226-other"));
+        let decision = engine.inspect(&mut ctx).await;
+        assert_eq!(decision.risk_score, 0, "unrelated fingerprint must not inherit risk");
+        assert!(matches!(decision.action, WafAction::Allow));
     }
 }


### PR DESCRIPTION
Closes #226

## Problem

`WafEngine::inspect()` called `scorer.score(ctx, None, &[], None, now_ms)`:

- `fp_key = None` — risk written on the **fingerprint axis** (e.g. by the FR-025 ingest worker) was never read at enforcement; only the IP/session axes counted. An actor could rotate IPs and shed all fp-accrued risk.
- `sync_deltas = &[]` — `risk_delta` contributions from matched custom rules were collected by `check_with_verdict()` but the pipeline called plain `check()`, so they never reached the scorer. The `score_with_l2` fold was dead in the engine path.

## Fix

- `inspect_pipeline` takes a `&mut Vec<Contributor>` out-parameter; Phase 12 switches from `custom_rules.check()` to `check_with_verdict()` and converts the accumulated `RiskDelta`s via `rule_deltas_to_contributors`. All 16 early-return sites are untouched.
- `inspect()` now passes `ctx.device_fp.as_deref()` (the fingerprint captured at the TLS/H2 layer) and the collected rule deltas into `score()`.

## Tests (engine.rs tests mod, appended at end)

- `rule_match_risk_deltas_raise_cumulative_score` — a log-action custom rule with `risk_delta: 80` lands the actor in the challenge band on the matching request (`risk_score == 80`, `cumulative_risk` result); a clean path for a fresh actor stays Allow/0.
- `fp_axis_risk_enforces_across_ips` — risk accrued under IP A with fingerprint X challenges a benign request from IP B carrying the same fingerprint; a different fingerprint from a fresh IP stays clean. Both tests fail without the fix (score would be 0 / fresh-actor).

## Verification

- `cargo test -p waf-engine --lib -- rules:: risk::` — 421 passed (docker-free set).
- New tests use the Postgres testcontainer fixture (`PG_TEST_URL` escape hatch) — they run in CI; local Docker socket is unavailable on this machine.
- `cargo clippy -p waf-engine --all-targets` — no errors.
- `cargo check -p gateway -p waf-api` — dependent crates compile (no public-contract change; `inspect()` signature unchanged).

## Conflict notes

Touches `inspect()`/`inspect_pipeline`/Phase 12 (~lines 875-1130) and appends tests at the end of the tests mod — no overlap with PR #237/#239 hunks (risk watcher/store region, ~lines 150-500, and interior test edits), so this is based directly on `main-harness`.

https://claude.ai/code/session_018YtgAuSKSMHKBJEuJtVuzV