### PR TITLE
fix(risk-api): return 501 from metrics/actors stubs instead of fabricated data

### DIFF
--- a/crates/waf-api/src/error.rs
+++ b/crates/waf-api/src/error.rs
@@ -23,6 +23,9 @@ pub enum ApiError {
     #[error("Payload too large: {0}")]
     PayloadTooLarge(String),
 
+    #[error("Not implemented: {0}")]
+    NotImplemented(String),
+
     #[error("Internal server error: {0}")]
     Internal(#[from] anyhow::Error),
 
@@ -38,6 +41,7 @@ impl IntoResponse for ApiError {
             Self::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg.clone()),
             Self::TooManyRequests(msg) => (StatusCode::TOO_MANY_REQUESTS, msg.clone()),
             Self::PayloadTooLarge(msg) => (StatusCode::PAYLOAD_TOO_LARGE, msg.clone()),
+            Self::NotImplemented(msg) => (StatusCode::NOT_IMPLEMENTED, msg.clone()),
             Self::Internal(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
             Self::Storage(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
         };
@@ -98,6 +102,14 @@ mod tests {
         let (status, msg) = read_body_message(resp).await;
         assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
         assert_eq!(msg, "slow down");
+    }
+
+    #[tokio::test]
+    async fn not_implemented_maps_to_501() {
+        let resp = ApiError::NotImplemented("no metrics yet".into()).into_response();
+        let (status, msg) = read_body_message(resp).await;
+        assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
+        assert_eq!(msg, "no metrics yet");
     }
 
     #[tokio::test]

--- a/crates/waf-api/src/risk_api.rs
+++ b/crates/waf-api/src/risk_api.rs
@@ -111,14 +111,13 @@ pub async fn put_risk_config(State(state): State<Arc<AppState>>, Json(body): Jso
     Ok(Json(resp))
 }
 
+/// Metrics aggregation does not exist yet: `RiskStore` has no query surface
+/// for counts or score percentiles. 501 keeps the UI from rendering zero
+/// KPIs as if the system were healthy and idle.
 pub async fn get_risk_metrics(_: State<Arc<AppState>>) -> ApiResult<Json<Value>> {
-    Ok(Json(json!({
-        "success": true,
-        "data": {
-            "actor_count": 0, "avg_score": 0, "p95_score": 0,
-            "scored_last_hour": 0, "blocked_last_hour": 0, "challenged_last_hour": 0
-        }
-    })))
+    Err(ApiError::NotImplemented(
+        "risk metrics are not implemented; the risk store has no aggregation query yet".into(),
+    ))
 }
 
 #[derive(Deserialize)]
@@ -128,14 +127,13 @@ pub struct ActorsQuery {
     pub page: Option<i64>,
 }
 
-/// **STUB — v1 placeholder.**
-///
-/// Returns an empty actor list; real-time risk-actor tracking is not yet
-/// implemented. Frontend should treat `data: []` as "no data available" rather
-/// than "no risky actors". Will be replaced with a live query against the
-/// risk-score store in a future release.
+/// Actor enumeration does not exist yet: `RiskStore` exposes only keyed
+/// lookups, no listing. 501 keeps the UI from rendering an empty table as
+/// "no risky actors" while credit/clear still mutate live per-IP state.
 pub async fn list_risk_actors(_: State<Arc<AppState>>, Query(_q): Query<ActorsQuery>) -> ApiResult<Json<Value>> {
-    Ok(Json(json!({ "success": true, "data": [], "total": 0 })))
+    Err(ApiError::NotImplemented(
+        "risk actor listing is not implemented; the risk store cannot enumerate actors yet".into(),
+    ))
 }
 
 /// Actor ids are IP addresses today (the admin panel lists actors by IP).

--- a/web/admin-panel/src/pages/risk-scoring/index.tsx
+++ b/web/admin-panel/src/pages/risk-scoring/index.tsx
@@ -120,7 +120,11 @@ export const RiskScoringPage: React.FC = () => {
     errorNotification: false,
   });
   const metrics = metricsQuery.result?.data;
-  const metricsError = metricsQuery.query.isError;
+  // 501 means the backend explicitly does not implement the endpoint yet —
+  // render that distinctly from a transient backend error, and never as data.
+  const metricsNotImplemented =
+    (metricsQuery.query.error as { statusCode?: number } | null)?.statusCode === 501;
+  const metricsError = metricsQuery.query.isError && !metricsNotImplemented;
 
   // ── API: config ───────────────────────────────────────────────────────────
 
@@ -152,6 +156,9 @@ export const RiskScoringPage: React.FC = () => {
       ? (actorsQuery.result.data as unknown as RiskActor[])
       : [];
   const actorsTotal = actorsQuery.result?.data?.total ?? actors.length;
+  const actorsNotImplemented =
+    (actorsQuery.query.error as { statusCode?: number } | null)?.statusCode === 501;
+  const actorsError = actorsQuery.query.isError && !actorsNotImplemented;
 
   const distributionData = useMemo(() => buildDistributionData(actors), [actors]);
 
@@ -303,7 +310,20 @@ export const RiskScoringPage: React.FC = () => {
         </Space>
       </Space>
 
-      {/* Metrics error fallback */}
+      {/* Metrics not-implemented / error fallback */}
+      {metricsNotImplemented && (
+        <Alert
+          type="info"
+          showIcon
+          message={t("risk.metricsNotImplemented", {
+            defaultValue: "Risk metrics are not implemented yet",
+          })}
+          description={t("risk.metricsNotImplementedDesc", {
+            defaultValue:
+              "The gateway does not aggregate risk metrics yet — the KPIs below are unavailable, not zero.",
+          })}
+        />
+      )}
       {metricsError && (
         <Alert
           type="warning"
@@ -575,7 +595,13 @@ export const RiskScoringPage: React.FC = () => {
                   justifyContent: "center",
                 }}
               >
-                <Typography.Text type="secondary">{t("risk.noActors")}</Typography.Text>
+                <Typography.Text type="secondary">
+                  {actorsNotImplemented || actorsError
+                    ? t("risk.distributionUnavailable", {
+                        defaultValue: "No actor data available",
+                      })
+                    : t("risk.noActors")}
+                </Typography.Text>
               </div>
             )}
           </Card>
@@ -583,7 +609,19 @@ export const RiskScoringPage: React.FC = () => {
 
         <Col xs={24} lg={14}>
           <Card size="small" title={t("risk.liveActors")}>
-            {actorsQuery.query.isError ? (
+            {actorsNotImplemented ? (
+              <Alert
+                type="info"
+                showIcon
+                message={t("risk.actorsNotImplemented", {
+                  defaultValue: "Actor listing is not implemented yet",
+                })}
+                description={t("risk.actorsNotImplementedDesc", {
+                  defaultValue:
+                    "The gateway cannot enumerate risk actors yet — this is missing data, not an empty threat list. Credit/clear actions still mutate live per-IP state.",
+                })}
+              />
+            ) : actorsError ? (
               <Alert
                 type="warning"
                 showIcon


### PR DESCRIPTION
Closes #230. Part of #223.

**Stacked on #239** (`fix/gh-228-risk-backend-restart-required`) because both edit adjacent regions of `risk_api.rs`; GitHub retargets to `main-harness` automatically once #239 merges. Merge order: #237 → #239 → this (independent of #242, a sibling on the same base).

## Problem

`GET /api/risk/metrics` returned hardcoded zero KPIs and `GET /api/risk/actors` a permanent empty list — both `success: true`. The risk panel rendered "no risky actors" plus zero metrics as real, healthy data, while the credit/clear actions on the same page mutate live per-IP risk state the operator cannot inspect.

## Fix (explicit not-implemented signal, per the issue's second AC option)

Real listing/aggregation needs an enumeration surface on the `RiskStore` trait across both memory and redis backends — that is #223 feature work, not this bug fix. Until then the API is honest:

- New `ApiError::NotImplemented` → HTTP 501 (`crates/waf-api/src/error.rs`), with a body message explaining what is missing.
- Both stub handlers return it; the stale "FE should treat [] as no data" doc comment is gone along with the fabricated envelopes.
- Risk panel (`risk-scoring/index.tsx`) inspects the error's `statusCode`: **501** renders a distinct info alert ("not implemented yet — missing data, not an empty threat list; credit/clear still mutate live state"), other errors keep the existing warning alert, and the "no risky actors" empty state is now reachable only from a genuine 200. KPI cards show "—" instead of zeros.

## Verification

- `cargo test -p waf-api --lib` — 120 passed (includes new `not_implemented_maps_to_501` mapping test).
- `cargo clippy -p waf-api --all-targets` — no errors.
- `npx tsc --noEmit` in `web/admin-panel` — clean.
- Grep confirms the two endpoints have no consumers other than the risk panel.

https://claude.ai/code/session_018YtgAuSKSMHKBJEuJtVuzV