### PR TITLE
fix(risk): schedule velocity/sequence idle-purge loop to bound actor maps

### DIFF
--- a/crates/waf-engine/src/engine.rs
+++ b/crates/waf-engine/src/engine.rs
@@ -475,7 +475,11 @@ impl WafEngine {
                     );
                 }
                 self.init_risk_layers(&cfg);
-                self.scorer.store(Arc::new(self.build_scorer(store)));
+                let scorer = Arc::new(self.build_scorer(store));
+                // Velocity/sequence maps are keyed on attacker-controlled
+                // RiskKeys; the idle-purge loop is what bounds them.
+                scorer.start_velocity_purge_loop(cfg.gc_interval_secs, Arc::new(crate::time::SystemClock));
+                self.scorer.store(scorer);
                 active_backend = built_backend.to_string();
                 self.replace_risk_config((*cfg).clone());
                 info!(file = %path.display(), backend = %active_backend, "risk: initial config loaded");

--- a/crates/waf-engine/src/risk/scorer.rs
+++ b/crates/waf-engine/src/risk/scorer.rs
@@ -53,8 +53,9 @@ pub struct Scorer<S: RiskStore + ?Sized> {
     challenge_verifier: Option<Arc<ChallengeVerifier>>,
     /// L2 anomaly detection layer (JA4↔UA mismatch, XFF, header sanity).
     anomaly: AnomalyLayer,
-    /// L2 velocity detection layer (sliding window, sequence FSM).
-    velocity: VelocityLayer,
+    /// L2 velocity detection layer (sliding window, sequence FSM). Shared
+    /// (`Arc`) so its idle-purge loop can outlive-safely reference it.
+    velocity: Arc<VelocityLayer>,
 }
 
 impl<S: RiskStore + ?Sized> Scorer<S> {
@@ -68,8 +69,15 @@ impl<S: RiskStore + ?Sized> Scorer<S> {
             canary: None,
             challenge_verifier: None,
             anomaly: AnomalyLayer::new(),
-            velocity: VelocityLayer::with_defaults(),
+            velocity: Arc::new(VelocityLayer::with_defaults()),
         }
+    }
+
+    /// Start the velocity/sequence idle-purge loop. Call once per scorer in
+    /// production (the engine does this when the scorer is built); without
+    /// it the velocity maps grow unbounded under attacker-controlled keys.
+    pub fn start_velocity_purge_loop(&self, interval_secs: u64, clock: Arc<dyn crate::time::Clock>) {
+        self.velocity.start_purge_loop(interval_secs, clock);
     }
 
     /// Set the seed layer.

--- a/crates/waf-engine/src/risk/velocity/mod.rs
+++ b/crates/waf-engine/src/risk/velocity/mod.rs
@@ -9,8 +9,15 @@
 pub mod sequence;
 pub mod window;
 
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::time::interval;
+use tracing::debug;
+
 use crate::risk::key::RiskKey;
 use crate::risk::state::Contributor;
+use crate::time::Clock;
 
 pub use sequence::{SEQUENCE_VIOLATION_DELTA, SequenceStore, SequenceViolation, TxEndpoint};
 pub use window::{VELOCITY_THRESHOLD_DELTA, VelocityStore};
@@ -69,6 +76,27 @@ impl VelocityLayer {
         let velocity_purged = self.velocity.purge_idle(now_ms);
         let sequence_purged = self.sequence.purge_idle();
         (velocity_purged, sequence_purged)
+    }
+
+    /// Spawn a background task that periodically purges idle actors from
+    /// both stores. Keys are attacker-controlled (full `RiskKey`: cookie,
+    /// IPv6, fingerprint), so without this loop a key spray grows the maps
+    /// unbounded. Mirrors `MemoryRiskStore::start_purge_loop`.
+    pub fn start_purge_loop(self: &Arc<Self>, interval_secs: u64, clock: Arc<dyn Clock>) {
+        let layer = Arc::clone(self);
+        tokio::spawn(async move {
+            let mut tick = interval(Duration::from_secs(interval_secs));
+            loop {
+                tick.tick().await;
+                let (velocity_purged, sequence_purged) = layer.purge_idle(clock.now_ms());
+                if velocity_purged > 0 || sequence_purged > 0 {
+                    debug!(
+                        velocity_purged,
+                        sequence_purged, "velocity layer: purged idle actors"
+                    );
+                }
+            }
+        });
     }
 
     /// Number of tracked actors in velocity store.
@@ -159,5 +187,45 @@ mod tests {
 
         // Velocity should purge, sequence might not (depends on state)
         assert!(v > 0 || s > 0);
+    }
+
+    /// The scheduled purge loop bounds the maps under a key spray: distinct
+    /// attacker-controlled keys stop accumulating once their windows go idle
+    /// and their sequence state returns to Idle — no caller ever invokes
+    /// `purge_idle` by hand.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn purge_loop_reaps_idle_actors_under_key_spray() {
+        use crate::time::test_utils::MockClock;
+
+        let layer = Arc::new(VelocityLayer::new(100));
+
+        // Spray 512 distinct IP keys at t=0. Otp-without-login is a violation
+        // that leaves the sequence state Idle, so both maps fill and both are
+        // reapable once idle.
+        for a in 0..2u8 {
+            for b in 0..=255u8 {
+                let ip = IpAddr::V4(Ipv4Addr::new(10, 99, a, b));
+                let _ = layer.evaluate(&RiskKey::from_ip(ip), Some(TxEndpoint::Otp), 0);
+            }
+        }
+        assert_eq!(layer.velocity_len(), 512);
+        assert_eq!(layer.sequence_len(), 512);
+
+        // Clock far past the 60s window: every entry is idle on first tick.
+        let clock = Arc::new(MockClock::new(120_000));
+        layer.start_purge_loop(1, clock);
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            if layer.velocity_len() == 0 && layer.sequence_len() == 0 {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        panic!(
+            "purge loop never drained the stores: velocity={}, sequence={}",
+            layer.velocity_len(),
+            layer.sequence_len()
+        );
     }
 }


### PR DESCRIPTION
Closes #227. Part of #223.

**Stacked on #239** (`fix/gh-228-risk-backend-restart-required`) because both edit `start_risk_watcher`'s initial-load branch; GitHub will retarget this PR to `main-harness` automatically once #239 merges and its branch is deleted. Merge order: #237 → #239 → this.

## Problem

`VelocityLayer::purge_idle` was called only from tests — no purge loop existed in the engine or gateway. The velocity sliding-window and sequence-FSM `DashMap`s are keyed on the full `RiskKey` (attacker-controlled: cookies, IPv6 addresses, fingerprints), so a key spray both evades the per-minute window (fresh window per key) and grows the maps unbounded → memory-exhaustion DoS.

## Fix

- `VelocityLayer::start_purge_loop(interval_secs, clock)` — background tokio task purging both stores each tick, mirroring `MemoryRiskStore::start_purge_loop` (same Clock abstraction, same debug-log shape).
- `Scorer.velocity` becomes `Arc<VelocityLayer>` with a `start_velocity_purge_loop` passthrough.
- `start_risk_watcher` starts the loop on `cfg.gc_interval_secs` (the same knob that paces the risk-store GC; config validation already rejects 0) when the scorer is built.

The `MemoryRiskStore` session/fp index growth mentioned in the issue is already bounded by that store's existing purge loop; no change needed there.

## Tests

- `purge_loop_reaps_idle_actors_under_key_spray` (velocity mod, docker-free): sprays 512 distinct IP keys (OTP-without-login, so both maps fill and sequence state stays Idle/reapable), asserts both maps hold 512, then starts the loop with a `MockClock` past the 60s window and asserts both maps drain to 0 with nobody calling `purge_idle` manually. Fails without the fix (maps never shrink).

## Verification

- `cargo test -p waf-engine --lib -- risk:: rules::` — 422 passed.
- `cargo clippy -p waf-engine --all-targets` — no errors.
- `cargo check -p gateway -p waf-api` — dependents compile; no public-contract change (`Scorer::new` signature unchanged).

https://claude.ai/code/session_018YtgAuSKSMHKBJEuJtVuzV