### PR TITLE
style: apply cargo fmt to unformatted test code on main-harness

### DIFF
--- a/crates/waf-api/src/geo_api.rs
+++ b/crates/waf-api/src/geo_api.rs
@@ -187,6 +187,9 @@ mod tests {
             );
         }
         assert!(matches!(validate_geo_action(&json!(5)), Err(ApiError::BadRequest(_))));
-        assert!(matches!(validate_geo_action(&Value::Null), Err(ApiError::BadRequest(_))));
+        assert!(matches!(
+            validate_geo_action(&Value::Null),
+            Err(ApiError::BadRequest(_))
+        ));
     }
 }

--- a/crates/waf-api/src/risk_api.rs
+++ b/crates/waf-api/src/risk_api.rs
@@ -176,7 +176,10 @@ mod tests {
     #[test]
     fn credit_amount_gate_matches_ui_contract() {
         for ui_amount in [50, 25, 10, DEFAULT_CREDIT_AMOUNT] {
-            assert!(validate_credit_amount(ui_amount).is_ok(), "UI amount {ui_amount} must pass");
+            assert!(
+                validate_credit_amount(ui_amount).is_ok(),
+                "UI amount {ui_amount} must pass"
+            );
         }
         for bad in [-50, -25, -10, 0, 101] {
             assert!(validate_credit_amount(bad).is_err(), "amount {bad} must be rejected");

--- a/crates/waf-engine/src/engine.rs
+++ b/crates/waf-engine/src/engine.rs
@@ -2021,7 +2021,9 @@ mod tests {
     async fn rule_match_risk_deltas_raise_cumulative_score() {
         let (engine, _container) = spawn_engine().await;
         engine.replace_risk_config(enabled_risk_config());
-        engine.custom_rules.add_file_rule(risk_delta_rule("gh226-bump", "/attack", 80));
+        engine
+            .custom_rules
+            .add_file_rule(risk_delta_rule("gh226-bump", "/attack", 80));
 
         let mut ctx = make_ctx("risk-test", "/attack/probe", "203.0.113.60");
         let decision = engine.inspect(&mut ctx).await;
@@ -2051,7 +2053,9 @@ mod tests {
     async fn fp_axis_risk_enforces_across_ips() {
         let (engine, _container) = spawn_engine().await;
         engine.replace_risk_config(enabled_risk_config());
-        engine.custom_rules.add_file_rule(risk_delta_rule("gh226-fp", "/attack", 80));
+        engine
+            .custom_rules
+            .add_file_rule(risk_delta_rule("gh226-fp", "/attack", 80));
 
         // Accrue risk under IP A with fingerprint X.
         let mut ctx = make_ctx("risk-test", "/attack/probe", "203.0.113.70");


### PR DESCRIPTION
## Problem

CI run [28746408621](https://github.com/future-and-go/mini-waf/actions/runs/28746408621) fails on `main-harness` at the Lint job's **Format check** step: `cargo fmt --all -- --check` exits 1, which also skips the Test and Build jobs.

## Root cause

Recent squash merges (#240, #241, #245) landed test-module lines that exceed rustfmt's width limit:

- `crates/waf-api/src/geo_api.rs` — overlong `assert!(matches!(...))`
- `crates/waf-api/src/risk_api.rs` — overlong `assert!(...)` with message
- `crates/waf-engine/src/engine.rs` — two overlong `add_file_rule` builder chains

## Fix

Ran `cargo fmt --all`. Whitespace-only wrapping in test code; no behavior change.

## Verification

- `cargo fmt --all -- --check` reproduced the exact 4 CI diffs before the fix, clean after
- `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --all-features` passes