### PR TITLE
fix(risk-ui): source risk-band preview from tier policies and match decide semantics

### DIFF
--- a/web/admin-panel/src/components/risk-band-preview.tsx
+++ b/web/admin-panel/src/components/risk-band-preview.tsx
@@ -1,77 +1,73 @@
 import { Typography, Space } from "antd";
 import type { CSSProperties } from "react";
 
+// Mirrors the engine's threshold gate (`risk/threshold.rs::decide`):
+//   score < allow   → Allow
+//   score >= block  → Block
+//   otherwise       → Challenge
+// Only `allow` and `block` are enforcement boundaries — there is no fourth
+// band and the tier's `challenge` value is not consulted by the gate.
 interface RiskBandPreviewProps {
-  riskAllow: number;
-  riskChallenge: number;
-  riskBlock: number;
+  allow: number;
+  block: number;
+  hideLegend?: boolean;
   style?: CSSProperties;
 }
 
 const BAND_COLORS = {
   allow: "#52c41a",
   challenge: "#faad14",
-  nearBlock: "#fa8c16",
   block: "#f5222d",
 } as const;
 
 export const RiskBandPreview: React.FC<RiskBandPreviewProps> = ({
-  riskAllow,
-  riskChallenge,
-  riskBlock,
+  allow,
+  block,
+  hideLegend,
   style,
 }) => {
-  const a = Math.max(0, Math.min(100, riskAllow));
-  const c = Math.max(0, Math.min(100, riskChallenge));
-  const b = Math.max(0, Math.min(100, riskBlock));
+  const a = Math.max(0, Math.min(100, allow));
+  const b = Math.max(a, Math.min(100, block));
 
   const greenPct = a;
-  const yellowPct = Math.max(0, c - a);
-  const orangePct = Math.max(0, b - c);
-  const redPct = Math.max(0, 100 - b);
+  const yellowPct = b - a;
+  const redPct = 100 - b;
 
   return (
     <Space direction="vertical" size={6} style={{ width: "100%", ...style }}>
       <div style={{ display: "flex", height: 20, borderRadius: 3, overflow: "hidden" }}>
         {greenPct > 0 && (
           <div
-            title={`Allow: 0–${a}`}
+            title={`Allow: score < ${a}`}
             style={{ width: `${greenPct}%`, background: BAND_COLORS.allow }}
           />
         )}
         {yellowPct > 0 && (
           <div
-            title={`Challenge: ${a}–${c}`}
+            title={`Challenge: ${a} ≤ score < ${b}`}
             style={{ width: `${yellowPct}%`, background: BAND_COLORS.challenge }}
-          />
-        )}
-        {orangePct > 0 && (
-          <div
-            title={`Block threshold: ${c}–${b}`}
-            style={{ width: `${orangePct}%`, background: BAND_COLORS.nearBlock }}
           />
         )}
         {redPct > 0 && (
           <div
-            title={`Block: ${b}–100`}
+            title={`Block: score ≥ ${b}`}
             style={{ width: `${redPct}%`, background: BAND_COLORS.block }}
           />
         )}
       </div>
-      <div style={{ display: "flex", flexWrap: "wrap", gap: "2px 14px" }}>
-        <Typography.Text type="secondary" style={{ fontSize: 11 }}>
-          <span style={{ color: BAND_COLORS.allow }}>■</span> Allow 0–{a}
-        </Typography.Text>
-        <Typography.Text type="secondary" style={{ fontSize: 11 }}>
-          <span style={{ color: BAND_COLORS.challenge }}>■</span> Challenge {a}–{c}
-        </Typography.Text>
-        <Typography.Text type="secondary" style={{ fontSize: 11 }}>
-          <span style={{ color: BAND_COLORS.nearBlock }}>■</span> Block {c}–{b}
-        </Typography.Text>
-        <Typography.Text type="secondary" style={{ fontSize: 11 }}>
-          <span style={{ color: BAND_COLORS.block }}>■</span> Hard block {b}–100
-        </Typography.Text>
-      </div>
+      {!hideLegend && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "2px 14px" }}>
+          <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+            <span style={{ color: BAND_COLORS.allow }}>■</span> Allow &lt; {a}
+          </Typography.Text>
+          <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+            <span style={{ color: BAND_COLORS.challenge }}>■</span> Challenge {a}–{b - 1}
+          </Typography.Text>
+          <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+            <span style={{ color: BAND_COLORS.block }}>■</span> Block ≥ {b}
+          </Typography.Text>
+        </div>
+      )}
     </Space>
   );
 };

--- a/web/admin-panel/src/pages/dashboard/index.tsx
+++ b/web/admin-panel/src/pages/dashboard/index.tsx
@@ -71,12 +71,19 @@ interface RuleRegistry {
 
 interface PanelConfigData {
   config?: {
-    risk_allow?: number;
-    risk_challenge?: number;
-    risk_block?: number;
     response_filtering?: { block_stack_traces?: boolean };
   };
 }
+
+interface TierPoliciesData {
+  policies?: Record<
+    string,
+    { risk_thresholds?: { allow?: number; challenge?: number; block?: number } }
+  >;
+}
+
+// Render order for the per-tier threshold preview (matches the tier ladder).
+const TIER_ORDER = ["critical", "high", "medium", "catch_all"] as const;
 
 // Map each detection engine to a *live* signal derived from data the dashboard
 // already fetches: rule-registry `source` substrings (case-insensitive) or an
@@ -178,6 +185,17 @@ export const DashboardPage: React.FC = () => {
     queryOptions: { staleTime: 60_000, retry: false },
   });
   const panelCfg = panelConfig.result?.data?.config;
+
+  // Enforcement risk thresholds come from tier policies (TierPolicy.
+  // risk_thresholds), not panel config — the preview must show what the
+  // engine actually enforces.
+  const tierPolicies = useCustom<TierPoliciesData>({
+    url: "/api/tier-policies",
+    method: "get",
+    queryOptions: { staleTime: 60_000, retry: false },
+    errorNotification: false,
+  });
+  const tierPolicyMap = tierPolicies.result?.data?.policies;
 
   const heatmap = useCustom<EndpointHeatmapData>({
     url: "/api/stats/endpoints",
@@ -499,20 +517,41 @@ export const DashboardPage: React.FC = () => {
       </Row>
 
       {/* Risk Score Distribution */}
-      {!panelConfig.query.isError && (
+      {!tierPolicies.query.isError && (
         <Card
           size="small"
           title={t("dashboard.riskDistribution")}
-          loading={panelConfig.query.isLoading && !panelCfg}
+          loading={tierPolicies.query.isLoading && !tierPolicyMap}
         >
-          {panelCfg ? (
+          {tierPolicyMap ? (
             <Row gutter={[16, 16]} align="middle">
               <Col xs={24} lg={14}>
-                <RiskBandPreview
-                  riskAllow={panelCfg.risk_allow ?? 50}
-                  riskChallenge={panelCfg.risk_challenge ?? 74}
-                  riskBlock={panelCfg.risk_block ?? 75}
-                />
+                <Typography.Text
+                  type="secondary"
+                  style={{ fontSize: 11, display: "block", marginBottom: 8 }}
+                >
+                  {t("dashboard.riskBandSource", {
+                    defaultValue:
+                      "Enforcement thresholds per tier (from tier policies): score < allow passes, score ≥ block is blocked, in between is challenged.",
+                  })}
+                </Typography.Text>
+                {TIER_ORDER.filter((tier) => tierPolicyMap[tier]?.risk_thresholds).map(
+                  (tier) => (
+                    <Row key={tier} gutter={8} align="middle" style={{ marginBottom: 8 }}>
+                      <Col flex="72px">
+                        <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+                          {tier}
+                        </Typography.Text>
+                      </Col>
+                      <Col flex="auto">
+                        <RiskBandPreview
+                          allow={tierPolicyMap[tier]?.risk_thresholds?.allow ?? 0}
+                          block={tierPolicyMap[tier]?.risk_thresholds?.block ?? 100}
+                        />
+                      </Col>
+                    </Row>
+                  ),
+                )}
               </Col>
               <Col xs={24} lg={10}>
                 <Row gutter={[8, 0]}>

--- a/web/admin-panel/src/pages/settings/index.tsx
+++ b/web/admin-panel/src/pages/settings/index.tsx
@@ -9,7 +9,6 @@ import {
   InputNumber,
   Row,
   Select,
-  Slider,
   Space,
   Switch,
   Tag,
@@ -35,7 +34,6 @@ import {
   DatabaseOutlined,
 } from "@ant-design/icons";
 import { useCustom, useCustomMutation } from "@refinedev/core";
-import { RiskBandPreview } from "../../components/risk-band-preview";
 import type { HttpError } from "@refinedev/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -44,9 +42,6 @@ import { httpClient } from "../../utils/axios";
 
 interface WafPanelConfig {
   shadow_mode: boolean;
-  risk_allow: number;
-  risk_challenge: number;
-  risk_block: number;
   challenge_type: string;
   honeypot_paths: string[];
   response_filtering: {
@@ -338,14 +333,6 @@ export const SettingsPage: React.FC = () => {
   const onSavePanel = async () => {
     try {
       const values = await form.validateFields();
-      // Client-side risk order guard (before any API call)
-      const ra = values.risk_allow as number;
-      const rc = values.risk_challenge as number;
-      const rb = values.risk_block as number;
-      if (!(ra < rc && rc < rb)) {
-        message.error(t("settings.panel.riskOrderError"));
-        return;
-      }
       setSaving(true);
       const resp = await httpClient.put<{ success: boolean; data: PanelConfigEnvelope }>(
         "/api/panel-config",
@@ -368,21 +355,6 @@ export const SettingsPage: React.FC = () => {
       setSaving(false);
     }
   };
-
-  const riskAllow = Form.useWatch("risk_allow", form) ?? envelope?.config?.risk_allow ?? 51;
-  const riskChallenge = Form.useWatch("risk_challenge", form) ?? envelope?.config?.risk_challenge ?? 74;
-  const riskBlock = Form.useWatch("risk_block", form) ?? envelope?.config?.risk_block ?? 75;
-
-  // Cross-field revalidate when sliders change so the InputNumber/risk_block
-  // shows its error immediately (without waiting for submit).
-  useEffect(() => {
-    if (form.isFieldTouched("risk_block")) {
-      form.validateFields(["risk_block"]).catch(() => {});
-    }
-    if (form.isFieldTouched("risk_challenge")) {
-      form.validateFields(["risk_challenge"]).catch(() => {});
-    }
-  }, [riskAllow, riskChallenge, form]);
 
   const ipsCount = (status?.rules?.allow_ips ?? 0) + (status?.rules?.block_ips ?? 0);
   const urlsCount = (status?.rules?.allow_urls ?? 0) + (status?.rules?.block_urls ?? 0);
@@ -536,87 +508,9 @@ export const SettingsPage: React.FC = () => {
               />
             </SectionCard>
 
-            {/* ── Risk Thresholds ──────────────────────────────────────── */}
-            <SectionCard
-              icon={<SecurityScanOutlined style={{ color: "#1677ff" }} />}
-              title={t("settings.panel.riskThresholds")}
-            >
-              <Form.Item
-                name="risk_allow"
-                label={
-                  <Row style={{ width: "100%" }} justify="space-between">
-                    <span style={{ color: "#52c41a", fontWeight: 600 }}>
-                      {t("settings.panel.allowBandShort")} (0 – {riskAllow})
-                    </span>
-                    <span style={{ fontVariantNumeric: "tabular-nums" }}>{riskAllow}</span>
-                  </Row>
-                }
-                rules={[{ required: true, type: "number", min: 0, max: 98 }]}
-              >
-                <Slider min={0} max={98} tooltip={{ open: false }} styles={{ track: { background: "#52c41a" } }} />
-              </Form.Item>
-
-              <Form.Item
-                name="risk_challenge"
-                label={
-                  <Row style={{ width: "100%" }} justify="space-between">
-                    <span style={{ color: "#fa8c16", fontWeight: 600 }}>
-                      {t("settings.panel.challengeBandShort")} ({riskAllow + 1} – {riskChallenge})
-                    </span>
-                    <span style={{ fontVariantNumeric: "tabular-nums" }}>{riskChallenge}</span>
-                  </Row>
-                }
-                dependencies={["risk_allow"]}
-                rules={[
-                  { required: true, type: "number" },
-                  {
-                    validator: async (_, v) => {
-                      const a = form.getFieldValue("risk_allow") as number;
-                      if (typeof v === "number" && v > a) return;
-                      return Promise.reject(new Error(t("settings.panel.riskOrderError")));
-                    },
-                  },
-                ]}
-              >
-                <Slider min={1} max={99} tooltip={{ open: false }} styles={{ track: { background: "#fa8c16" } }} />
-              </Form.Item>
-
-              <Row align="middle" style={{ marginTop: 4 }}>
-                <Typography.Text type="secondary">
-                  {t("settings.panel.blockThresholdLabel")}:{" "}
-                </Typography.Text>
-                <Tag color="red" style={{ marginLeft: 8, fontWeight: 600 }}>
-                  &gt;= {riskBlock}
-                </Tag>
-                <Form.Item
-                  name="risk_block"
-                  noStyle
-                  dependencies={["risk_challenge"]}
-                  rules={[
-                    { required: true, type: "number" },
-                    {
-                      validator: async (_, v) => {
-                        const c = form.getFieldValue("risk_challenge") as number;
-                        if (typeof v === "number" && v > c) return;
-                        return Promise.reject(new Error(t("settings.panel.riskOrderError")));
-                      },
-                    },
-                  ]}
-                >
-                  <InputNumber min={2} max={100} size="small" style={{ width: 80, marginLeft: 12 }} />
-                </Form.Item>
-              </Row>
-              <div style={{ marginTop: 16 }}>
-                <Typography.Text type="secondary" style={{ fontSize: 12, display: "block", marginBottom: 8 }}>
-                  {t("settings.riskBandPreview")}
-                </Typography.Text>
-                <RiskBandPreview
-                  riskAllow={riskAllow}
-                  riskChallenge={riskChallenge}
-                  riskBlock={riskBlock}
-                />
-              </div>
-            </SectionCard>
+            {/* Risk thresholds are enforced per tier (TierPolicy.risk_thresholds,
+                edited on the tier-policies page) — the old panel-config sliders
+                here had no effect on enforcement and were removed. */}
 
             {/* ── Challenge Engine ─────────────────────────────────────── */}
             <SectionCard


### PR DESCRIPTION
Closes #231. Part of #223.

## Problem

Two disconnects between the risk UI and enforcement:

1. **Orphaned thresholds.** The dashboard preview and a full slider editor on the settings page were fed from `WafPanelConfig.risk_allow/challenge/block` (defaults 51/74/75), but nothing in `gateway/` or `waf-engine/` reads those fields — enforcement uses `TierPolicy.risk_thresholds` (tier defaults 20/60/85). Operators could "tune" thresholds that changed nothing.
2. **Mislabeled band.** `RiskBandPreview` rendered a 4-band model whose middle band said "Block", but `threshold::decide` has exactly three outcomes: `score < allow` → Allow, `score >= block` → Block, otherwise Challenge. That band is challenged, not blocked.

## Fix (per the issue's "read tier thresholds in the UI" option)

- `RiskBandPreview` is now a 3-band component driven by `allow`/`block` only, with band boundaries and labels lifted from `threshold::decide` semantics (documented in the component).
- The dashboard's risk-distribution card fetches `GET /api/tier-policies` and renders the enforced thresholds for each tier (critical/high/medium/catch_all), with a caption stating the semantics and source.
- The settings page's panel-config threshold editor (sliders, cross-field order validation, client-side order guard, preview) is removed with a comment pointing to the tier-policies page as the editing surface. Saving settings no longer writes the dead `risk_*` fields.

**Retained (deliberately):** the `risk_allow/challenge/block` fields on `waf_common::WafPanelConfig` and their validation. They are config-file compat surface with their own tests; removing them is #223 cleanup, not this bug. Their i18n keys are likewise left in the locale files.

## Verification

- `npx tsc --noEmit` in `web/admin-panel` — clean; grep confirms no remaining consumer of the old `riskAllow/riskChallenge/riskBlock` props or of panel-config `risk_*` in the FE.
- Band-boundary correctness is pinned on the Rust side by the existing `threshold::decide` unit tests; the FE preview now takes its numbers from the same tier-policy source the engine loads. The admin panel has no JS test runner, so no FE unit test was added.
- No backend changes.

https://claude.ai/code/session_018YtgAuSKSMHKBJEuJtVuzV