### PR TITLE
fix(risk-store): close memory apply race, make Redis reset atomic, guard cluster mode

### DIFF
--- a/crates/waf-engine/src/risk/store/conformance.rs
+++ b/crates/waf-engine/src/risk/store/conformance.rs
@@ -316,6 +316,77 @@ pub async fn test_decay_disabled_when_rate_zero<S: RiskStore>(store: &S) {
     );
 }
 
+/// Concurrent first-applies for one multi-axis actor must converge.
+///
+/// No delta batch may be lost and every axis must resolve to the same score.
+/// Exercises the create/merge race, so it needs real parallelism — call from
+/// a multi-thread runtime.
+pub async fn test_concurrent_apply_no_lost_deltas<S: RiskStore + 'static>(store: std::sync::Arc<S>) {
+    const TASKS: usize = 16;
+    const ROUNDS: usize = 20;
+
+    store.reset_all().await.unwrap();
+
+    for round in 0..ROUNDS {
+        let round_u8 = u8::try_from(round).unwrap();
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 42, 42, round_u8));
+        let fp = 900_000 + round as u64;
+        let session = SessionId::new(vec![9, 9, round_u8, 1]);
+        let key = RiskKey {
+            ip: Some(ip),
+            fp_hash: Some(fp),
+            session: Some(session.clone()),
+        };
+
+        // Barrier releases all appliers at once to maximize collisions on
+        // the first-create path.
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(TASKS));
+        let mut handles = Vec::with_capacity(TASKS);
+        for _ in 0..TASKS {
+            let store = std::sync::Arc::clone(&store);
+            let key = key.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            handles.push(tokio::spawn(async move {
+                barrier.wait().await;
+                store.apply(&key, &[make_contributor(1, 1000)], 1000).await.unwrap();
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        let expected = u8::try_from(TASKS).unwrap();
+        let axis_keys = [
+            RiskKey {
+                ip: Some(ip),
+                fp_hash: None,
+                session: None,
+            },
+            RiskKey {
+                ip: None,
+                fp_hash: Some(fp),
+                session: None,
+            },
+            RiskKey {
+                ip: None,
+                fp_hash: None,
+                session: Some(session.clone()),
+            },
+        ];
+        for axis_key in axis_keys {
+            let state = store
+                .read(&axis_key)
+                .await
+                .unwrap()
+                .expect("every axis must resolve after concurrent applies");
+            assert_eq!(
+                state.clamped_score, expected,
+                "round {round}: every axis must see all {TASKS} concurrent deltas (no lost batch, no split-brain)"
+            );
+        }
+    }
+}
+
 /// Admin clear must remove the state so no axis resurrects the old score.
 pub async fn test_clear_removes_all_axes<S: RiskStore>(store: &S) {
     store.reset_all().await.unwrap();
@@ -435,6 +506,12 @@ mod tests {
             ..Default::default()
         });
         test_decay_honors_configured_rate(&store).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn memory_store_concurrent_apply_no_lost_deltas() {
+        let store = std::sync::Arc::new(MemoryRiskStore::new());
+        test_concurrent_apply_no_lost_deltas(store).await;
     }
 
     #[tokio::test]

--- a/crates/waf-engine/src/risk/store/memory.rs
+++ b/crates/waf-engine/src/risk/store/memory.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use dashmap::DashMap;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use tokio::time::interval;
 use tracing::{debug, info};
 
@@ -31,6 +31,12 @@ pub struct MemoryRiskStore {
     by_fp: DashMap<u64, StateRef>,
     by_session: DashMap<Vec<u8>, StateRef>,
     decay: DecayConfig,
+    /// Serializes index resolution (find + upsert) across the three maps.
+    /// Without it, concurrent first-applies for the same actor can both miss,
+    /// mint separate states, and split-brain the indices — dropping one delta
+    /// batch. Held only for the map operations, never across `.await` or the
+    /// per-state fold.
+    index_lock: Mutex<()>,
 }
 
 impl MemoryRiskStore {
@@ -47,6 +53,7 @@ impl MemoryRiskStore {
             by_fp: DashMap::new(),
             by_session: DashMap::new(),
             decay,
+            index_lock: Mutex::new(()),
         }
     }
 
@@ -147,13 +154,20 @@ impl RiskStore for MemoryRiskStore {
             });
         }
 
-        let (state_ref, is_new) = if let Some(existing) = self.find_existing(key) {
-            (existing, false)
-        } else {
-            let new_state = RiskState::new(now_ms);
-            let new_ref = Arc::new(RwLock::new(new_state));
-            self.upsert_indices(key, &new_ref);
-            (new_ref, true)
+        // Resolve + unify indices under the index lock so concurrent applies
+        // for the same actor always converge on one state (no lost creates,
+        // no split-brained axes).
+        let (state_ref, is_new) = {
+            let _guard = self.index_lock.lock();
+            if let Some(existing) = self.find_existing(key) {
+                // Merge-on-collide: ensure all axes point to the same Arc.
+                self.upsert_indices(key, &existing);
+                (existing, false)
+            } else {
+                let new_ref = Arc::new(RwLock::new(RiskState::new(now_ms)));
+                self.upsert_indices(key, &new_ref);
+                (new_ref, true)
+            }
         };
 
         // Apply decay then fold deltas under write lock (atomic)
@@ -164,11 +178,6 @@ impl RiskStore for MemoryRiskStore {
                 apply_decay(&mut state, now_ms, &self.decay);
             }
             fold(&mut state, deltas, now_ms);
-        }
-
-        // Re-unify indices (merge-on-collide: ensure all axes point to same Arc)
-        if !is_new {
-            self.upsert_indices(key, &state_ref);
         }
 
         let state = state_ref.read().clone();
@@ -185,13 +194,17 @@ impl RiskStore for MemoryRiskStore {
             return Ok(());
         }
 
-        let state_ref = if let Some(existing) = self.find_existing(key) {
-            existing
-        } else {
-            let new_state = RiskState::new(now_ms);
-            let new_ref = Arc::new(RwLock::new(new_state));
-            self.upsert_indices(key, &new_ref);
-            new_ref
+        // Same index-lock discipline as `apply`: resolve + unify atomically.
+        let state_ref = {
+            let _guard = self.index_lock.lock();
+            if let Some(existing) = self.find_existing(key) {
+                self.upsert_indices(key, &existing);
+                existing
+            } else {
+                let new_ref = Arc::new(RwLock::new(RiskState::new(now_ms)));
+                self.upsert_indices(key, &new_ref);
+                new_ref
+            }
         };
 
         {
@@ -202,7 +215,6 @@ impl RiskStore for MemoryRiskStore {
             state.last_updated_ms = now_ms;
         }
 
-        self.upsert_indices(key, &state_ref);
         Ok(())
     }
 

--- a/crates/waf-engine/src/risk/store/redis.rs
+++ b/crates/waf-engine/src/risk/store/redis.rs
@@ -28,7 +28,7 @@ use redis::{Script, aio::ConnectionManager};
 use tokio::time::timeout;
 use tracing::{debug, warn};
 
-use super::redis_lua::{APPLY_SCRIPT, CLEAR_SCRIPT, FORCE_MAX_SCRIPT};
+use super::redis_lua::{APPLY_SCRIPT, CLEAR_SCRIPT, FORCE_MAX_SCRIPT, RESET_SCRIPT};
 use crate::risk::config::DecayConfig;
 use crate::risk::key::RiskKey;
 use crate::risk::state::{Contributor, RiskState};
@@ -83,6 +83,7 @@ pub struct RedisRiskStore {
     apply_script: Script,
     force_max_script: Script,
     clear_script: Script,
+    reset_script: Script,
 }
 
 impl std::fmt::Debug for RedisRiskStore {
@@ -110,6 +111,24 @@ impl RedisRiskStore {
             .await
             .context("risk redis: ping")?;
 
+        // The Lua scripts derive state keys from a prefix argument (not KEYS),
+        // which Redis Cluster rejects with CROSSSLOT on every apply — the
+        // store would run permanently degraded. Fail at startup instead.
+        match redis::cmd("INFO").arg("cluster").query_async::<String>(&mut conn).await {
+            Ok(info) if info.contains("cluster_enabled:1") => {
+                return Err(anyhow!(
+                    "risk redis: {} is a Redis Cluster; the risk store requires a single \
+                     non-cluster Redis/Valkey instance (its Lua scripts compute state keys \
+                     outside KEYS, which cluster slot routing rejects with CROSSSLOT)",
+                    cfg.url
+                ));
+            }
+            Ok(_) => {}
+            // Some restricted deployments block INFO; connectivity is already
+            // proven by PING, so proceed without the cluster check.
+            Err(e) => warn!(error = %e, "risk redis: could not verify non-cluster mode (INFO failed)"),
+        }
+
         let cache_capacity = NonZeroUsize::new(cfg.cache_capacity).unwrap_or(NonZeroUsize::MIN);
         Ok(Self {
             conn,
@@ -118,6 +137,7 @@ impl RedisRiskStore {
             apply_script: Script::new(APPLY_SCRIPT),
             force_max_script: Script::new(FORCE_MAX_SCRIPT),
             clear_script: Script::new(CLEAR_SCRIPT),
+            reset_script: Script::new(RESET_SCRIPT),
             cfg,
         })
     }
@@ -489,41 +509,22 @@ impl RiskStore for RedisRiskStore {
     }
 
     async fn reset_all(&self) -> anyhow::Result<()> {
+        // Single Lua execution = atomic swap-with-empty (the trait contract):
+        // concurrent readers see either the full pre-reset store or nothing,
+        // never a half-cleared keyspace. The script blocks the server while it
+        // runs, which is acceptable for a rare emergency/admin operation.
         let pattern = format!("{}*", self.cfg.key_prefix);
         let mut conn = self.conn.clone();
-        let mut deleted = 0_usize;
 
-        // SCAN-based deletion (cooperative, bounded batches)
-        let scan_fut = async {
-            let mut cursor = 0_u64;
-            loop {
-                let (next_cursor, keys): (u64, Vec<String>) = redis::cmd("SCAN")
-                    .arg(cursor)
-                    .arg("MATCH")
-                    .arg(&pattern)
-                    .arg("COUNT")
-                    .arg(100)
-                    .query_async(&mut conn)
-                    .await?;
-
-                if !keys.is_empty() {
-                    let mut pipe = redis::pipe();
-                    for k in &keys {
-                        pipe.del(k);
-                    }
-                    let _: () = pipe.query_async(&mut conn).await?;
-                    deleted += keys.len();
-                }
-
-                cursor = next_cursor;
-                if cursor == 0 {
-                    break;
-                }
-            }
-            Ok::<_, redis::RedisError>(deleted)
+        let invocation_fut = async {
+            self.reset_script
+                .prepare_invoke()
+                .arg(&pattern)
+                .invoke_async::<i64>(&mut conn)
+                .await
         };
 
-        match timeout(Duration::from_secs(30), scan_fut).await {
+        match timeout(Duration::from_secs(30), invocation_fut).await {
             Ok(Ok(n)) => {
                 self.record_ok();
                 self.cache.lock().clear();

--- a/crates/waf-engine/src/risk/store/redis_lua.rs
+++ b/crates/waf-engine/src/risk/store/redis_lua.rs
@@ -322,6 +322,27 @@ end
 return deleted
 ";
 
+/// Reset script: atomically delete every key under the store's prefix.
+///
+/// The `RiskStore::reset_all` contract requires swap-with-empty semantics:
+/// concurrent readers must see either the pre-reset or post-reset store,
+/// never a partially cleared one. A single Lua execution is atomic in Redis,
+/// so all keys vanish in one step. `KEYS` is O(N) and blocks the server for
+/// the duration, which is acceptable here: reset is a rare emergency/admin
+/// amnesty operation and the keyspace is bounded by the store prefix.
+/// `UNLINK` defers the actual memory reclaim off the command thread.
+///
+/// ARGV[1]: match pattern (`{key_prefix}*`)
+///
+/// Returns: number of keys removed
+pub const RESET_SCRIPT: &str = r"
+local keys = redis.call('KEYS', ARGV[1])
+for i = 1, #keys do
+    redis.call('UNLINK', keys[i])
+end
+return #keys
+";
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -332,5 +353,6 @@ mod tests {
         assert!(!APPLY_SCRIPT.is_empty());
         assert!(!FORCE_MAX_SCRIPT.is_empty());
         assert!(!CLEAR_SCRIPT.is_empty());
+        assert!(!RESET_SCRIPT.is_empty());
     }
 }

--- a/crates/waf-engine/src/risk/tests/conformance_redis.rs
+++ b/crates/waf-engine/src/risk/tests/conformance_redis.rs
@@ -41,6 +41,33 @@ async fn redis_store_passes_conformance() {
     run_all(&store).await;
 }
 
+/// Concurrent applies must not lose delta batches or split-brain the axes
+/// (the Lua apply script is atomic per invocation — this pins that parity
+/// with the memory backend's index-lock behavior).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn redis_concurrent_apply_no_lost_deltas() {
+    use crate::risk::store::conformance::test_concurrent_apply_no_lost_deltas;
+
+    let Ok(url) = std::env::var("REDIS_TEST_URL") else {
+        tracing::info!("skipping: REDIS_TEST_URL unset");
+        return;
+    };
+
+    let store = RedisRiskStore::new(RedisRiskConfig {
+        url,
+        key_prefix: unique_prefix(),
+        ttl_secs: 3600,
+        op_timeout: Duration::from_millis(500),
+        breaker_threshold: 5,
+        cache_capacity: 1000,
+        decay: DecayConfig::default(),
+    })
+    .await
+    .expect("connect to REDIS_TEST_URL");
+
+    test_concurrent_apply_no_lost_deltas(std::sync::Arc::new(store)).await;
+}
+
 /// The Lua apply script must decay by the configured rate, not the default.
 #[tokio::test]
 async fn redis_decay_honors_configured_rate() {


### PR DESCRIPTION
Closes #232. Part of #223.

## Problems

1. **Memory `apply` TOCTOU.** `MemoryRiskStore::apply` resolved the actor with `find_existing` and then inserted into the three DashMap indices with no synchronization between the two steps. Two concurrent first-requests for the same actor (e.g. across axes) could both miss, mint separate `Arc<RwLock<RiskState>>`s, and leave the indices split-brained — one delta batch folded into a state nothing points at anymore. The Redis backend never had this problem (single atomic Lua invocation).
2. **Redis `reset_all` contract violation.** `store_trait.rs` mandates swap-with-empty ("concurrent readers see either pre or post state, never partial"), but the Redis implementation looped SCAN+DEL in batches — readers could observe a half-cleared store mid-reset.
3. **Silent Redis Cluster failure.** The Lua scripts compute `state:{owner}` keys from a prefix ARGV instead of declaring them in `KEYS`, so Redis Cluster returns CROSSSLOT on every apply — the store would run permanently in degraded fallback with only a per-op warning.

## Fixes

- `MemoryRiskStore` gains an `index_lock: Mutex<()>` held across resolve + upsert in `apply` and `force_max` (the AC's "single-lock" option). The lock covers only the index map operations — the decay/fold still happens under the per-state `RwLock`, and the lock is never held across an `.await`, so the hot path serializes only for microsecond-scale map lookups. Merge-on-collide re-unification moved inside the same critical section.
- `reset_all` on Redis now executes one Lua script (`KEYS {prefix}*` + `UNLINK` each). One script execution is atomic to all other commands, satisfying swap-with-empty. The blocking `KEYS` scan is documented as acceptable: reset is a rare emergency/admin amnesty op and the pattern is bounded by the store prefix.
- `RedisRiskStore::new` now runs `INFO cluster` after PING and returns a startup error naming the CROSSSLOT reason when `cluster_enabled:1`. If `INFO` itself is blocked (some managed deployments), it warns and proceeds — connectivity is already proven by PING.

## Verification

- New conformance case `test_concurrent_apply_no_lost_deltas`: 20 rounds of 16 barrier-released concurrent appliers on a triple-axis key, asserting each single axis reads the exact summed score. **Fails on the pre-fix memory store at round 0** (`assertion failed: round 0: every axis must see all 16 concurrent deltas`), passes with the fix. Wired into memory tests (multi-thread runtime) and a `REDIS_TEST_URL`-gated Redis variant.
- `cargo test -p waf-engine --features redis-store --lib risk::` — 276 passed, 0 failed (includes all 22 store tests).
- `cargo clippy -p waf-engine --features redis-store --all-targets` — clean; `cargo check -p waf-engine` (default features) and `-p gateway -p waf-api` — clean.
- Redis-backed suites (`conformance_redis.rs`, `redis_failover.rs`) compile locally and execute in CI where `REDIS_TEST_URL` is provided (local Docker socket is unavailable in this environment).

## Notes

- The cluster guard turns a silent permanent-degraded deployment into a clean boot failure; single-instance Redis/Valkey remains the documented supported topology (`redis_lua.rs` header).
- No public API shape changes; `RiskStore` trait is untouched.

https://claude.ai/code/session_018YtgAuSKSMHKBJEuJtVuzV